### PR TITLE
DROID-2613 Widgets | Fix | Fix limit for tree widgets with custom source

### DIFF
--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/widgets/TreeWidgetContainer.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/widgets/TreeWidgetContainer.kt
@@ -95,7 +95,8 @@ class TreeWidgetContainer(
                             level = ROOT_INDENT,
                             expanded = paths,
                             path = widget.id + SEPARATOR + widget.source.id + SEPARATOR,
-                            data = data
+                            data = data,
+                            limit = rootLevelLimit
                         )
                     )
                 }
@@ -132,7 +133,8 @@ class TreeWidgetContainer(
                             level = ROOT_INDENT,
                             expanded = paths,
                             path = widget.id + SEPARATOR + widget.source.id + SEPARATOR,
-                            data = data
+                            data = data,
+                            limit = 0
                         )
                     )
                 }
@@ -229,11 +231,12 @@ class TreeWidgetContainer(
         expanded: List<TreePath>,
         level: Int,
         path: TreePath,
-        data: Map<Id, ObjectWrapper.Basic>
+        data: Map<Id, ObjectWrapper.Basic>,
+        limit: Int
     ): List<WidgetView.Tree.Element> = buildList {
         links.forEachIndexed { index, link ->
             // Applying limit only for root level:
-            if (level == 0 && rootLevelLimit > 0 && index == rootLevelLimit) {
+            if (level == 0 && limit > 0 && index == limit) {
                 return@buildList
             }
             val obj = data[link]
@@ -263,7 +266,8 @@ class TreeWidgetContainer(
                             level = level.inc(),
                             expanded = expanded,
                             path = currentLinkPath + SEPARATOR,
-                            data = data
+                            data = data,
+                            limit = limit
                         )
                     )
                 }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/widgets/TreeWidgetContainer.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/widgets/TreeWidgetContainer.kt
@@ -96,7 +96,7 @@ class TreeWidgetContainer(
                             expanded = paths,
                             path = widget.id + SEPARATOR + widget.source.id + SEPARATOR,
                             data = data,
-                            limit = rootLevelLimit
+                            rootLimit = rootLevelLimit
                         )
                     )
                 }
@@ -134,7 +134,7 @@ class TreeWidgetContainer(
                             expanded = paths,
                             path = widget.id + SEPARATOR + widget.source.id + SEPARATOR,
                             data = data,
-                            limit = 0
+                            rootLimit = 0
                         )
                     )
                 }
@@ -232,11 +232,11 @@ class TreeWidgetContainer(
         level: Int,
         path: TreePath,
         data: Map<Id, ObjectWrapper.Basic>,
-        limit: Int
+        rootLimit: Int
     ): List<WidgetView.Tree.Element> = buildList {
         links.forEachIndexed { index, link ->
             // Applying limit only for root level:
-            if (level == 0 && limit > 0 && index == limit) {
+            if (level == 0 && rootLimit > 0 && index == rootLimit) {
                 return@buildList
             }
             val obj = data[link]
@@ -267,7 +267,7 @@ class TreeWidgetContainer(
                             expanded = expanded,
                             path = currentLinkPath + SEPARATOR,
                             data = data,
-                            limit = limit
+                            rootLimit = rootLimit
                         )
                     )
                 }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/widgets/TreeWidgetContainer.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/widgets/TreeWidgetContainer.kt
@@ -134,7 +134,7 @@ class TreeWidgetContainer(
                             expanded = paths,
                             path = widget.id + SEPARATOR + widget.source.id + SEPARATOR,
                             data = data,
-                            rootLimit = 0
+                            rootLimit = WidgetConfig.NO_LIMIT
                         )
                     )
                 }


### PR DESCRIPTION
Limits for tree widgets are only enforced at the root level for bundled widgets. For widgets using a custom object as their source, these limits are not enforced at the root level.