### PR TITLE
Droid 3097 catch sigsys signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ ktlint
 signing.properties
 app/release
 .kotlin/
+app/.cxx

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,19 @@ android {
         buildConfigField "boolean", "LOG_EDITOR_CONTROL_PANEL", localProperties.getProperty("LOG_EDITOR_CONTROL_PANEL", "false")
         buildConfigField "boolean", "ENABLE_STRICT_MODE", "false"
         resValue "string", "SENTRY_DSN", config.sentryApiKey
+        externalNativeBuild {
+            cmake {
+                // Specify any cpp flags if needed
+                cppFlags "-std=c++11"
+            }
+       }
+    }
+    
+    externalNativeBuild {
+        cmake {
+            // Provide the path to your CMakeLists.txt file
+            path "src/main/cpp/CMakeLists.txt"
+        }
     }
 
     packagingOptions {

--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -1,4 +1,4 @@
 version.versionMajor=0
 version.versionMinor=33
-version.versionPatch=31
+version.versionPatch=32
 version.useDatedVersionName=false

--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -1,4 +1,4 @@
 version.versionMajor=0
 version.versionMinor=33
-version.versionPatch=32
+version.versionPatch=33
 version.useDatedVersionName=false

--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -1,4 +1,4 @@
 version.versionMajor=0
 version.versionMinor=33
-version.versionPatch=29
+version.versionPatch=30
 version.useDatedVersionName=false

--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -1,4 +1,4 @@
 version.versionMajor=0
 version.versionMinor=33
-version.versionPatch=30
+version.versionPatch=31
 version.useDatedVersionName=false

--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -1,4 +1,4 @@
 version.versionMajor=0
 version.versionMinor=33
-version.versionPatch=33
+version.versionPatch=34
 version.useDatedVersionName=false

--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -1,4 +1,4 @@
 version.versionMajor=0
-version.versionMinor=34
-version.versionPatch=0
+version.versionMinor=33
+version.versionPatch=29
 version.useDatedVersionName=false

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,18 @@
+# CMakeLists.txt
+cmake_minimum_required(VERSION 3.4.1)
+
+add_library(
+    signal_handler
+    SHARED
+    signal_handler.c
+)
+
+find_library(
+    log-lib
+    log
+)
+
+target_link_libraries(
+    signal_handler
+    ${log-lib}
+)

--- a/app/src/main/cpp/signal_handler.c
+++ b/app/src/main/cpp/signal_handler.c
@@ -1,0 +1,30 @@
+// signal_handler.c
+#include <jni.h>
+#include <signal.h>
+#include <android/log.h>
+
+#define LOG_TAG "SignalHandler"
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
+
+void sigsys_handler(int signum, siginfo_t *info, void *context) {
+    LOGI("SIGSYS signal received and ignored.");
+    // Ignore the signal to prevent the app from crashing
+}
+
+void setup_sigsys_handler() {
+    struct sigaction sa;
+    sa.sa_flags = SA_SIGINFO;
+    sa.sa_sigaction = sigsys_handler;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGSYS, &sa, NULL) == -1) {
+        LOGI("Failed to set up SIGSYS handler");
+    } else {
+        LOGI("SIGSYS handler set up successfully");
+    }
+}
+
+// Correctly named JNI function
+JNIEXPORT void JNICALL
+Java_com_anytypeio_anytype_app_AndroidApplication_00024SignalHandler_initSignalHandler(JNIEnv *env, jobject thiz) {
+    setup_sigsys_handler();
+}

--- a/app/src/main/java/com/anytypeio/anytype/app/AndroidApplication.kt
+++ b/app/src/main/java/com/anytypeio/anytype/app/AndroidApplication.kt
@@ -50,11 +50,21 @@ class AndroidApplication : Application(), HasComponentDependencies {
         ComponentManager(main, this)
     }
 
