### PR TITLE
DROID-3611 Navigation | Fix | Allow restoration of last opened space from loading state on splash screen - Hotfix

### DIFF
--- a/core-models/src/main/java/com/anytypeio/anytype/core_models/ObjectWrapper.kt
+++ b/core-models/src/main/java/com/anytypeio/anytype/core_models/ObjectWrapper.kt
@@ -354,6 +354,12 @@ sealed class ObjectWrapper {
                         && spaceAccountStatus != SpaceStatus.SPACE_REMOVING
                         && spaceAccountStatus != SpaceStatus.SPACE_DELETED
             }
+
+        val isUnknown: Boolean
+            get() {
+                return spaceLocalStatus == SpaceStatus.UNKNOWN
+                        && spaceAccountStatus == SpaceStatus.UNKNOWN
+            }
     }
 
     inline fun <reified T> getValue(relation: Key): T? {

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/splash/SplashViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/splash/SplashViewModelTest.kt
@@ -1,16 +1,21 @@
 package com.anytypeio.anytype.presentation.splash
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import app.cash.turbine.test
 import com.anytypeio.anytype.CrashReporter
 import com.anytypeio.anytype.analytics.base.Analytics
 import com.anytypeio.anytype.core_models.StubConfig
+import com.anytypeio.anytype.core_models.StubSpaceView
 import com.anytypeio.anytype.core_models.primitives.SpaceId
+import com.anytypeio.anytype.core_models.restrictions.SpaceStatus
 import com.anytypeio.anytype.domain.auth.interactor.CheckAuthorizationStatus
 import com.anytypeio.anytype.domain.auth.interactor.GetLastOpenedObject
 import com.anytypeio.anytype.domain.auth.interactor.LaunchAccount
 import com.anytypeio.anytype.domain.auth.interactor.LaunchWallet
 import com.anytypeio.anytype.domain.auth.model.AuthStatus
 import com.anytypeio.anytype.domain.base.Either
+import com.anytypeio.anytype.domain.base.Result
+import com.anytypeio.anytype.domain.base.Resultat
 import com.anytypeio.anytype.domain.block.repo.BlockRepository
 import com.anytypeio.anytype.domain.config.UserSettingsRepository
 import com.anytypeio.anytype.domain.misc.LocaleProvider
@@ -23,7 +28,13 @@ import com.anytypeio.anytype.presentation.analytics.AnalyticSpaceHelperDelegate
 import com.anytypeio.anytype.presentation.auth.account.MigrationHelperDelegate
 import com.anytypeio.anytype.presentation.util.CoroutinesTestRule
 import java.util.Locale
+import kotlin.test.assertEquals
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -183,6 +194,114 @@ class SplashViewModelTest {
         runBlocking {
             verify(launchWallet, times(1)).invoke(any())
             verify(launchAccount, times(1)).invoke(any())
+        }
+    }
+
+    @Test
+    fun `should navigate to vault if space view loading times out`() = runTest {
+        // GIVEN
+
+        val deeplink = "test-deeplink"
+
+        val status = AuthStatus.AUTHORIZED
+        val response = Either.Right(status)
+
+        val space = defaultSpaceConfig.space
+
+        stubCheckAuthStatus(response)
+        stubLaunchWallet()
+        stubLaunchAccount()
+        stubGetLastOpenedObject()
+
+        getLastOpenedSpace.stub {
+            onBlocking {
+                async(Unit)
+            } doReturn Resultat.Success(
+                SpaceId(space)
+            )
+        }
+
+        initViewModel()
+
+        // WHEN
+        // simulate spaceManager.observe() never emits a valid space view (simulate timeout)
+        spaceManager.stub {
+            on { observe() } doReturn flow { /* no emission */ }
+        }
+        spaceViewSubscriptionContainer.stub {
+            on { observe() } doReturn flow { /* no emission */ }
+        }
+
+        vm.commands.test {
+            // Act: manually trigger proceedWithVaultNavigation
+            vm.onDeepLinkLaunch(deeplink)
+
+            // THEN
+            // small delay to allow the coroutine to timeout internally
+            delay(SplashViewModel.SPACE_LOADING_TIMEOUT + 100)
+
+
+            val first = awaitItem()
+            assertEquals(
+                expected = SplashViewModel.Command.NavigateToVault(deeplink),
+                actual = first
+            )
+        }
+    }
+
+    @Test
+    fun `should navigate to space view when space is restored`() = runTest {
+        // GIVEN
+
+        val deeplink = "test-deeplink"
+
+        val status = AuthStatus.AUTHORIZED
+        val response = Either.Right(status)
+
+        val space = defaultSpaceConfig.space
+
+        val spaceView = StubSpaceView(
+            targetSpaceId = space,
+            spaceLocalStatus = SpaceStatus.OK,
+            spaceAccountStatus = SpaceStatus.OK
+        )
+
+        stubCheckAuthStatus(response)
+        stubLaunchWallet()
+        stubLaunchAccount()
+        stubGetLastOpenedObject()
+
+        getLastOpenedSpace.stub {
+            onBlocking {
+                async(Unit)
+            } doReturn Resultat.Success(
+                SpaceId(space)
+            )
+        }
+
+        initViewModel()
+
+        // WHEN
+        // simulate spaceManager.observe() never emits a valid space view (simulate timeout)
+        spaceManager.stub {
+            on { observe() } doReturn flowOf(defaultSpaceConfig)
+        }
+        spaceViewSubscriptionContainer.stub {
+            on { observe(SpaceId(defaultSpaceConfig.space)) } doReturn flowOf(spaceView)
+        }
+
+        vm.commands.test {
+            // Act: manually trigger proceedWithVaultNavigation
+            vm.onDeepLinkLaunch(deeplink)
+
+            val first = awaitItem()
+            assertEquals(
+                expected = SplashViewModel.Command.NavigateToWidgets(
+                    space = defaultSpaceConfig.space,
+                    deeplink
+                ),
+                actual = first
+            )
         }
     }
 

--- a/test/core-models-stub/src/main/java/com/anytypeio/anytype/core_models/DataView.kt
+++ b/test/core-models-stub/src/main/java/com/anytypeio/anytype/core_models/DataView.kt
@@ -103,11 +103,13 @@ fun StubSpaceView(
     spaceAccessType: SpaceAccessType = SpaceAccessType.DEFAULT,
     sharedSpaceLimit: Int? = null,
     spaceAccountStatus: SpaceStatus? = null,
-    spaceLocalStatus: SpaceStatus? = null
+    spaceLocalStatus: SpaceStatus? = null,
+    chatId: Id? = null
 
 ) = ObjectWrapper.SpaceView(
     map = mapOf(
         Relations.ID to id,
+        Relations.CHAT_ID to chatId,
         Relations.TARGET_SPACE_ID to targetSpaceId,
         Relations.SPACE_ACCESS_TYPE to spaceAccessType.code.toDouble(),
         Relations.SHARED_SPACES_LIMIT to sharedSpaceLimit?.toDouble(),

--- a/test/core-models-stub/src/main/java/com/anytypeio/anytype/core_models/DataView.kt
+++ b/test/core-models-stub/src/main/java/com/anytypeio/anytype/core_models/DataView.kt
@@ -1,6 +1,7 @@
 package com.anytypeio.anytype.core_models
 
 import com.anytypeio.anytype.core_models.multiplayer.SpaceAccessType
+import com.anytypeio.anytype.core_models.restrictions.SpaceStatus
 import com.anytypeio.anytype.test_utils.MockDataFactory
 
 fun StubDataView(
@@ -100,13 +101,17 @@ fun StubSpaceView(
     id: Id = MockDataFactory.randomUuid(),
     targetSpaceId: Id = MockDataFactory.randomUuid(),
     spaceAccessType: SpaceAccessType = SpaceAccessType.DEFAULT,
-    sharedSpaceLimit: Int? = null
+    sharedSpaceLimit: Int? = null,
+    spaceAccountStatus: SpaceStatus? = null,
+    spaceLocalStatus: SpaceStatus? = null
 
 ) = ObjectWrapper.SpaceView(
     map = mapOf(
         Relations.ID to id,
         Relations.TARGET_SPACE_ID to targetSpaceId,
         Relations.SPACE_ACCESS_TYPE to spaceAccessType.code.toDouble(),
-        Relations.SHARED_SPACES_LIMIT to sharedSpaceLimit?.toDouble()
+        Relations.SHARED_SPACES_LIMIT to sharedSpaceLimit?.toDouble(),
+        Relations.SPACE_ACCOUNT_STATUS to spaceAccountStatus?.code?.toDouble(),
+        Relations.SPACE_LOCAL_STATUS to spaceLocalStatus?.code?.toDouble()
     )
 )


### PR DESCRIPTION
### Changes

	•	Added timeout when restoring the last opened space:
	•	If the spaceViews.observe() does not emit a valid view within 5 seconds, fallback behavior is triggered.
	•	Logged warnings:
	•	When the observed space view remains in an unknown status, a warning (Timber.w) is now emitted.
	•	When a timeout occurs, a warning is logged to indicate that navigation fallback was triggered.
	•	Improved restoration logic:
	•	Now we proceed to open the last object (navigate to widgets or space chat) even if the space view is still in a loading state.
	•	This ensures a faster and smoother restoration experience without forcing the user to wait for the full space loading.

### Motivation

Previously, restoration was blocked until the space view fully loaded, potentially causing a long wait or even blocking navigation if there were network issues or inconsistencies.
With this change:
	•	We guarantee a maximum wait time (5s).
	•	We can navigate the user to their last location as soon as possible, even if the full data is still loading in the background.

### Impact
	•	Faster and more resilient app startup and restoration experience.
	•	Better debug visibility through new warnings.
	•	Improved UX during app launches or recovery scenarios.