### PR TITLE
DROID-3264 Editor | Enhancement | Added stroke color shape_tertiary to imageIcon

### DIFF
--- a/core-ui/src/main/res/layout/item_block_title.xml
+++ b/core-ui/src/main/res/layout/item_block_title.xml
@@ -52,7 +52,6 @@
 
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/imageIcon"
-        tools:src="@drawable/a123"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:maxHeight="443dp"
@@ -67,19 +66,19 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:shapeAppearance="@style/TitleImageAppearanceOverlay"
-        app:strokeColor="@color/background_primary"
-        app:strokeWidth="4dp"
+        app:strokeColor="@color/shape_tertiary"
+        app:strokeWidth="1dp"
         tools:visibility="visible" />
 
     <com.anytypeio.anytype.core_ui.widgets.text.TextInputWidget
         android:id="@+id/title"
         style="@style/BlockTitleContentStyle"
         android:layout_width="0dp"
+        android:layout_marginTop="@dimen/dp_16"
         android:hint="@string/untitled"
         android:paddingStart="20dp"
         android:paddingEnd="20dp"
         app:ignoreDragAndDrop="true"
-        android:layout_marginTop="@dimen/dp_16"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/barrier"


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
