### PR TITLE
DROID-1750 Library | Fix | Ensuring unique keys for lazy column to prevent crash in the library component

### DIFF
--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/library/LibraryViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/library/LibraryViewModel.kt
@@ -23,7 +23,6 @@ import com.anytypeio.anytype.presentation.library.delegates.MyRelationsDelegate
 import com.anytypeio.anytype.presentation.library.delegates.MyTypesDelegate
 import com.anytypeio.anytype.presentation.navigation.NavigationViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -303,7 +302,7 @@ class LibraryViewModel(
                 } else {
                     libType
                 }
-            }
+            }.distinctBy { view -> view.id }
         )
     }
 
@@ -328,7 +327,7 @@ class LibraryViewModel(
                 } else {
                     libRelation
                 }
-            }
+            }.distinctBy { view -> view.id }
         )
     }
 


### PR DESCRIPTION
Fixing crash:

```
Key "rel-XXXXXX" was already used. If you are using LazyColumn/Row please make sure you provide a unique key for each item.
```