+
+    object SignalHandler {
+        init {
+            System.loadLibrary("signal_handler")
+        }
+
+        external fun initSignalHandler()
+    }
+
     override fun onCreate() {
         if (BuildConfig.ENABLE_STRICT_MODE) {
             enableStrictMode()
         }
         super.onCreate()
+        SignalHandler.initSignalHandler()
         main.inject(this)
         setupAnalytics()
         setupTimber()

--- a/app/src/main/java/com/anytypeio/anytype/app/DefaultFeatureToggles.kt
+++ b/app/src/main/java/com/anytypeio/anytype/app/DefaultFeatureToggles.kt
@@ -30,5 +30,5 @@ class DefaultFeatureToggles @Inject constructor(
         get() = false
 
     override val isNewSpaceHomeEnabled: Boolean
-        get() = true
+        get() = false
 }

--- a/app/src/main/java/com/anytypeio/anytype/di/feature/vault/VaultDI.kt
+++ b/app/src/main/java/com/anytypeio/anytype/di/feature/vault/VaultDI.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.anytypeio.anytype.analytics.base.Analytics
 import com.anytypeio.anytype.core_utils.di.scope.PerScreen
 import com.anytypeio.anytype.di.common.ComponentDependencies
+import com.anytypeio.anytype.domain.account.AwaitAccountStartManager
 import com.anytypeio.anytype.domain.auth.repo.AuthRepository
 import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
 import com.anytypeio.anytype.domain.block.repo.BlockRepository
@@ -69,4 +70,5 @@ interface VaultComponentDependencies : ComponentDependencies {
     fun auth(): AuthRepository
     fun appActionManager(): AppActionManager
     fun logger(): Logger
+    fun awaitAccount(): AwaitAccountStartManager
 }

--- a/app/src/main/java/com/anytypeio/anytype/ui/home/HomeScreenFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/home/HomeScreenFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -235,6 +236,10 @@ class HomeScreenFragment : BaseComposeFragment(),
                     )
                 }
             }
+
+            BackHandler {
+                vm.onBackClicked()
+            }
         }
     }
 
@@ -273,6 +278,8 @@ class HomeScreenFragment : BaseComposeFragment(),
             Timber.d("Deeplink  from fragment args")
             vm.onResume(DefaultDeepLinkResolver.resolve(deepLinkFromFragmentArgs))
             arguments?.putString(DEEP_LINK_KEY, null)
+        } else {
+            vm.onResume(null)
         }
     }
 

