### PR TITLE
DROID-1984 Protocol  | Fix | Type source object as list

### DIFF
--- a/core-models/src/main/java/com/anytypeio/anytype/core_models/ObjectWrapper.kt
+++ b/core-models/src/main/java/com/anytypeio/anytype/core_models/ObjectWrapper.kt
@@ -162,7 +162,7 @@ sealed class ObjectWrapper {
         val id: Id by default
         val uniqueKey: String? by default
         val name: String? by default
-        val sourceObject: Id? by default
+        val sourceObject: Id? get() = getSingleValue(Relations.SOURCE_OBJECT)
         val description: String? by default
         val isArchived: Boolean? by default
         val iconEmoji: String? by default
@@ -264,6 +264,13 @@ sealed class ObjectWrapper {
         else
             null
     }
+
+    inline fun <reified T> getSingleValue(relation: Key): T? =
+        when (val value = map.getOrDefault(relation, null)) {
+            is T -> value
+            is List<*> -> value.typeOf<T>().firstOrNull()
+            else -> null
+        }
 
     inline fun <reified T> getValues(relation: Key): List<T> {
         return when (val value = map.getOrDefault(relation, emptyList<T>())) {

--- a/domain/src/test/java/com/anytypeio/anytype/domain/misc/GetObjectTypeTest.kt
+++ b/domain/src/test/java/com/anytypeio/anytype/domain/misc/GetObjectTypeTest.kt
@@ -9,6 +9,7 @@ import com.anytypeio.anytype.domain.block.repo.BlockRepository
 import com.anytypeio.anytype.domain.util.dispatchers
 import com.anytypeio.anytype.test_utils.MockDataFactory
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
@@ -85,6 +86,139 @@ class GetObjectTypeTest {
                 limit = defaultParams.limit,
                 offset = defaultParams.offset,
                 fulltext = ""
+            )
+        }
+    }
+
+    @Test
+    fun `should return source object when Struct returns String`() {
+
+        val sourceObject = MockDataFactory.randomUuid()
+        val type1 = ObjectWrapper.Type(
+            mapOf(
+                Relations.ID to MockDataFactory.randomUuid(),
+                Relations.UNIQUE_KEY to MockDataFactory.randomUuid(),
+                Relations.SOURCE_OBJECT to sourceObject
+            )
+        )
+
+        runBlocking {
+            stubGetObjectTypes(types = listOf(type1))
+
+            val firstTimeResult = usecase.execute(params = defaultParams)
+            firstTimeResult.fold(
+                onFailure = { Assert.fail() },
+                onSuccess = { results ->
+                    assertEquals(
+                        expected = sourceObject,
+                        actual = results.first().sourceObject
+                    )
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `type should has source object when Struct returns list of one element`() {
+
+        val sourceObject = MockDataFactory.randomUuid()
+        val type1 = ObjectWrapper.Type(
+            mapOf(
+                Relations.ID to MockDataFactory.randomUuid(),
+                Relations.UNIQUE_KEY to MockDataFactory.randomUuid(),
+                Relations.SOURCE_OBJECT to listOf(sourceObject)
+            )
+        )
+
+        runBlocking {
+            stubGetObjectTypes(types = listOf(type1))
+
+            val firstTimeResult = usecase.execute(params = defaultParams)
+            firstTimeResult.fold(
+                onFailure = { Assert.fail() },
+                onSuccess = { results ->
+                    assertEquals(
+                        expected = sourceObject,
+                        actual = results.first().sourceObject
+                    )
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `type should has source object when Struct returns list of several elements`() {
+
+        val sourceObject = MockDataFactory.randomUuid()
+        val sourceObject2 = MockDataFactory.randomUuid()
+        val sourceObject3 = MockDataFactory.randomUuid()
+        val type1 = ObjectWrapper.Type(
+            mapOf(
+                Relations.ID to MockDataFactory.randomUuid(),
+                Relations.UNIQUE_KEY to MockDataFactory.randomUuid(),
+                Relations.SOURCE_OBJECT to listOf(sourceObject, sourceObject2, sourceObject3)
+            )
+        )
+
+        runBlocking {
+            stubGetObjectTypes(types = listOf(type1))
+
+            val firstTimeResult = usecase.execute(params = defaultParams)
+            firstTimeResult.fold(
+                onFailure = { Assert.fail() },
+                onSuccess = { results ->
+                    assertEquals(
+                        expected = sourceObject,
+                        actual = results.first().sourceObject
+                    )
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `type should has no source object when Struct returns empty list of`() {
+
+        val type1 = ObjectWrapper.Type(
+            mapOf(
+                Relations.ID to MockDataFactory.randomUuid(),
+                Relations.UNIQUE_KEY to MockDataFactory.randomUuid(),
+                Relations.SOURCE_OBJECT to emptyList<String>()
+            )
+        )
+
+        runBlocking {
+            stubGetObjectTypes(types = listOf(type1))
+
+            val firstTimeResult = usecase.execute(params = defaultParams)
+            firstTimeResult.fold(
+                onFailure = { Assert.fail() },
+                onSuccess = { results ->
+                    assertNull(results.first().sourceObject)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `type should has no source object when Struct returns null`() {
+
+        val type1 = ObjectWrapper.Type(
+            mapOf(
+                Relations.ID to MockDataFactory.randomUuid(),
+                Relations.UNIQUE_KEY to MockDataFactory.randomUuid()
+            )
+        )
+
+        runBlocking {
+            stubGetObjectTypes(types = listOf(type1))
+
+            val firstTimeResult = usecase.execute(params = defaultParams)
+            firstTimeResult.fold(
+                onFailure = { Assert.fail() },
+                onSuccess = { results ->
+                    assertNull(results.first().sourceObject)
+                }
             )
         }
     }


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
