### PR TITLE
DROID-2058 Relations | Object type is not displayed first of featured relations

### DIFF
--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/widgets/FeaturedRelationGroupWidget.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/widgets/FeaturedRelationGroupWidget.kt
@@ -320,9 +320,6 @@ class FeaturedRelationGroupWidget : ConstraintLayout {
                         maxLines = 1
                         ellipsize = TextUtils.TruncateAt.END
                     }
-                    if (relation.value == null) {
-                        view.alpha = 0.5f
-                    }
                     view.setOnClickListener {
                         click(ListenerType.Relation.Featured(relation))
                     }
@@ -341,9 +338,6 @@ class FeaturedRelationGroupWidget : ConstraintLayout {
                         isSingleLine = true
                         maxLines = 1
                         ellipsize = TextUtils.TruncateAt.END
-                    }
-                    if (relation.value == null) {
-                        view.alpha = 0.5f
                     }
                     view.setOnClickListener {
                         click(ListenerType.Relation.Featured(relation))

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/render/DefaultBlockViewRenderer.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/render/DefaultBlockViewRenderer.kt
@@ -2115,6 +2115,7 @@ class DefaultBlockViewRenderer @Inject constructor(
             keys = obj.featuredRelations,
             details = details
         )
+            .sortedByDescending { it.key == Relations.TYPE }
         return BlockView.FeaturedRelation(
             id = block.id,
             relations = views,

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetExtension.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetExtension.kt
@@ -221,6 +221,8 @@ private fun ObjectState.DataView.mapFeaturedRelations(
         }
     }
 }
+    .sortedByDescending { it.key == Relations.SET_OF }
+    .sortedByDescending { it.key == Relations.TYPE }
 
 fun List<DVRecord>.update(new: List<DVRecord>): List<DVRecord> {
     val update = new.associateBy { rec -> rec[ID_KEY] as String }


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