--- a/app/src/main/java/com/anytypeio/anytype/ui/spaces/SelectSpaceScreen.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/spaces/SelectSpaceScreen.kt
@@ -146,13 +146,13 @@ private fun SelectSpaceSpaceItem(
             modifier = Modifier
                 .size(96.dp)
                 .align(Alignment.CenterHorizontally)
-                .clip(RoundedCornerShape(4.dp))
+                .clip(RoundedCornerShape(12.dp))
                 .then(
                     if (item.view.isSelected)
                         Modifier.border(
                             width = if (item.view.isSelected) 2.dp else 0.dp,
                             color = Color.White,
-                            shape = RoundedCornerShape(4.dp)
+                            shape = RoundedCornerShape(12.dp)
                         )
                     else
                         Modifier

--- a/app/src/main/java/com/anytypeio/anytype/ui/vault/VaultScreen.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/vault/VaultScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
@@ -245,7 +244,7 @@ fun VaultSpaceCard(
 
                     is Wallpaper.Gradient -> {
                         Modifier.background(
-                            brush = Brush.horizontalGradient(
+                            brush = Brush.verticalGradient(
                                 colors = gradient(
                                     gradient = wallpaper.code,
                                     alpha = 0.3f
@@ -257,7 +256,7 @@ fun VaultSpaceCard(
 
                     is Wallpaper.Default -> {
                         Modifier.background(
-                            brush = Brush.horizontalGradient(
+                            brush = Brush.verticalGradient(
                                 colors = gradient(
                                     gradient = CoverGradient.SKY,
                                     alpha = 0.3f

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ import com.android.build.gradle.LibraryPlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper
 
 buildscript {
-    ext.compile_sdk = 35
-    ext.target_sdk = 35
+    ext.compile_sdk = 34
+    ext.target_sdk = 34
     ext.min_sdk = 26
 
     ext.application_id = 'io.anytype.app'

--- a/core-models/src/main/java/com/anytypeio/anytype/core_models/settings/VaultSettings.kt
+++ b/core-models/src/main/java/com/anytypeio/anytype/core_models/settings/VaultSettings.kt
@@ -1,5 +1,7 @@
 package com.anytypeio.anytype.core_models.settings
 
+import com.anytypeio.anytype.core_models.DEFAULT_RELATIVE_DATES
+import com.anytypeio.anytype.core_models.FALLBACK_DATE_PATTERN
 import com.anytypeio.anytype.core_models.Id
 
 data class VaultSettings(
@@ -7,4 +9,13 @@ data class VaultSettings(
     val orderOfSpaces: List<Id> = emptyList(),
     val isRelativeDates: Boolean,
     val dateFormat: String
-)
+) {
+    companion object {
+        fun default() : VaultSettings = VaultSettings(
+            showIntroduceVault = false,
+            orderOfSpaces = emptyList(),
+            isRelativeDates = DEFAULT_RELATIVE_DATES,
+            dateFormat = FALLBACK_DATE_PATTERN
+        )
+    }
+}

--- a/core-ui/src/main/res/drawable/ic_nav_panel_back.xml
+++ b/core-ui/src/main/res/drawable/ic_nav_panel_back.xml
@@ -7,6 +7,6 @@
       android:pathData="M20,25L11,16L20,7"
       android:strokeWidth="1.5"
       android:fillColor="@color/transparent_black"
-      android:strokeColor="@color/navigation_panel_icon"
+      android:strokeColor="@color/glyph_active"
       android:strokeLineCap="round"/>
 </vector>

--- a/core-ui/src/main/res/drawable/ic_nav_panel_plus.xml
+++ b/core-ui/src/main/res/drawable/ic_nav_panel_plus.xml
@@ -5,6 +5,6 @@
     android:viewportHeight="32">
   <path
       android:pathData="M15.25,25.25C15.25,25.664 15.586,26 16,26C16.414,26 16.75,25.664 16.75,25.25V16.75H25.25C25.664,16.75 26,16.414 26,16C26,15.586 25.664,15.25 25.25,15.25H16.75V6.75C16.75,6.336 16.414,6 16,6C15.586,6 15.25,6.336 15.25,6.75V15.25H6.75C6.336,15.25 6,15.586 6,16C6,16.414 6.336,16.75 6.75,16.75H15.25V25.25Z"
-      android:fillColor="@color/navigation_panel_icon"
+      android:fillColor="@color/glyph_active"
       android:fillType="evenOdd"/>
 </vector>

--- a/core-ui/src/main/res/drawable/ic_nav_panel_search.xml
+++ b/core-ui/src/main/res/drawable/ic_nav_panel_search.xml
@@ -7,11 +7,11 @@
       android:pathData="M15,13.998m-7.25,0a7.25,7.25 0,1 1,14.5 0a7.25,7.25 0,1 1,-14.5 0"
       android:strokeWidth="1.5"
       android:fillColor="@color/transparent_black"
-      android:strokeColor="@color/navigation_panel_icon"/>
+      android:strokeColor="@color/glyph_active"/>
   <path
       android:pathData="M26,24.998L20.5,19.5"
       android:strokeWidth="1.5"
       android:fillColor="@color/transparent_black"
-      android:strokeColor="@color/navigation_panel_icon"
+      android:strokeColor="@color/glyph_active"
       android:strokeLineCap="round"/>
 </vector>

--- a/core-ui/src/main/res/drawable/widget_main_bottom_toolbar_background.xml
+++ b/core-ui/src/main/res/drawable/widget_main_bottom_toolbar_background.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="16dp"/>
-    <solid android:color="@color/navigation_panel"/>
+    <solid android:color="@color/background_primary"/>
 </shape>

--- a/domain/src/main/java/com/anytypeio/anytype/domain/vault/ObserveVaultSettings.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/vault/ObserveVaultSettings.kt
@@ -1,8 +1,7 @@
 package com.anytypeio.anytype.domain.vault
 
-import com.anytypeio.anytype.core_models.FALLBACK_DATE_PATTERN
-import com.anytypeio.anytype.core_models.DEFAULT_RELATIVE_DATES
 import com.anytypeio.anytype.core_models.settings.VaultSettings
+import com.anytypeio.anytype.domain.account.AwaitAccountStartManager
 import com.anytypeio.anytype.domain.auth.repo.AuthRepository
 import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
 import com.anytypeio.anytype.domain.base.FlowInteractor
@@ -11,32 +10,25 @@ import com.anytypeio.anytype.domain.debugging.Logger
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flatMapLatest
 
 class ObserveVaultSettings @Inject constructor(
+    private val awaitAccountStart: AwaitAccountStartManager,
     private val settings: UserSettingsRepository,
     private val auth: AuthRepository,
     private val logger: Logger,
     dispatchers: AppCoroutineDispatchers
 ): FlowInteractor<Unit, VaultSettings>(dispatchers.io) {
-    override fun build(): Flow<VaultSettings> = flow {
-        val acc = auth.getCurrentAccount()
-        emitAll(
-            settings
-                .observeVaultSettings(acc)
-                .catch {
-                    logger.logException(it, "Error while observing vault settings")
-                    emit(
-                        VaultSettings(
-                            showIntroduceVault = false,
-                            orderOfSpaces = emptyList(),
-                            isRelativeDates = DEFAULT_RELATIVE_DATES,
-                            dateFormat = FALLBACK_DATE_PATTERN
-                        )
-                    )
-                }
-        )
-    }
+
+    override fun build(): Flow<VaultSettings> = awaitAccountStart
+        .awaitStart()
+        .flatMapLatest {
+            val acc = auth.getCurrentAccount()
+            settings.observeVaultSettings(acc)
+        }.catch {
+            logger.logException(it, "Error while observing vault settings")
+            emit(VaultSettings.default())
+        }
+
     override fun build(params: Unit): Flow<VaultSettings> = build()
 }

--- a/domain/src/test/java/com/anytypeio/anytype/domain/settings/ObserveVaultSettingsTest.kt
+++ b/domain/src/test/java/com/anytypeio/anytype/domain/settings/ObserveVaultSettingsTest.kt
@@ -1,0 +1,86 @@
+package com.anytypeio.anytype.domain.settings
+
+import app.cash.turbine.test
+import com.anytypeio.anytype.core_models.settings.VaultSettings
+import com.anytypeio.anytype.domain.account.AwaitAccountStartManager
+import com.anytypeio.anytype.domain.auth.repo.AuthRepository
+import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
+import com.anytypeio.anytype.domain.common.DefaultCoroutineTestRule
+import com.anytypeio.anytype.domain.config.UserSettingsRepository
+import com.anytypeio.anytype.domain.debugging.Logger
+import com.anytypeio.anytype.domain.vault.ObserveVaultSettings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.verifyNoInteractions
+
+class ObserveVaultSettingsTest {
+
+    @get:Rule
+    val rule = DefaultCoroutineTestRule()
+
+    val dispatchers = AppCoroutineDispatchers(
+        io = rule.dispatcher,
+        computation = rule.dispatcher,
+        main = rule.dispatcher
+    )
+
+    @Mock
+    lateinit var awaitAccountStartManager: AwaitAccountStartManager
+
+    @Mock
+    lateinit var logger: Logger
+
+    @Mock
+    lateinit var authRepository: AuthRepository
+
+    @Mock
+    lateinit var settingsRepository: UserSettingsRepository
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+    }
+
+    @Test
+    fun `should emit default vault settings when getAccount throws an exceptiom`() = runTest {
+
+        awaitAccountStartManager.stub {
+            on {
+                awaitStart()
+            } doReturn flowOf(AwaitAccountStartManager.State.Started)
+        }
+
+        authRepository.stub {
+            onBlocking {
+                getCurrentAccount()
+            } doThrow IllegalStateException()
+        }
+
+        val useCase = ObserveVaultSettings(
+            settings = settingsRepository,
+            auth = authRepository,
+            logger = logger,
+            dispatchers = dispatchers,
+            awaitAccountStart = awaitAccountStartManager
+        )
+
+        useCase.flow().test {
+            assertEquals(
+                expected = VaultSettings.default(),
+                actual = awaitItem()
+            )
+            awaitComplete()
+        }
+
+        verifyNoInteractions(settingsRepository)
+    }
+}

--- a/feature-all-content/src/main/java/com/anytypeio/anytype/feature_allcontent/ui/AllContentScreen.kt
+++ b/feature-all-content/src/main/java/com/anytypeio/anytype/feature_allcontent/ui/AllContentScreen.kt
@@ -849,6 +849,7 @@ fun SwipeToDismissListItems(
             } else {
                 false
             }
+            return@rememberSwipeToDismissBoxState true
         },
         positionalThreshold = { it * .5f }
     )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,12 +3,12 @@ middlewareVersion = "v0.37.0"
 kotlinVersion = '2.0.21'
 kspVersion = "2.0.21-1.0.25"
 
-androidxCoreVersion = "1.15.0"
+androidxCoreVersion = "1.13.1"
 
-androidxComposeVersion = '1.7.5'
-composeMaterial3Version = '1.3.1'
-composeMaterialVersion = '1.7.5'
-composeConstraintLayoutVersion = '1.1.0'
+androidxComposeVersion = '1.7.4'
+composeMaterial3Version = '1.3.0'
+composeMaterialVersion = '1.7.4'
+composeConstraintLayoutVersion = '1.0.1'
 
 dokkaVersion = '1.9.20'
 
@@ -16,7 +16,7 @@ activityComposeVersion = '1.9.3'
 composeReorderableVersion = 'e9ef693f63'
 accompanistVersion = "0.34.0"
 appcompatVersion = '1.7.0'
-fragmentVersion = "1.8.5"
+fragmentVersion = "1.8.4"
 exoplayerVersion = "2.19.1"
 wireVersion = "4.9.8"
 glideVersion = "4.14.2"
@@ -32,13 +32,13 @@ androidxTestCoreVersion = '1.6.1'
 androidxCoreTestingVersion = '2.2.0'
 androidxSecurityCryptoVersion = '1.0.0'
 androidxPreferenceVersion = '1.2.1'
-constraintLayoutVersion = '2.2.0'
+constraintLayoutVersion = '2.1.4'
 recyclerviewVersion = '1.3.2'
 emojiCompatVersion = '1.1.0'
-lifecycleVersion = '2.8.7'
-lifecycleRuntimeComposeVersion = '2.8.7'
-navigationVersion = '2.8.4'
-navigationComposeVersion = '2.8.4'
+lifecycleVersion = '2.8.6'
+lifecycleRuntimeComposeVersion = '2.8.6'
+navigationVersion = '2.8.3'
+navigationComposeVersion = '2.8.3'
 shimmerLayoutVersion = '0.5.0'
 photoViewVersion = '2.3.0'
 daggerVersion = '2.51'
@@ -64,7 +64,7 @@ coilComposeVersion = '2.6.0'
 sentryVersion = '7.13.0'
 
 composeQrCodeVersion = '1.0.1'
-fragmentComposeVersion = "1.8.5"
+fragmentComposeVersion = "1.8.4"
 
 [libraries]
 middleware = { module = "io.anyproto:anytype-heart-android", version.ref = "middlewareVersion" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-middlewareVersion = "v0.37.0"
+middlewareVersion = "v0.37.3"
 kotlinVersion = '2.0.21'
 kspVersion = "2.0.21-1.0.25"
 

--- a/localization/src/main/res/values-ru-rRU/strings.xml
+++ b/localization/src/main/res/values-ru-rRU/strings.xml
@@ -1160,7 +1160,7 @@
     <string name="multiplayer_upgrade_button_request">✦ Обновите, чтобы добавить больше участников</string>
     <string name="multiplayer_upgrade_spaces_button">✦ Обновите, чтобы добавить больше пространств</string>
     <string name="multiplayer_members">Участники</string>
-    <string name="multiplayer_leave_request">Оставить запрос</string>
+    <string name="multiplayer_leave_request">Запрос на выход</string>
     <string name="multiplayer_join_request">Запрос на присоединение</string>
     <string name="multiplayer_approve_request">Утверждено</string>
     <string name="multiplayer_view_request">Посмотреть запрос</string>

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomeScreenViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomeScreenViewModel.kt
@@ -142,7 +142,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.scan
-import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -1725,30 +1724,33 @@ class HomeScreenViewModel(
 
     fun onBackClicked() {
         viewModelScope.launch {
-            openWidgetObjectsHistory.forEach { (obj, space) ->
-                closeObject
-                    .async(
-                        CloseBlock.Params(
-                            target = obj,
-                            space = space
+            if (spaceManager.getState() is SpaceManager.State.Space) {
+                // Proceed with releasing resources before exiting
+                openWidgetObjectsHistory.forEach { (obj, space) ->
+                    closeObject
+                        .async(
+                            CloseBlock.Params(
+                                target = obj,
+                                space = space
+                            )
                         )
-                    )
-                    .onSuccess {
-                        Timber.d("Closed object from widget object session history: $obj")
-                    }
-                    .onFailure {
-                        Timber.e(it, "Error while closing object from history")
-                    }
-            }
-            spaceManager.clear()
-            clearLastOpenedSpace.async(Unit).fold(
-                onSuccess = {
-                    Timber.d("Cleared last opened space before opening vault")
-                },
-                onFailure = {
-                    Timber.e(it, "Error while clearing last opened space before opening vault")
+                        .onSuccess {
+                            Timber.d("Closed object from widget object session history: $obj")
+                        }
+                        .onFailure {
+                            Timber.e(it, "Error while closing object from history")
+                        }
                 }
-            )
+                spaceManager.clear()
+                clearLastOpenedSpace.async(Unit).fold(
+                    onSuccess = {
+                        Timber.d("Cleared last opened space before opening vault")
+                    },
+                    onFailure = {
+                        Timber.e(it, "Error while clearing last opened space before opening vault")
+                    }
+                )
+            }
             commands.emit(Command.OpenVault)
         }
     }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/spaces/SpaceSettingsViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/spaces/SpaceSettingsViewModel.kt
@@ -33,7 +33,6 @@ import com.anytypeio.anytype.domain.misc.UrlBuilder
 import com.anytypeio.anytype.domain.multiplayer.ActiveSpaceMemberSubscriptionContainer
 import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
 import com.anytypeio.anytype.domain.multiplayer.UserPermissionProvider
-import com.anytypeio.anytype.domain.multiplayer.isSharingLimitReached
 import com.anytypeio.anytype.domain.multiplayer.sharedSpaceCount
 import com.anytypeio.anytype.domain.payments.GetMembershipStatus
 import com.anytypeio.anytype.domain.search.ProfileSubscriptionManager
@@ -96,10 +95,10 @@ class SpaceSettingsViewModel(
                     .map { wrapper ->
                         wrapper.getValue<Double?>(Relations.SHARED_SPACES_LIMIT)?.toInt() ?: 0
                          },
-                spaceViewContainer.sharedSpaceCount(userPermissionProvider.all())
-            ) { spaceView, permission, sharedSpaceLimit: Int, sharedSpaceCount: Int ->
+                spaceViewContainer.sharedSpaceCount(userPermissionProvider.all()),
+                activeSpaceMemberSubscriptionContainer.observe(params.space),
+            ) { spaceView, permission, sharedSpaceLimit: Int, sharedSpaceCount: Int, store ->
                 Timber.d("Got shared space limit: $sharedSpaceLimit, shared space count: $sharedSpaceCount")
-                val store = activeSpaceMemberSubscriptionContainer.get(params.space)
                 val requests: Int = if (store is ActiveSpaceMemberSubscriptionContainer.Store.Data) {
                     store.members.count { it.status == ParticipantStatus.JOINING }
                 } else {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -7,12 +7,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion 35
+    compileSdkVersion 34
     buildToolsVersion "34.0.0"
 
     defaultConfig {
         applicationId "com.anytypeio.anytype.sample"
         minSdkVersion 26
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/versioning.gradle
+++ b/versioning.gradle
@@ -98,7 +98,7 @@ ext.getBuildVersionName = {
         def date = getCurrentDate()
         return "${versionMajor}.${versionMinor}.${versionPatch}-${date}"
     } else {
-        return "${versionMajor}.${versionMinor}.${versionPatch}"
+        return "${versionMajor}.${versionMinor}.${versionPatch}-beta"
     }
 }
 


### PR DESCRIPTION
we have a problem on android <12 after updating to go 1.23. 
Official solution by the go team(introduced in go 1.23.3) is to catch and ignore sigsys signal [https://github.com/golang/go/pull/69543](https://github.com/golang/go/pull/69543)

But we can't do it inside the anytype-heaert lib because shared library can't catch signals.