### PR TITLE
DROID-1620 Collection | Enhancement | View's default object type

### DIFF
--- a/app/src/androidTest/java/com/anytypeio/anytype/features/sets/dv/TestObjectSetSetup.kt
+++ b/app/src/androidTest/java/com/anytypeio/anytype/features/sets/dv/TestObjectSetSetup.kt
@@ -209,10 +209,8 @@ abstract class TestObjectSetSetup {
             dispatchers = dispatchers
         )
         createDataViewObject = CreateDataViewObject(
-            getTemplates = getTemplates,
             repo = repo,
             storeOfRelations = storeOfRelations,
-            getDefaultPageType = getDefaultPageType,
             dispatchers = dispatchers
         )
         setObjectDetails = UpdateDetail(repo)

--- a/app/src/main/java/com/anytypeio/anytype/di/feature/ObjectSetDI.kt
+++ b/app/src/main/java/com/anytypeio/anytype/di/feature/ObjectSetDI.kt
@@ -331,13 +331,9 @@ object ObjectSetModule {
     fun provideCreateDataViewRecordUseCase(
         repo: BlockRepository,
         storeOfRelations: StoreOfRelations,
-        getDefaultPageType: GetDefaultPageType,
-        getTemplates: GetTemplates,
         dispatchers: AppCoroutineDispatchers
     ): CreateDataViewObject = CreateDataViewObject(
         repo = repo,
-        getDefaultPageType = getDefaultPageType,
-        getTemplates = getTemplates,
         storeOfRelations = storeOfRelations,
         dispatchers = dispatchers
     )

--- a/core-models/src/main/java/com/anytypeio/anytype/core_models/Block.kt
+++ b/core-models/src/main/java/com/anytypeio/anytype/core_models/Block.kt
@@ -287,7 +287,8 @@ data class Block(
                 val hideIcon: Boolean = false,
                 val coverFit: Boolean = false,
                 val coverRelationKey: String? = null,
-                val defaultTemplateId: Id? = null,
+                val defaultTemplate: Id? = null,
+                val defaultObjectType: Id? = null,
             ) {
 
                 enum class Type(val formattedName: String) {

--- a/middleware/src/main/java/com/anytypeio/anytype/middleware/mappers/ToCoreModelMappers.kt
+++ b/middleware/src/main/java/com/anytypeio/anytype/middleware/mappers/ToCoreModelMappers.kt
@@ -503,7 +503,8 @@ fun MDVView.toCoreModels(): DVViewer = DVViewer(
     hideIcon = hideIcon,
     coverFit = coverFit,
     coverRelationKey = coverRelationKey.ifEmpty { null },
-    defaultTemplateId = defaultTemplateId.ifEmpty { null }
+    defaultTemplate = defaultTemplateId.ifEmpty { null },
+    defaultObjectType = defaultObjectTypeId.ifEmpty { null }
 )
 
 fun MDVRelation.toCoreModels(): DVViewerRelation = DVViewerRelation(

--- a/middleware/src/main/java/com/anytypeio/anytype/middleware/mappers/ToCoreModelMappers.kt
+++ b/middleware/src/main/java/com/anytypeio/anytype/middleware/mappers/ToCoreModelMappers.kt
@@ -24,6 +24,7 @@ import com.anytypeio.anytype.core_models.FileLimits
 import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.core_models.ObjectOrder
 import com.anytypeio.anytype.core_models.ObjectType
+import com.anytypeio.anytype.core_models.ObjectTypeIds
 import com.anytypeio.anytype.core_models.ObjectView
 import com.anytypeio.anytype.core_models.Payload
 import com.anytypeio.anytype.core_models.Relation
@@ -504,7 +505,7 @@ fun MDVView.toCoreModels(): DVViewer = DVViewer(
     coverFit = coverFit,
     coverRelationKey = coverRelationKey.ifEmpty { null },
     defaultTemplate = defaultTemplateId.ifEmpty { null },
-    defaultObjectType = defaultObjectTypeId.ifEmpty { null }
+    defaultObjectType = defaultObjectTypeId.ifEmpty { ObjectTypeIds.PAGE }
 )
 
 fun MDVRelation.toCoreModels(): DVViewerRelation = DVViewerRelation(

--- a/middleware/src/main/java/com/anytypeio/anytype/middleware/mappers/ToMiddlewareModelMappers.kt
+++ b/middleware/src/main/java/com/anytypeio/anytype/middleware/mappers/ToMiddlewareModelMappers.kt
@@ -329,7 +329,8 @@ fun Block.Content.DataView.Viewer.toMiddlewareModel(): MDVView =
             Block.Content.DataView.Viewer.Size.MEDIUM -> MDVViewCardSize.Medium
             Block.Content.DataView.Viewer.Size.LARGE -> MDVViewCardSize.Large
         },
-        defaultTemplateId = defaultTemplateId.orEmpty()
+        defaultTemplateId = defaultTemplate.orEmpty(),
+        defaultObjectTypeId = defaultObjectType.orEmpty(),
     )
 
 fun Block.Content.DataView.Viewer.Type.toMiddlewareModel(): MDVViewType = when (this) {

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetExtension.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetExtension.kt
@@ -424,7 +424,7 @@ fun DVViewer.updateFields(fields: DVViewerFields?): DVViewer {
         hideIcon = fields.hideIcon,
         cardSize = fields.cardSize,
         coverFit = fields.coverFit,
-        defaultTemplateId = fields.defaultTemplateId
+        defaultTemplate = fields.defaultTemplateId
     )
 }
 

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetExtension.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetExtension.kt
@@ -381,25 +381,6 @@ fun ObjectState.DataView.filterOutDeletedAndMissingObjects(query: List<Id>): Lis
     return query.filter(::isValidObject)
 }
 
-suspend fun ObjectState.DataView.Set.isTemplatesAllowed(
-    setOfValue: List<Id>,
-    storeOfObjectTypes: StoreOfObjectTypes,
-    getDefaultPageType: GetDefaultPageType
-): Boolean {
-    val objectDetails = details[setOfValue.first()]?.map.orEmpty()
-    return when (objectDetails.type) {
-        ObjectTypeIds.OBJECT_TYPE -> {
-            val objectWrapper = ObjectWrapper.Type(objectDetails)
-            objectWrapper.isTemplatesAllowed()
-        }
-        ObjectTypeIds.RELATION -> {
-            //We have set of relations, need to check default object type
-            storeOfObjectTypes.isTemplatesAllowedForDefaultType(getDefaultPageType)
-        }
-        else -> false
-    }
-}
-
 fun ObjectState.DataView.Set.isSetByRelation(setOfValue: List<Id>): Boolean {
     val objectDetails = details[setOfValue.first()]?.map.orEmpty()
     return objectDetails.type == ObjectTypeIds.RELATION
@@ -525,4 +506,11 @@ private fun isActiveViewer(index: Int, viewer: DVViewer, session: ObjectSetSessi
     } else {
         index == 0
     }
+}
+
+suspend fun List<ViewerView>.isActiveHasTemplates(storeOfObjectTypes: StoreOfObjectTypes): Boolean {
+    val activeViewer = firstOrNull { it.isActive }
+    val viewerDefaultObjectTypeId = activeViewer?.defaultObjectType ?: return false
+    val viewerDefaultObjectType = storeOfObjectTypes.get(viewerDefaultObjectTypeId) ?: return false
+    return viewerDefaultObjectType.isTemplatesAllowed()
 }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetExtension.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetExtension.kt
@@ -460,7 +460,7 @@ fun ObjectState.DataView.toViewersView(ctx: Id, session: ObjectSetSession): List
     val viewers = dataViewContent.viewers
     return when (this) {
         is ObjectState.DataView.Collection -> mapViewers(
-            defaultObjectType = { it.defaultObjectType ?: VIEW_DEFAULT_OBJECT_TYPE },
+            defaultObjectType = { it.defaultObjectType },
             viewers = viewers,
             session = session
         )
@@ -468,7 +468,7 @@ fun ObjectState.DataView.toViewersView(ctx: Id, session: ObjectSetSession): List
             val setOfValue = getSetOfValue(ctx)
             if (isSetByRelation(setOfValue = setOfValue)) {
                 mapViewers(
-                    defaultObjectType = { it.defaultObjectType ?: VIEW_DEFAULT_OBJECT_TYPE },
+                    defaultObjectType = { it.defaultObjectType },
                     viewers = viewers,
                     session = session
                 )

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetExtension.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetExtension.kt
@@ -508,7 +508,7 @@ private fun isActiveViewer(index: Int, viewer: DVViewer, session: ObjectSetSessi
     }
 }
 
-suspend fun List<ViewerView>.isActiveHasTemplates(storeOfObjectTypes: StoreOfObjectTypes): Boolean {
+suspend fun List<ViewerView>.isActiveWithTemplates(storeOfObjectTypes: StoreOfObjectTypes): Boolean {
     val activeViewer = firstOrNull { it.isActive }
     val viewerDefaultObjectTypeId = activeViewer?.defaultObjectType ?: return false
     val viewerDefaultObjectType = storeOfObjectTypes.get(viewerDefaultObjectTypeId) ?: return false

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
@@ -944,7 +944,8 @@ class ObjectSetViewModel(
                                 CreateDataViewObject.Params.SetByRelation(
                                     filters = viewer.filters,
                                     relations = setObject.setOf,
-                                    template = templateId
+                                    template = templateId,
+                                    type = viewer.defaultObjectType
                                 )
                             )
                         }
@@ -966,8 +967,11 @@ class ObjectSetViewModel(
     }
 
     private fun proceedWithAddingObjectToCollection(templateId: Id? = null) {
+        val state = stateReducer.state.value.dataViewState() ?: return
+        val viewer = state.viewerById(session.currentViewerId.value) ?: return
         val createObjectParams = CreateDataViewObject.Params.Collection(
-            templateId = templateId
+            templateId = templateId,
+            type = viewer.defaultObjectType
         )
         proceedWithCreatingDataViewObject(createObjectParams) { result ->
             val params = AddObjectToCollection.Params(

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
@@ -504,14 +504,14 @@ class ObjectSetViewModel(
                 when {
                     viewer == null -> DataViewViewState.Collection.NoView
                     viewer.isEmpty() -> {
-                        val hasTemplates = _dvViews.value.isActiveHasTemplates(storeOfObjectTypes)
+                        val hasTemplates = _dvViews.value.isActiveWithTemplates(storeOfObjectTypes)
                         DataViewViewState.Collection.NoItems(
                             title = viewer.title,
                             hasTemplates = hasTemplates
                         )
                     }
                     else -> {
-                        val hasTemplates = _dvViews.value.isActiveHasTemplates(storeOfObjectTypes)
+                        val hasTemplates = _dvViews.value.isActiveWithTemplates(storeOfObjectTypes)
                         DataViewViewState.Collection.Default(
                             viewer = viewer,
                             hasTemplates = hasTemplates
@@ -562,13 +562,13 @@ class ObjectSetViewModel(
                     render.isEmpty() -> {
                         DataViewViewState.Set.NoItems(
                             title = render.title,
-                            hasTemplates = _dvViews.value.isActiveHasTemplates(storeOfObjectTypes)
+                            hasTemplates = _dvViews.value.isActiveWithTemplates(storeOfObjectTypes)
                         )
                     }
                     else -> {
                         DataViewViewState.Set.Default(
                             viewer = render,
-                            hasTemplates = _dvViews.value.isActiveHasTemplates(storeOfObjectTypes)
+                            hasTemplates = _dvViews.value.isActiveWithTemplates(storeOfObjectTypes)
                         )
                     }
                 }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
@@ -498,7 +498,7 @@ class ObjectSetViewModel(
                 }
             }
             is DataViewState.Loaded -> {
-                _dvViews.value = objectState.viewers.toView(session)
+                _dvViews.value = objectState.dataViewState()?.toViewersView(context, session) ?: emptyList()
                 val relations = objectState.dataViewContent.relationLinks.mapNotNull {
                     storeOfRelations.getByKey(it.key)
                 }
@@ -552,7 +552,7 @@ class ObjectSetViewModel(
                 }
             }
             is DataViewState.Loaded -> {
-                _dvViews.value = objectState.viewers.toView(session)
+                _dvViews.value = objectState.dataViewState()?.toViewersView(context, session) ?: emptyList()
                 val relations = objectState.dataViewContent.relationLinks.mapNotNull {
                     storeOfRelations.getByKey(it.key)
                 }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
@@ -1498,10 +1498,10 @@ class ObjectSetViewModel(
                 session.currentViewerId
             ) { state, currentViewId ->
 
-                val viewer = state.dataViewState()?.viewerById(currentViewId) ?: return@combine null
+                val viewer = state.dataViewState()?.viewerById(currentViewId)
                 val viewerDefObjType = fetchViewerDefaultObjectType(viewer)
 
-                if (viewerDefObjType?.isTemplatesAllowed() == true) {
+                if (viewer != null && viewerDefObjType?.isTemplatesAllowed() == true) {
                     fetchAndProcessTemplates(viewerDefObjType, viewer)
                 } else {
                     Timber.d("Templates are not allowed for type:[${viewerDefObjType?.id}]")
@@ -1557,7 +1557,8 @@ class ObjectSetViewModel(
     fun onTemplateItemClicked(item: TemplateView) {
         val state = templatesWidgetState.value
         if (state.isMoreMenuVisible) {
-            templatesWidgetState.value = state.copy(isMoreMenuVisible = false, moreMenuTemplate = null)
+            templatesWidgetState.value =
+                state.copy(isMoreMenuVisible = false, moreMenuTemplate = null)
             return
         }
         when(item) {

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
@@ -1545,7 +1545,7 @@ class ObjectSetViewModel(
                                     urlBuilder = urlBuilder,
                                     coverImageHashProvider = coverImageHashProvider,
                                     objectTypeDefaultTemplate = objectType.defaultTemplateId,
-                                    viewerDefaultTemplate = viewer.defaultTemplateId
+                                    viewerDefaultTemplate = viewer.defaultTemplate
                                 )
                             } + listOf(TemplateView.New(objectType.id))
                     }.collectLatest {
@@ -1713,7 +1713,7 @@ class ObjectSetViewModel(
         val params = UpdateDataViewViewer.Params.Template(
             context = context,
             target = state.dataViewBlock.id,
-            viewer = viewer.copy(defaultTemplateId = template.id)
+            viewer = viewer.copy(defaultTemplate = template.id)
         )
         viewModelScope.launch {
             updateDataViewViewer(params).proceed(

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/state/ObjectState.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/state/ObjectState.kt
@@ -4,6 +4,7 @@ import com.anytypeio.anytype.core_models.Block
 import com.anytypeio.anytype.core_models.DV
 import com.anytypeio.anytype.core_models.DVViewer
 import com.anytypeio.anytype.core_models.Id
+import com.anytypeio.anytype.core_models.ObjectTypeIds
 import com.anytypeio.anytype.core_models.RelationLink
 import com.anytypeio.anytype.core_models.restrictions.DataViewRestrictions
 import com.anytypeio.anytype.core_models.restrictions.ObjectRestriction
@@ -65,5 +66,9 @@ sealed class ObjectState {
     object ErrorLayout : ObjectState() {
         override val isInitialized: Boolean
             get() = false
+    }
+
+    companion object {
+        val COLLECTION_OR_SET_BY_RELATION_DEFAULT_OBJECT_TYPE = ObjectTypeIds.PAGE
     }
 }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/state/ObjectState.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/state/ObjectState.kt
@@ -3,6 +3,7 @@ package com.anytypeio.anytype.presentation.sets.state
 import com.anytypeio.anytype.core_models.Block
 import com.anytypeio.anytype.core_models.DV
 import com.anytypeio.anytype.core_models.DVViewer
+import com.anytypeio.anytype.core_models.DVViewerType
 import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.core_models.ObjectTypeIds
 import com.anytypeio.anytype.core_models.RelationLink
@@ -69,6 +70,7 @@ sealed class ObjectState {
     }
 
     companion object {
-        val COLLECTION_OR_SET_BY_RELATION_DEFAULT_OBJECT_TYPE = ObjectTypeIds.PAGE
+        const val VIEW_DEFAULT_OBJECT_TYPE = ObjectTypeIds.PAGE
+        val VIEW_TYPE_UNSUPPORTED = DVViewerType.BOARD
     }
 }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/viewer/ViewerView.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/viewer/ViewerView.kt
@@ -9,7 +9,8 @@ data class ViewerView(
     val type: DVViewerType,
     val isActive: Boolean,
     val showActionMenu: Boolean = false,
-    val isUnsupported: Boolean = false
+    val isUnsupported: Boolean = false,
+    val defaultObjectType: Id?
 )
 
 

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/templates/ObjectTypeTemplatesContainer.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/templates/ObjectTypeTemplatesContainer.kt
@@ -10,9 +10,7 @@ import com.anytypeio.anytype.core_models.ObjectWrapper
 import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.domain.library.StoreSearchParams
 import com.anytypeio.anytype.domain.library.StorelessSubscriptionContainer
-import com.anytypeio.anytype.domain.library.StorelessSubscriptionContainer.Companion.SUBSCRIPTION_TEMPLATES
 import com.anytypeio.anytype.domain.workspace.WorkspaceManager
-import javax.inject.Named
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/collections/CollectionTemplatesDelegateTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/collections/CollectionTemplatesDelegateTest.kt
@@ -52,7 +52,7 @@ class CollectionTemplatesDelegateTest: ObjectSetViewModelTestSetup() {
         stubWorkspaceManager(mockCollection.workspaceId)
         stubInterceptEvents()
         stubInterceptThreadStatus()
-        stubStoreOfObjectTypes(defaultTypeMap)
+        stubStoreOfObjectTypes(defaultType, defaultTypeMap)
         stubGetDefaultPageType(type = defaultType, name = defaultTypeName)
         stubTemplatesContainer(type = defaultType)
 
@@ -109,7 +109,7 @@ class CollectionTemplatesDelegateTest: ObjectSetViewModelTestSetup() {
         stubWorkspaceManager(mockCollection.workspaceId)
         stubInterceptEvents()
         stubInterceptThreadStatus()
-        stubStoreOfObjectTypes(defaultTypeMap)
+        stubStoreOfObjectTypes(defaultType, defaultTypeMap)
         stubGetDefaultPageType(type = defaultType, name = defaultTypeName)
 
         val details = Block.Details(

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/collections/MockSet.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/collections/MockSet.kt
@@ -5,6 +5,7 @@ import com.anytypeio.anytype.core_models.DVFilter
 import com.anytypeio.anytype.core_models.DVViewerType
 import com.anytypeio.anytype.core_models.ObjectType
 import com.anytypeio.anytype.core_models.ObjectTypeIds
+import com.anytypeio.anytype.core_models.ObjectWrapper
 import com.anytypeio.anytype.core_models.Relation
 import com.anytypeio.anytype.core_models.RelationFormat
 import com.anytypeio.anytype.core_models.Relations
@@ -35,7 +36,6 @@ class MockSet(context: String, val setOfValue: String = "setOf-${RandomString.ma
     val workspaceId = "workspace-${RandomString.make()}"
     val subscriptionId = DefaultDataViewSubscription.getSubscriptionId(context)
     val setOf get() = setOfValue
-    val setOfNote = ObjectTypeIds.NOTE
 
     // RELATION OBJECTS
     val relationObject1 = StubRelationObject(
@@ -212,6 +212,25 @@ class MockSet(context: String, val setOfValue: String = "setOf-${RandomString.ma
                 mapOf(
                     Relations.ID to relationObject3.id,
                     Relations.RELATION_KEY to relationObject3.key,
+                    Relations.TYPE to ObjectTypeIds.RELATION
+                )
+            )
+        )
+    )
+
+    fun detailsSetByRelation(relationSetBy: ObjectWrapper.Relation) = Block.Details(
+        details = mapOf(
+            root to Block.Fields(
+                mapOf(
+                    Relations.ID to root,
+                    Relations.LAYOUT to ObjectType.Layout.SET.code.toDouble(),
+                    Relations.SET_OF to relationSetBy.key
+                )
+            ),
+            relationSetBy.key to Block.Fields(
+                mapOf(
+                    Relations.ID to relationSetBy.id,
+                    Relations.RELATION_KEY to relationSetBy.key,
                     Relations.TYPE to ObjectTypeIds.RELATION
                 )
             )

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/collections/MockSet.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/collections/MockSet.kt
@@ -69,7 +69,7 @@ class MockSet(context: String, val setOfValue: String = "setOf-${RandomString.ma
         StubDataViewViewRelation(key = relationObject1.key, isVisible = true)
     private val dvViewerRelation2 =
         StubDataViewViewRelation(key = relationObject2.key, isVisible = true)
-    private val dvViewerRelation3 =
+    val dvViewerRelation3 =
         StubDataViewViewRelation(key = relationObject3.key, isVisible = true)
     private val dvViewerRelation4 =
         StubDataViewViewRelation(key = relationObject4.key, isVisible = true)
@@ -77,11 +77,11 @@ class MockSet(context: String, val setOfValue: String = "setOf-${RandomString.ma
         StubDataViewViewRelation(key = relationObject5.key, isVisible = true)
 
     // RELATION LINKS
-    private val relationLink1 = StubRelationLink(relationObject1.key)
-    private val relationLink2 = StubRelationLink(relationObject2.key)
-    private val relationLink3 = StubRelationLink(relationObject3.key)
-    private val relationLink4 = StubRelationLink(relationObject4.key)
-    private val relationLink5 = StubRelationLink(relationObject5.key)
+    val relationLink1 = StubRelationLink(relationObject1.key)
+    val relationLink2 = StubRelationLink(relationObject2.key)
+    val relationLink3 = StubRelationLink(relationObject3.key)
+    val relationLink4 = StubRelationLink(relationObject4.key)
+    val relationLink5 = StubRelationLink(relationObject5.key)
 
     // SEARCH OBJECTS COMMAND, RELATION KEYS
     val dvKeys = listOf(
@@ -111,7 +111,7 @@ class MockSet(context: String, val setOfValue: String = "setOf-${RandomString.ma
     )
 
     // VIEWS
-    private val viewerList =
+    val viewerList =
         StubDataViewView(
             id = "dvViewerList-${RandomString.make()}",
             viewerRelations = listOf(
@@ -136,7 +136,7 @@ class MockSet(context: String, val setOfValue: String = "setOf-${RandomString.ma
             type = DVViewerType.GRID,
             filters = filters
         )
-    private val viewerGallery =
+    val viewerGallery =
         StubDataViewView(
             id = "dvViewerGallery-${RandomString.make()}",
             viewerRelations = listOf(

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/collections/ObjectCreateTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/collections/ObjectCreateTest.kt
@@ -2,6 +2,8 @@ package com.anytypeio.anytype.presentation.collections
 
 import app.cash.turbine.testIn
 import com.anytypeio.anytype.core_models.ObjectTypeIds
+import com.anytypeio.anytype.core_models.Relation
+import com.anytypeio.anytype.core_models.StubRelationObject
 import com.anytypeio.anytype.domain.base.Resultat
 import com.anytypeio.anytype.domain.dataview.interactor.CreateDataViewObject
 import com.anytypeio.anytype.presentation.sets.ObjectSetCommand
@@ -162,7 +164,13 @@ class ObjectCreateTest : ObjectSetViewModelTestSetup() {
     @Test
     fun `Should create and open Object when clicking on New button in Set by Relations`() = runTest {
 
-        mockObjectSet = MockSet(context = root, setOfValue = ObjectTypeIds.NOTE)
+        val setByRelationValue = "setByRelation-${RandomString.make()}"
+        mockObjectSet = MockSet(context = root, setOfValue = setByRelationValue)
+        val relationSetBy = StubRelationObject(
+            key = setByRelationValue,
+            isReadOnlyValue = false,
+            format = Relation.Format.LONG_TEXT
+        )
 
         // SETUP
         stubWorkspaceManager(mockObjectSet.workspaceId)
@@ -170,14 +178,17 @@ class ObjectCreateTest : ObjectSetViewModelTestSetup() {
         stubInterceptThreadStatus()
         stubOpenObject(
             doc = listOf(mockObjectSet.header, mockObjectSet.title, mockObjectSet.dataView),
-            details = mockObjectSet.detailsSetByRelation
+            details = mockObjectSet.detailsSetByRelation(relationSetBy)
         )
+        //stubStoreOfRelations(mockObjectSet)
+        storeOfRelations.merge(listOf(relationSetBy))
+
         stubSubscriptionResults(
             subscription = mockObjectSet.subscriptionId,
             workspace = mockObjectSet.workspaceId,
             storeOfRelations = storeOfRelations,
             keys = mockObjectSet.dvKeys,
-            sources = listOf(mockObjectSet.setOf),
+            sources = listOf(setByRelationValue),
             dvFilters = mockObjectSet.filters,
             objects = listOf(mockObjectSet.obj1, mockObjectSet.obj2)
         )
@@ -188,9 +199,10 @@ class ObjectCreateTest : ObjectSetViewModelTestSetup() {
         )
         doReturn(Resultat.success(result)).`when`(createDataViewObject).async(
             CreateDataViewObject.Params.SetByRelation(
-                relations = listOf(mockObjectSet.relationObject3.id),
+                relations = listOf(setByRelationValue),
                 filters = mockObjectSet.filters,
-                template = null
+                template = null,
+                type = ObjectTypeIds.PAGE
             )
         )
         doReturn(Resultat.success(Unit)).`when`(closeBlock).async(mockObjectSet.root)
@@ -207,9 +219,10 @@ class ObjectCreateTest : ObjectSetViewModelTestSetup() {
         verifyBlocking(createDataViewObject, times(1)) {
             async(
                 CreateDataViewObject.Params.SetByRelation(
-                    relations = listOf(mockObjectSet.relationObject3.id),
+                    relations = listOf(relationSetBy.key),
                     filters = mockObjectSet.filters,
-                    template = null
+                    template = null,
+                    type = ObjectTypeIds.PAGE
                 )
             )
         }
@@ -252,7 +265,8 @@ class ObjectCreateTest : ObjectSetViewModelTestSetup() {
         )
         doReturn(Resultat.success(result)).`when`(createDataViewObject).async(
             CreateDataViewObject.Params.Collection(
-                templateId = null
+                templateId = null,
+                type = ObjectTypeIds.PAGE
             )
         )
         doReturn(Resultat.success(Unit)).`when`(closeBlock).async(objectCollection.root)
@@ -267,7 +281,7 @@ class ObjectCreateTest : ObjectSetViewModelTestSetup() {
         advanceUntilIdle()
 
         verifyBlocking(createDataViewObject, times(1)) {
-            async(CreateDataViewObject.Params.Collection(null))
+            async(CreateDataViewObject.Params.Collection(type = ObjectTypeIds.PAGE, templateId = null))
         }
 
         verifyBlocking(closeBlock, times(1)) { async(objectCollection.root)}

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/collections/ObjectStateCollectionViewTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/collections/ObjectStateCollectionViewTest.kt
@@ -1,17 +1,19 @@
 package com.anytypeio.anytype.presentation.collections
 
 import app.cash.turbine.testIn
+import com.anytypeio.anytype.core_models.DV
 import com.anytypeio.anytype.core_models.ObjectType
 import com.anytypeio.anytype.core_models.ObjectTypeIds
 import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.core_models.StubObject
+import com.anytypeio.anytype.presentation.objects.SupportedLayouts
 import com.anytypeio.anytype.presentation.sets.DataViewViewState
 import com.anytypeio.anytype.presentation.sets.ObjectSetViewModel
 import com.anytypeio.anytype.presentation.sets.SetOrCollectionHeaderState
 import com.anytypeio.anytype.presentation.sets.main.ObjectSetViewModelTestSetup
 import com.anytypeio.anytype.presentation.sets.model.Viewer
 import com.anytypeio.anytype.presentation.sets.state.ObjectState
-import com.anytypeio.anytype.test_utils.MockDataFactory
+import com.anytypeio.anytype.presentation.sets.state.ObjectState.Companion.VIEW_DEFAULT_OBJECT_TYPE
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
@@ -19,6 +21,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import net.bytebuddy.utility.RandomString
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -521,34 +524,41 @@ class ObjectStateCollectionViewTest : ObjectSetViewModelTestSetup() {
     }
 
     @Test
-    fun `should be collection with templates present when default type is custom with proper recommended layout`() = runTest {
+    fun `should be collection with templates present when active view hasn't defaultTemplateId`() = runTest {
         // SETUP
-
-        val defaultObjectType = MockDataFactory.randomString()
-        val defaultObjectTypeName = "CustomName"
 
         stubWorkspaceManager(mockObjectCollection.workspaceId)
         stubInterceptEvents()
         stubInterceptThreadStatus()
-        stubGetDefaultPageType(defaultObjectType, defaultObjectTypeName)
         stubTemplatesContainer(
-            type = defaultObjectType,
-            templates = listOf(StubObject(objectType = defaultObjectType))
+            type = VIEW_DEFAULT_OBJECT_TYPE,
+            templates = listOf(StubObject(objectType = VIEW_DEFAULT_OBJECT_TYPE))
+        )
+
+        session.currentViewerId.value = mockObjectCollection.viewerList.id
+        val dataview = mockObjectCollection.dataView.copy(
+            content = (mockObjectCollection.dataView.content as DV).copy(
+                viewers = listOf(
+                    mockObjectCollection.viewerGrid.copy(defaultObjectType = ObjectTypeIds.PROFILE),
+                    mockObjectCollection.viewerList.copy(defaultObjectType = null)
+                )
+            )
         )
 
         stubOpenObject(
             doc = listOf(
                 mockObjectCollection.header,
                 mockObjectCollection.title,
-                mockObjectCollection.dataView
+                dataview
             ),
             details = mockObjectCollection.details
         )
         stubStoreOfObjectTypes(
+            VIEW_DEFAULT_OBJECT_TYPE,
             mapOf(
-                Relations.ID to defaultObjectType,
+                Relations.ID to VIEW_DEFAULT_OBJECT_TYPE,
                 Relations.RECOMMENDED_LAYOUT to ObjectType.Layout.BASIC.code.toDouble(),
-                Relations.NAME to defaultObjectTypeName
+                Relations.NAME to "VIEW_DEFAULT_OBJECT_TYPE"
             )
         )
         stubStoreOfRelations(mockObjectCollection)
@@ -578,22 +588,92 @@ class ObjectStateCollectionViewTest : ObjectSetViewModelTestSetup() {
     }
 
     @Test
-    fun `should be collection without templates allowed when default type is custom with not proper recommended layout`() = runTest {
+    fun `should be collection without templates allowed when active viewer default type is NOTE`() = runTest {
         // SETUP
-
-        val defaultObjectType = MockDataFactory.randomString()
-        val defaultObjectTypeName = "CustomName"
 
         stubWorkspaceManager(mockObjectCollection.workspaceId)
         stubInterceptEvents()
         stubInterceptThreadStatus()
-        stubGetDefaultPageType(defaultObjectType, defaultObjectTypeName)
+        stubTemplatesContainer()
+
+        session.currentViewerId.value = mockObjectCollection.viewerList.id
+        val dataview = mockObjectCollection.dataView.copy(
+            content = (mockObjectCollection.dataView.content as DV).copy(
+                viewers = listOf(
+                    mockObjectCollection.viewerGrid.copy(defaultObjectType = ObjectTypeIds.PROFILE),
+                    mockObjectCollection.viewerList.copy(defaultObjectType = ObjectTypeIds.NOTE)
+                )
+            )
+        )
 
         stubOpenObject(
             doc = listOf(
                 mockObjectCollection.header,
                 mockObjectCollection.title,
-                mockObjectCollection.dataView
+                dataview
+            ),
+            details = mockObjectCollection.details
+        )
+        stubStoreOfObjectTypes(
+            ObjectTypeIds.NOTE,
+            mapOf(
+                Relations.ID to ObjectTypeIds.NOTE,
+                Relations.RECOMMENDED_LAYOUT to ObjectType.Layout.NOTE.code.toDouble(),
+                Relations.NAME to "NOTE"
+            )
+        )
+        stubStoreOfRelations(mockObjectCollection)
+        stubSubscriptionResults(
+            subscription = mockObjectCollection.subscriptionId,
+            workspace = mockObjectCollection.workspaceId,
+            collection = root,
+            storeOfRelations = storeOfRelations,
+            keys = mockObjectCollection.dvKeys,
+            dvSorts = mockObjectCollection.sorts
+        )
+
+        // TESTING
+        viewModel.onStart(ctx = root)
+
+        val viewerFlow = viewModel.currentViewer.testIn(backgroundScope)
+        val stateFlow = stateReducer.state.testIn(backgroundScope)
+
+        // ASSERT STATES
+        assertIs<ObjectState.Init>(stateFlow.awaitItem())
+        assertIs<DataViewViewState.Init>(viewerFlow.awaitItem())
+        assertIs<ObjectState.DataView.Collection>(stateFlow.awaitItem())
+
+        val item = viewerFlow.awaitItem()
+        assertIs<DataViewViewState.Collection.NoItems>(item)
+        assertFalse(item.hasTemplates)
+    }
+
+    @Test
+    fun `should be collection without templates allowed when active viewer default type is custom type without recommended layouts`() = runTest {
+        // SETUP
+
+        val defaultObjectType = RandomString.make()
+        val defaultObjectTypeName = RandomString.make()
+
+        stubWorkspaceManager(mockObjectCollection.workspaceId)
+        stubInterceptEvents()
+        stubInterceptThreadStatus()
+
+        session.currentViewerId.value = mockObjectCollection.viewerList.id
+        val dataview = mockObjectCollection.dataView.copy(
+            content = (mockObjectCollection.dataView.content as DV).copy(
+                viewers = listOf(
+                    mockObjectCollection.viewerGrid.copy(defaultObjectType = ObjectTypeIds.PROFILE),
+                    mockObjectCollection.viewerList.copy(defaultObjectType = defaultObjectType)
+                )
+            )
+        )
+
+        stubOpenObject(
+            doc = listOf(
+                mockObjectCollection.header,
+                mockObjectCollection.title,
+                dataview
             ),
             details = mockObjectCollection.details
         )
@@ -601,7 +681,7 @@ class ObjectStateCollectionViewTest : ObjectSetViewModelTestSetup() {
             defaultObjectType,
             mapOf(
                 Relations.ID to defaultObjectType,
-                Relations.RECOMMENDED_LAYOUT to ObjectType.Layout.SET.code.toDouble(),
+                Relations.RECOMMENDED_LAYOUT to ObjectType.Layout.COLLECTION.code.toDouble(),
                 Relations.NAME to defaultObjectTypeName
             )
         )
@@ -632,22 +712,31 @@ class ObjectStateCollectionViewTest : ObjectSetViewModelTestSetup() {
     }
 
     @Test
-    fun `should be collection without templates allowed when default type is NOTE`() = runTest {
+    fun `should be collection with templates allowed when active viewer default type is custom type with recommended layouts`() = runTest {
         // SETUP
 
-        val defaultObjectType = ObjectTypeIds.NOTE
-        val defaultObjectTypeName = "Note"
+        val defaultObjectType = RandomString.make()
+        val defaultObjectTypeName = RandomString.make()
 
         stubWorkspaceManager(mockObjectCollection.workspaceId)
         stubInterceptEvents()
         stubInterceptThreadStatus()
-        stubGetDefaultPageType(defaultObjectType, defaultObjectTypeName)
+
+        session.currentViewerId.value = mockObjectCollection.viewerList.id
+        val dataview = mockObjectCollection.dataView.copy(
+            content = (mockObjectCollection.dataView.content as DV).copy(
+                viewers = listOf(
+                    mockObjectCollection.viewerGrid.copy(defaultObjectType = ObjectTypeIds.PROFILE),
+                    mockObjectCollection.viewerList.copy(defaultObjectType = defaultObjectType)
+                )
+            )
+        )
 
         stubOpenObject(
             doc = listOf(
                 mockObjectCollection.header,
                 mockObjectCollection.title,
-                mockObjectCollection.dataView
+                dataview
             ),
             details = mockObjectCollection.details
         )
@@ -655,7 +744,7 @@ class ObjectStateCollectionViewTest : ObjectSetViewModelTestSetup() {
             defaultObjectType,
             mapOf(
                 Relations.ID to defaultObjectType,
-                Relations.RECOMMENDED_LAYOUT to ObjectType.Layout.NOTE.code.toDouble(),
+                Relations.RECOMMENDED_LAYOUT to SupportedLayouts.editorLayouts.random().code.toDouble(),
                 Relations.NAME to defaultObjectTypeName
             )
         )
@@ -682,6 +771,6 @@ class ObjectStateCollectionViewTest : ObjectSetViewModelTestSetup() {
 
         val item = viewerFlow.awaitItem()
         assertIs<DataViewViewState.Collection.NoItems>(item)
-        assertFalse(item.hasTemplates)
+        assertTrue(item.hasTemplates)
     }
 }

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/collections/ObjectStateCollectionViewTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/collections/ObjectStateCollectionViewTest.kt
@@ -598,6 +598,7 @@ class ObjectStateCollectionViewTest : ObjectSetViewModelTestSetup() {
             details = mockObjectCollection.details
         )
         stubStoreOfObjectTypes(
+            defaultObjectType,
             mapOf(
                 Relations.ID to defaultObjectType,
                 Relations.RECOMMENDED_LAYOUT to ObjectType.Layout.SET.code.toDouble(),
@@ -651,6 +652,7 @@ class ObjectStateCollectionViewTest : ObjectSetViewModelTestSetup() {
             details = mockObjectCollection.details
         )
         stubStoreOfObjectTypes(
+            defaultObjectType,
             mapOf(
                 Relations.ID to defaultObjectType,
                 Relations.RECOMMENDED_LAYOUT to ObjectType.Layout.NOTE.code.toDouble(),

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/collections/ObjectStateCollectionViewTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/collections/ObjectStateCollectionViewTest.kt
@@ -540,7 +540,7 @@ class ObjectStateCollectionViewTest : ObjectSetViewModelTestSetup() {
             content = (mockObjectCollection.dataView.content as DV).copy(
                 viewers = listOf(
                     mockObjectCollection.viewerGrid.copy(defaultObjectType = ObjectTypeIds.PROFILE),
-                    mockObjectCollection.viewerList.copy(defaultObjectType = null)
+                    mockObjectCollection.viewerList.copy(defaultObjectType = ObjectTypeIds.PAGE)
                 )
             )
         )

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/collections/ObjectStateSetViewTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/collections/ObjectStateSetViewTest.kt
@@ -439,7 +439,7 @@ class ObjectStateSetViewTest : ObjectSetViewModelTestSetup() {
             sources = listOf(ObjectTypeIds.PAGE),
             dvFilters = mockObjectSet.filters
         )
-        stubStoreOfObjectTypes(pageTypeMap)
+        stubStoreOfObjectTypes(ObjectTypeIds.PAGE, pageTypeMap)
         stubTemplatesContainer(
             type = ObjectTypeIds.PAGE,
             templates = listOf(StubObject(objectType = ObjectTypeIds.PAGE))

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/ObjectSetReducerTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/ObjectSetReducerTest.kt
@@ -4,6 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.anytypeio.anytype.core_models.Block
 import com.anytypeio.anytype.core_models.DVSort
 import com.anytypeio.anytype.core_models.Event
+import com.anytypeio.anytype.core_models.ObjectTypeIds
 import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.core_models.StubDataView
 import com.anytypeio.anytype.core_models.StubDataViewView
@@ -98,7 +99,8 @@ class ObjectSetReducerTest {
                     type = Block.Content.DataView.Sort.Type.DESC
                 )
             ),
-            filters = listOf()
+            filters = listOf(),
+            defaultObjectType = ObjectTypeIds.PAGE
         )
 
         val dataView = Block(
@@ -226,7 +228,8 @@ class ObjectSetReducerTest {
                     type = Block.Content.DataView.Sort.Type.ASC
                 )
             ),
-            filters = listOf()
+            filters = listOf(),
+            defaultObjectType = ObjectTypeIds.PAGE
         )
 
         val viewerList = Block.Content.DataView.Viewer(
@@ -273,7 +276,8 @@ class ObjectSetReducerTest {
                     )
                 ),
                 filters = listOf(),
-                viewerRelations = viewerGrid.viewerRelations
+                viewerRelations = viewerGrid.viewerRelations,
+                defaultObjectType = ObjectTypeIds.PAGE
             )
         )
 
@@ -295,7 +299,8 @@ class ObjectSetReducerTest {
                         type = viewerGrid.type,
                         viewerRelations = viewerGrid.viewerRelations,
                         sorts = viewerGrid.sorts,
-                        filters = viewerGrid.filters
+                        filters = viewerGrid.filters,
+                        defaultObjectType = ObjectTypeIds.PAGE
                     ),
                     Block.Content.DataView.Viewer(
                         id = viewerList.id,
@@ -308,7 +313,8 @@ class ObjectSetReducerTest {
                                 type = Block.Content.DataView.Sort.Type.DESC
                             )
                         ),
-                        filters = listOf()
+                        filters = listOf(),
+                        defaultObjectType = ObjectTypeIds.PAGE
                     )
                 )
             ),
@@ -433,7 +439,8 @@ class ObjectSetReducerTest {
                         type = viewer1.type,
                         viewerRelations = viewer1.viewerRelations,
                         sorts = expectedSorts,
-                        filters = viewer1.filters
+                        filters = viewer1.filters,
+                        defaultObjectType = ObjectTypeIds.PAGE
                     ),
                     Block.Content.DataView.Viewer(
                         id = viewer2.id,
@@ -441,7 +448,8 @@ class ObjectSetReducerTest {
                         type = Block.Content.DataView.Viewer.Type.GRID,
                         viewerRelations = viewer2.viewerRelations,
                         sorts = listOf(sort1),
-                        filters = listOf()
+                        filters = listOf(),
+                        defaultObjectType = ObjectTypeIds.PAGE
                     )
                 ),
                 targetObjectId = (dataView.content as Block.Content.DataView).targetObjectId
@@ -553,7 +561,8 @@ class ObjectSetReducerTest {
                         type = viewer1.type,
                         viewerRelations = viewer1.viewerRelations,
                         sorts = viewer1.sorts,
-                        filters = expectedFilters
+                        filters = expectedFilters,
+                        defaultObjectType = ObjectTypeIds.PAGE
                     )
                 ),
                 targetObjectId = (dataView.content as Block.Content.DataView).targetObjectId
@@ -660,7 +669,8 @@ class ObjectSetReducerTest {
                         type = viewer1.type,
                         viewerRelations = expectedRelations,
                         sorts = viewer1.sorts,
-                        filters = viewer1.filters
+                        filters = viewer1.filters,
+                        defaultObjectType = ObjectTypeIds.PAGE
                     )
                 ),
                 targetObjectId = (dataView.content as Block.Content.DataView).targetObjectId
@@ -759,7 +769,8 @@ class ObjectSetReducerTest {
                         name = newViewerName,
                         cardSize = newCardSize,
                         coverFit = newCoverFit,
-                        coverRelationKey = relationKey1
+                        coverRelationKey = relationKey1,
+                        defaultObjectType = ObjectTypeIds.PAGE
                     )
                 ),
                 targetObjectId = (dataView.content as Block.Content.DataView).targetObjectId
@@ -837,7 +848,8 @@ class ObjectSetReducerTest {
                         sorts = viewer.sorts,
                         filters = viewer.filters,
                         name = viewer.name,
-                        coverRelationKey = viewer.coverRelationKey
+                        coverRelationKey = viewer.coverRelationKey,
+                        defaultObjectType = ObjectTypeIds.PAGE
                     )
                 ),
                 relationLinks = listOf(relationLink1, relationLink3),

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/ObjectSetTemplatesMenuTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/ObjectSetTemplatesMenuTest.kt
@@ -57,7 +57,7 @@ class ObjectSetTemplatesMenuTest : ObjectSetViewModelTestSetup() {
                 sources = listOf(ObjectTypeIds.PAGE),
                 dvFilters = mockObjectSet.filters
             )
-            stubStoreOfObjectTypes(pageTypeMap)
+            stubStoreOfObjectTypes(ObjectTypeIds.PAGE, pageTypeMap)
             stubTemplatesContainer(
                 type = ObjectTypeIds.PAGE,
                 templates = listOf(templateView)

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/ViewerDefaultObjectTypeTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/ViewerDefaultObjectTypeTest.kt
@@ -7,7 +7,7 @@ import com.anytypeio.anytype.core_models.StubDataView
 import com.anytypeio.anytype.presentation.collections.MockCollection
 import com.anytypeio.anytype.presentation.collections.MockSet
 import com.anytypeio.anytype.presentation.sets.main.ObjectSetViewModelTestSetup
-import com.anytypeio.anytype.presentation.sets.state.ObjectState.Companion.COLLECTION_OR_SET_BY_RELATION_DEFAULT_OBJECT_TYPE
+import com.anytypeio.anytype.presentation.sets.state.ObjectState.Companion.VIEW_DEFAULT_OBJECT_TYPE
 import com.anytypeio.anytype.test_utils.MockDataFactory
 import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -29,7 +29,7 @@ class ViewerDefaultObjectTypeTest : ObjectSetViewModelTestSetup() {
     private lateinit var mockSetByRelation: MockSet
     private lateinit var mockCollection: MockCollection
 
-    val defaultTypeId = COLLECTION_OR_SET_BY_RELATION_DEFAULT_OBJECT_TYPE
+    val defaultTypeId = VIEW_DEFAULT_OBJECT_TYPE
     val customType1Id = "customType1-${RandomString.make()}"
     val customType2Id = "customType2-${RandomString.make()}"
     val customType1Map = mapOf(

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/ViewerDefaultObjectTypeTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/ViewerDefaultObjectTypeTest.kt
@@ -1,0 +1,296 @@
+package com.anytypeio.anytype.presentation.sets
+
+import com.anytypeio.anytype.core_models.ObjectType
+import com.anytypeio.anytype.core_models.ObjectTypeIds
+import com.anytypeio.anytype.core_models.Relations
+import com.anytypeio.anytype.core_models.StubDataView
+import com.anytypeio.anytype.presentation.collections.MockCollection
+import com.anytypeio.anytype.presentation.collections.MockSet
+import com.anytypeio.anytype.presentation.sets.main.ObjectSetViewModelTestSetup
+import com.anytypeio.anytype.presentation.sets.state.ObjectState.Companion.COLLECTION_OR_SET_BY_RELATION_DEFAULT_OBJECT_TYPE
+import com.anytypeio.anytype.test_utils.MockDataFactory
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import net.bytebuddy.utility.RandomString
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.MockitoAnnotations
+
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ViewerDefaultObjectTypeTest : ObjectSetViewModelTestSetup() {
+
+    private lateinit var closable: AutoCloseable
+    private lateinit var viewModel: ObjectSetViewModel
+    private lateinit var mockSetByType: MockSet
+    private lateinit var mockSetByRelation: MockSet
+    private lateinit var mockCollection: MockCollection
+
+    val defaultTypeId = COLLECTION_OR_SET_BY_RELATION_DEFAULT_OBJECT_TYPE
+    val customType1Id = "customType1-${RandomString.make()}"
+    val customType2Id = "customType2-${RandomString.make()}"
+    val customType1Map = mapOf(
+        Relations.ID to customType1Id,
+        Relations.TYPE to ObjectTypeIds.OBJECT_TYPE,
+        Relations.RECOMMENDED_LAYOUT to ObjectType.Layout.TODO.code.toDouble(),
+        Relations.NAME to "customType1"
+    )
+
+    val customType2Map = mapOf(
+        Relations.ID to customType2Id,
+        Relations.TYPE to ObjectTypeIds.OBJECT_TYPE,
+        Relations.RECOMMENDED_LAYOUT to ObjectType.Layout.SET.code.toDouble(),
+        Relations.NAME to "customType2"
+    )
+
+    val pageTypeMap = mapOf(
+        Relations.ID to defaultTypeId,
+        Relations.TYPE to ObjectTypeIds.OBJECT_TYPE,
+        Relations.RECOMMENDED_LAYOUT to ObjectType.Layout.BASIC.code.toDouble(),
+        Relations.NAME to MockDataFactory.randomString()
+    )
+
+    @Before
+    fun setup() {
+        closable = MockitoAnnotations.openMocks(this)
+        viewModel = givenViewModel()
+    }
+
+    @After
+    fun after() {
+        rule.advanceTime()
+        closable.close()
+    }
+
+    @Test
+    fun `set by type should has this type for all views default object type ids`() = runTest {
+
+        val setOfValue = MockDataFactory.randomUuid()
+        mockSetByType = MockSet(context = root, setOfValue = setOfValue)
+
+        with(mockSetByType) {
+            stubWorkspaceManager(workspaceId)
+            stubInterceptEvents()
+            stubInterceptThreadStatus()
+
+            with(storeOfObjectTypes) {
+                set(defaultTypeId, pageTypeMap)
+                set(customType1Id, customType1Map)
+                set(customType2Id, customType2Map)
+            }
+
+            val viewer1 = viewerGrid.copy(defaultObjectType = customType1Id)
+            val viewer2 = viewerGallery.copy(defaultObjectType = customType2Id)
+            val viewer3 = viewerList.copy(defaultObjectType = null)
+
+            val dataViewWith3Views = StubDataView(
+                id = "dv-${RandomString.make()}",
+                views = listOf(viewer1, viewer2, viewer3),
+                relationLinks = listOf(
+                    relationLink1,
+                    relationLink2,
+                    relationLink3,
+                    relationLink4,
+                    relationLink5
+                )
+            )
+            stubOpenObject(
+                doc = listOf(header, title, dataViewWith3Views),
+                details = details
+            )
+            stubSubscriptionResults(
+                subscription = subscriptionId,
+                workspace = workspaceId,
+                storeOfRelations = storeOfRelations,
+                keys = dvKeys,
+                sources = listOf(setOfValue),
+                dvFilters = filters
+            )
+            stubTemplatesContainer()
+        }
+
+        viewModel.onStart(ctx = root)
+
+        advanceUntilIdle()
+
+        val result = viewModel.viewersWidgetState.value
+
+        val viewer1 = result.items[0]
+        val viewer2 = result.items[1]
+        val viewer3 = result.items[2]
+
+        assertEquals(
+            expected = setOfValue,
+            actual = viewer1.defaultObjectType
+        )
+        assertEquals(
+            expected = setOfValue,
+            actual = viewer2.defaultObjectType
+        )
+        assertEquals(
+            expected = setOfValue,
+            actual = viewer3.defaultObjectType
+        )
+        assertEquals(
+            expected = 3,
+            actual = result.items.size
+        )
+    }
+
+    @Test
+    fun `set by relation should has proper views default object type ids`() = runTest {
+
+        mockSetByRelation = MockSet(context = root, setOfValue = MockSet("").relationObject3.id)
+        with(mockSetByRelation) {
+
+            stubWorkspaceManager(workspaceId)
+            stubInterceptEvents()
+            stubInterceptThreadStatus()
+
+            with(storeOfObjectTypes) {
+                set(defaultTypeId, pageTypeMap)
+                set(customType1Id, customType1Map)
+                set(customType2Id, customType2Map)
+            }
+
+            val viewer1 = viewerGrid.copy(defaultObjectType = customType1Id)
+            val viewer2 = viewerGallery.copy(defaultObjectType = customType2Id)
+            val viewer3 = viewerList.copy(defaultObjectType = null)
+
+            val dataViewWith3Views = StubDataView(
+                id = "dv-${RandomString.make()}",
+                views = listOf(viewer1, viewer2, viewer3),
+                relationLinks = listOf(
+                    relationLink1,
+                    relationLink2,
+                    relationLink3,
+                    relationLink4,
+                    relationLink5
+                )
+            )
+            stubOpenObject(
+                doc = listOf(header, title, dataViewWith3Views),
+                details = detailsSetByRelation
+            )
+            stubSubscriptionResults(
+                subscription = subscriptionId,
+                workspace = workspaceId,
+                storeOfRelations = storeOfRelations,
+                keys = dvKeys,
+                sources = listOf(relationObject3.id),
+                dvFilters = filters
+            )
+            stubTemplatesContainer()
+        }
+
+        viewModel.onStart(ctx = root)
+
+        advanceUntilIdle()
+
+        val result = viewModel.viewersWidgetState.value
+
+        val viewer1 = result.items[0]
+        val viewer2 = result.items[1]
+        val viewer3 = result.items[2]
+
+        assertEquals(
+            expected = customType1Id,
+            actual = viewer1.defaultObjectType
+        )
+        assertEquals(
+            expected = customType2Id,
+            actual = viewer2.defaultObjectType
+        )
+        assertEquals(
+            expected = defaultTypeId,
+            actual = viewer3.defaultObjectType
+        )
+        assertEquals(
+            expected = 3,
+            actual = result.items.size
+        )
+    }
+
+    @Test
+    fun `collection should has proper views default object type ids`() = runTest {
+
+        mockCollection = MockCollection(context = root)
+        with(mockCollection) {
+            stubWorkspaceManager(workspaceId)
+            stubStoreOfRelations(this)
+
+            stubWorkspaceManager(workspaceId)
+            stubInterceptEvents()
+            stubInterceptThreadStatus()
+
+            with(storeOfObjectTypes) {
+                set(defaultTypeId, pageTypeMap)
+                set(customType1Id, customType1Map)
+                set(customType2Id, customType2Map)
+            }
+
+            val viewer1 = viewerGrid.copy(defaultObjectType = customType1Id)
+            val viewer2 = viewerGallery.copy(defaultObjectType = customType2Id)
+            val viewer3 = viewerList.copy(defaultObjectType = null)
+
+            session.currentViewerId.value = viewer3.id
+
+            val dataViewWith3Views = StubDataView(
+                id = "dv-${RandomString.make()}",
+                views = listOf(viewer1, viewer2, viewer3),
+                relationLinks = listOf(
+                    relationLink1,
+                    relationLink2,
+                    relationLink3,
+                    relationLink4,
+                    relationLink5,
+                    relationLink6
+                )
+            )
+            stubOpenObject(
+                doc = listOf(header, title, dataViewWith3Views),
+                details = details
+            )
+            stubSubscriptionResults(
+                subscription = this.subscriptionId,
+                collection = root,
+                workspace = workspaceId,
+                storeOfRelations = storeOfRelations,
+                keys = dvKeys,
+                objects = listOf(obj1, obj2),
+                dvSorts = sorts
+            )
+            stubTemplatesContainer()
+        }
+
+        viewModel.onStart(ctx = root)
+
+        advanceUntilIdle()
+
+        val result = viewModel.viewersWidgetState.value
+
+        val viewer1 = result.items[0]
+        val viewer2 = result.items[1]
+        val viewer3 = result.items[2]
+
+        assertEquals(
+            expected = customType1Id,
+            actual = viewer1.defaultObjectType
+        )
+        assertEquals(
+            expected = customType2Id,
+            actual = viewer2.defaultObjectType
+        )
+        assertEquals(
+            expected = defaultTypeId,
+            actual = viewer3.defaultObjectType
+        )
+        assertEquals(
+            expected = 3,
+            actual = result.items.size
+        )
+    }
+}

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/ViewerDefaultObjectTypeTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/ViewerDefaultObjectTypeTest.kt
@@ -84,7 +84,7 @@ class ViewerDefaultObjectTypeTest : ObjectSetViewModelTestSetup() {
 
             val viewer1 = viewerGrid.copy(defaultObjectType = customType1Id)
             val viewer2 = viewerGallery.copy(defaultObjectType = customType2Id)
-            val viewer3 = viewerList.copy(defaultObjectType = null)
+            val viewer3 = viewerList.copy(defaultObjectType = ObjectTypeIds.PAGE)
 
             val dataViewWith3Views = StubDataView(
                 id = "dv-${RandomString.make()}",
@@ -158,7 +158,7 @@ class ViewerDefaultObjectTypeTest : ObjectSetViewModelTestSetup() {
 
             val viewer1 = viewerGrid.copy(defaultObjectType = customType1Id)
             val viewer2 = viewerGallery.copy(defaultObjectType = customType2Id)
-            val viewer3 = viewerList.copy(defaultObjectType = null)
+            val viewer3 = viewerList.copy(defaultObjectType = ObjectTypeIds.PAGE)
 
             val dataViewWith3Views = StubDataView(
                 id = "dv-${RandomString.make()}",
@@ -234,7 +234,7 @@ class ViewerDefaultObjectTypeTest : ObjectSetViewModelTestSetup() {
 
             val viewer1 = viewerGrid.copy(defaultObjectType = customType1Id)
             val viewer2 = viewerGallery.copy(defaultObjectType = customType2Id)
-            val viewer3 = viewerList.copy(defaultObjectType = null)
+            val viewer3 = viewerList.copy(defaultObjectType = ObjectTypeIds.PAGE)
 
             session.currentViewerId.value = viewer3.id
 

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/main/ObjectSetViewModelTestSetup.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/main/ObjectSetViewModelTestSetup.kt
@@ -29,6 +29,7 @@ import com.anytypeio.anytype.domain.`object`.ConvertObjectToCollection
 import com.anytypeio.anytype.domain.`object`.DuplicateObjects
 import com.anytypeio.anytype.domain.`object`.UpdateDetail
 import com.anytypeio.anytype.domain.objects.DefaultObjectStore
+import com.anytypeio.anytype.domain.objects.DefaultStoreOfObjectTypes
 import com.anytypeio.anytype.domain.objects.DefaultStoreOfRelations
 import com.anytypeio.anytype.domain.objects.ObjectStore
 import com.anytypeio.anytype.domain.objects.SetObjectListIsArchived
@@ -150,7 +151,6 @@ open class ObjectSetViewModelTestSetup {
     @Mock
     lateinit var addObjectToCollection: AddObjectToCollection
 
-    @Mock
     lateinit var storeOfObjectTypes: StoreOfObjectTypes
 
     @Mock
@@ -211,6 +211,7 @@ open class ObjectSetViewModelTestSetup {
             dispatchers = dispatchers
         )
         dataViewSubscription = DefaultDataViewSubscription(dataViewSubscriptionContainer)
+        storeOfObjectTypes = DefaultStoreOfObjectTypes()
         return ObjectSetViewModel(
             openObjectSet = openObjectSet,
             closeBlock = closeBlock,
@@ -371,10 +372,8 @@ open class ObjectSetViewModelTestSetup {
         )
     }
 
-    fun stubStoreOfObjectTypes(map: Map<String, Any?> = emptyMap()) {
-        storeOfObjectTypes.stub {
-            onBlocking { get(any()) } doReturn ObjectWrapper.Type(map = map)
-        }
+    suspend fun stubStoreOfObjectTypes(id: String = "", map: Map<String, Any?> = emptyMap()) {
+        storeOfObjectTypes.set(id, map)
     }
 
     fun stubGetDefaultPageType(type: String = defaultObjectPageType, name: String = defaultObjectPageTypeName) {

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/main/SetByRelationTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/main/SetByRelationTest.kt
@@ -1,6 +1,7 @@
 package com.anytypeio.anytype.presentation.sets.main
 
 import app.cash.turbine.test
+import com.anytypeio.anytype.core_models.ObjectTypeIds
 import com.anytypeio.anytype.domain.dataview.interactor.CreateDataViewObject
 import com.anytypeio.anytype.presentation.collections.MockSet
 import com.anytypeio.anytype.presentation.sets.DataViewViewState
@@ -115,7 +116,8 @@ class SetByRelationTest : ObjectSetViewModelTestSetup() {
             CreateDataViewObject.Params.SetByRelation(
                 relations = listOf(mockObjectSet.relationObject3.id),
                 filters = mockObjectSet.filters,
-                template = null
+                template = null,
+                type = ObjectTypeIds.PAGE
             )
         )
 
@@ -138,7 +140,8 @@ class SetByRelationTest : ObjectSetViewModelTestSetup() {
                     CreateDataViewObject.Params.SetByRelation(
                         relations = listOf(mockObjectSet.relationObject3.id),
                         filters = mockObjectSet.filters,
-                        template = null
+                        template = null,
+                        type = ObjectTypeIds.PAGE
                     )
                 )
             }

--- a/test/core-models-stub/src/main/java/com/anytypeio/anytype/core_models/DataView.kt
+++ b/test/core-models-stub/src/main/java/com/anytypeio/anytype/core_models/DataView.kt
@@ -32,7 +32,8 @@ fun StubDataViewView(
     cardSize: DVViewerCardSize = DVViewerCardSize.SMALL,
     hideIcon: Boolean = false,
     coverFit: Boolean = false,
-    coverRelationKey: String? = null
+    coverRelationKey: String? = null,
+    defaultObjectType: Id? = null
 ): DVViewer = DVViewer(
     id = id,
     filters = filters,
@@ -43,7 +44,8 @@ fun StubDataViewView(
     cardSize = cardSize,
     hideIcon = hideIcon,
     coverFit = coverFit,
-    coverRelationKey = coverRelationKey
+    coverRelationKey = coverRelationKey,
+    defaultObjectType = defaultObjectType
 )
 
 fun StubDataViewViewRelation(

--- a/test/core-models-stub/src/main/java/com/anytypeio/anytype/core_models/DataView.kt
+++ b/test/core-models-stub/src/main/java/com/anytypeio/anytype/core_models/DataView.kt
@@ -33,7 +33,7 @@ fun StubDataViewView(
     hideIcon: Boolean = false,
     coverFit: Boolean = false,
     coverRelationKey: String? = null,
-    defaultObjectType: Id? = null
+    defaultObjectType: Id = ObjectTypeIds.PAGE
 ): DVViewer = DVViewer(
     id = id,
     filters = filters,


### PR DESCRIPTION
- To create an object in the Collection, the type is now taken from the View; in case it is absent, the Page type is used.
- To create an object in the Set by relation, the type is now taken from the View; in case it is absent, the Page type is used.
- To create an object in the Set by type, the type is taken from the Set query






