### PR TITLE
DROID-3876 Filters | Adds support for LAST_YEAR, CURRENT_YEAR, and NEXT_YEAR date filter options, part2

### DIFF
--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -1,4 +1,4 @@
 version.versionMajor=0
 version.versionMinor=39
-version.versionPatch=21
+version.versionPatch=22
 version.useDatedVersionName=false

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/ObjectSetRenderMapper.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/ObjectSetRenderMapper.kt
@@ -341,35 +341,51 @@ private val quickOptionDefaultOrder by lazy {
 }
 
 private val quickOptionOrderMap: Map<DVFilterCondition, List<DVFilterQuickOption>> by lazy {
+
+    // Extended options including all date ranges
+    val extendedOptions = listOf(
+        DVFilterQuickOption.TODAY,
+        DVFilterQuickOption.YESTERDAY,
+        DVFilterQuickOption.TOMORROW,
+        DVFilterQuickOption.CURRENT_WEEK,
+        DVFilterQuickOption.LAST_WEEK,
+        DVFilterQuickOption.NEXT_WEEK,
+        DVFilterQuickOption.CURRENT_MONTH,
+        DVFilterQuickOption.LAST_MONTH,
+        DVFilterQuickOption.NEXT_MONTH,
+        DVFilterQuickOption.CURRENT_YEAR,
+        DVFilterQuickOption.LAST_YEAR,
+        DVFilterQuickOption.NEXT_YEAR,
+    )
+
+    // Default options for exact dates and offsets
+    val defaultOptions = listOf(
+        DVFilterQuickOption.DAYS_AGO,
+        DVFilterQuickOption.DAYS_AHEAD,
+        DVFilterQuickOption.EXACT_DATE,
+    )
+
     buildMap {
+        // Equal condition: specific day options + defaults
         put(
             DVFilterCondition.EQUAL, listOf(
                 DVFilterQuickOption.TODAY,
                 DVFilterQuickOption.YESTERDAY,
                 DVFilterQuickOption.TOMORROW,
-                DVFilterQuickOption.DAYS_AGO,
-                DVFilterQuickOption.DAYS_AHEAD,
-                DVFilterQuickOption.EXACT_DATE,
-            )
+            ) + defaultOptions
         )
 
-        put(
-            DVFilterCondition.IN, listOf(
-                DVFilterQuickOption.TODAY,
-                DVFilterQuickOption.YESTERDAY,
-                DVFilterQuickOption.TOMORROW,
-                DVFilterQuickOption.CURRENT_WEEK,
-                DVFilterQuickOption.LAST_WEEK,
-                DVFilterQuickOption.NEXT_WEEK,
-                DVFilterQuickOption.CURRENT_MONTH,
-                DVFilterQuickOption.LAST_MONTH,
-                DVFilterQuickOption.NEXT_MONTH,
-                DVFilterQuickOption.CURRENT_YEAR,
-                DVFilterQuickOption.LAST_YEAR,
-                DVFilterQuickOption.NEXT_YEAR,
-            )
-        )
+        // Comparison conditions: all extended options + defaults (includes years)
+        val comparisonOptions = extendedOptions + defaultOptions
+        put(DVFilterCondition.GREATER, comparisonOptions)
+        put(DVFilterCondition.LESS, comparisonOptions)
+        put(DVFilterCondition.GREATER_OR_EQUAL, comparisonOptions)
+        put(DVFilterCondition.LESS_OR_EQUAL, comparisonOptions)
 
+        // In condition: only extended options (no defaults)
+        put(DVFilterCondition.IN, extendedOptions)
+
+        // Empty conditions
         put(DVFilterCondition.EMPTY, emptyList())
         put(DVFilterCondition.NOT_EMPTY, emptyList())
     }

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/filter/FilterExtensionsTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/filter/FilterExtensionsTest.kt
@@ -1,8 +1,17 @@
 package com.anytypeio.anytype.presentation.sets.filter
 
+import com.anytypeio.anytype.core_models.DVFilterCondition
+import com.anytypeio.anytype.core_models.DVFilterQuickOption
+import com.anytypeio.anytype.core_models.Relation
+import com.anytypeio.anytype.core_models.StubRelationObject
+import com.anytypeio.anytype.core_models.primitives.Field
+import com.anytypeio.anytype.domain.primitives.FieldParser
 import com.anytypeio.anytype.presentation.extension.checkboxFilterValue
+import com.anytypeio.anytype.presentation.relations.toCreateFilterDateView
 import org.junit.Assert
 import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 class FilterExtensionsTest {
 
@@ -79,5 +88,180 @@ class FilterExtensionsTest {
         val expected = false
 
         Assert.assertEquals(expected, result)
+    }
+
+    @Test
+    fun `toCreateFilterDateView should return correct date filter views for EQUAL condition with TODAY option`() {
+        // Given
+        val relation = StubRelationObject(
+            key = "testDateRelation",
+            format = Relation.Format.DATE
+        )
+        val condition = DVFilterCondition.EQUAL
+        val value = 1640995200000L // Sample timestamp
+        val fieldParser: FieldParser = mock()
+        
+        val mockDateField = mock<Field.Date>()
+        whenever(fieldParser.toDate(any = value)).thenReturn(mockDateField)
+
+        // When
+        val result = relation.toCreateFilterDateView(
+            quickOption = DVFilterQuickOption.TODAY,
+            condition = condition,
+            value = value,
+            fieldParser = fieldParser
+        )
+
+        // Then
+        Assert.assertTrue("Should contain TODAY option", result.any { it.type == DVFilterQuickOption.TODAY })
+        Assert.assertTrue("Should contain YESTERDAY option", result.any { it.type == DVFilterQuickOption.YESTERDAY })
+        Assert.assertTrue("Should contain TOMORROW option", result.any { it.type == DVFilterQuickOption.TOMORROW })
+        Assert.assertTrue("Should contain EXACT_DATE option", result.any { it.type == DVFilterQuickOption.EXACT_DATE })
+
+        val todayOption = result.first { it.type == DVFilterQuickOption.TODAY }
+        Assert.assertTrue("TODAY option should be selected", todayOption.isSelected)
+        Assert.assertEquals("Relation key should match", "testDateRelation", todayOption.id)
+        Assert.assertEquals("Condition should match", condition, todayOption.condition)
+        Assert.assertEquals("Value should match when selected", value, todayOption.value)
+    }
+
+    @Test
+    fun `toCreateFilterDateView should return correct date filter views for GREATER condition with extended options`() {
+        // Given
+        val relation = StubRelationObject(
+            key = "testDateRelation",
+            format = Relation.Format.DATE
+        )
+        val condition = DVFilterCondition.GREATER
+        val value = 1640995200000L
+        val fieldParser: FieldParser = mock()
+
+        whenever(fieldParser.toDate(any = value)).thenReturn(null)
+
+        // When
+        val result = relation.toCreateFilterDateView(
+            quickOption = DVFilterQuickOption.CURRENT_YEAR,
+            condition = condition,
+            value = value,
+            fieldParser = fieldParser
+        )
+
+        // Then
+        Assert.assertTrue("Should contain CURRENT_YEAR option", result.any { it.type == DVFilterQuickOption.CURRENT_YEAR })
+        Assert.assertTrue("Should contain LAST_YEAR option", result.any { it.type == DVFilterQuickOption.LAST_YEAR })
+        Assert.assertTrue("Should contain NEXT_YEAR option", result.any { it.type == DVFilterQuickOption.NEXT_YEAR })
+        Assert.assertTrue("Should contain EXACT_DATE option", result.any { it.type == DVFilterQuickOption.EXACT_DATE })
+
+        val currentYearOption = result.first { it.type == DVFilterQuickOption.CURRENT_YEAR }
+        Assert.assertTrue("CURRENT_YEAR option should be selected", currentYearOption.isSelected)
+        Assert.assertEquals("Value should match when selected", value, currentYearOption.value)
+    }
+
+    @Test
+    fun `toCreateFilterDateView should handle EXACT_DATE option correctly`() {
+        // Given
+        val relation = StubRelationObject(
+            key = "testDateRelation",
+            format = Relation.Format.DATE
+        )
+        val condition = DVFilterCondition.EQUAL
+        val value = 1640995200000L
+        val fieldParser: FieldParser = mock()
+
+        whenever(fieldParser.toDate(any = value)).thenReturn(null)
+
+        // When
+        val result = relation.toCreateFilterDateView(
+            quickOption = DVFilterQuickOption.EXACT_DATE,
+            condition = condition,
+            value = value,
+            fieldParser = fieldParser
+        )
+
+        // Then
+        val exactDateOption = result.first { it.type == DVFilterQuickOption.EXACT_DATE }
+        Assert.assertTrue("EXACT_DATE option should be selected when value > 0", exactDateOption.isSelected)
+        Assert.assertEquals("Value should match", value, exactDateOption.value)
+    }
+
+    @Test
+    fun `toCreateFilterDateView should handle zero value with EXACT_DATE option`() {
+        // Given
+        val relation = StubRelationObject(
+            key = "testDateRelation",
+            format = Relation.Format.DATE
+        )
+        val condition = DVFilterCondition.EQUAL
+        val value = 0L
+        val fieldParser: FieldParser = mock()
+
+        whenever(fieldParser.toDate(any = value)).thenReturn(null)
+
+        // When
+        val result = relation.toCreateFilterDateView(
+            quickOption = DVFilterQuickOption.EXACT_DATE,
+            condition = condition,
+            value = value,
+            fieldParser = fieldParser
+        )
+
+        // Then
+        val exactDateOption = result.first { it.type == DVFilterQuickOption.EXACT_DATE }
+        Assert.assertFalse("EXACT_DATE option should not be selected when value is 0", exactDateOption.isSelected)
+        Assert.assertEquals("Value should be NO_VALUE when not selected", CreateFilterView.Date.NO_VALUE, exactDateOption.value)
+    }
+
+    @Test
+    fun `toCreateFilterDateView should handle IN condition with extended options only`() {
+        // Given
+        val relation = StubRelationObject(
+            key = "testDateRelation",
+            format = Relation.Format.DATE
+        )
+        val condition = DVFilterCondition.IN
+        val value = 1640995200000L
+        val fieldParser: FieldParser = mock()
+
+        whenever(fieldParser.toDate(any = value)).thenReturn(null)
+
+        // When
+        val result = relation.toCreateFilterDateView(
+            quickOption = DVFilterQuickOption.CURRENT_MONTH,
+            condition = condition,
+            value = value,
+            fieldParser = fieldParser
+        )
+
+        // Then
+        Assert.assertTrue("Should contain CURRENT_MONTH option", result.any { it.type == DVFilterQuickOption.CURRENT_MONTH })
+        Assert.assertTrue("Should contain CURRENT_YEAR option", result.any { it.type == DVFilterQuickOption.CURRENT_YEAR })
+        Assert.assertFalse("Should not contain EXACT_DATE option for IN condition", result.any { it.type == DVFilterQuickOption.EXACT_DATE })
+        Assert.assertFalse("Should not contain DAYS_AGO option for IN condition", result.any { it.type == DVFilterQuickOption.DAYS_AGO })
+
+        val currentMonthOption = result.first { it.type == DVFilterQuickOption.CURRENT_MONTH }
+        Assert.assertTrue("CURRENT_MONTH option should be selected", currentMonthOption.isSelected)
+    }
+
+    @Test
+    fun `toCreateFilterDateView should handle EMPTY condition with no options`() {
+        // Given
+        val relation = StubRelationObject(
+            key = "testDateRelation",
+            format = Relation.Format.DATE
+        )
+        val condition = DVFilterCondition.EMPTY
+        val value = 1640995200000L
+        val fieldParser: FieldParser = mock()
+
+        // When
+        val result = relation.toCreateFilterDateView(
+            quickOption = null,
+            condition = condition,
+            value = value,
+            fieldParser = fieldParser
+        )
+
+        // Then
+        Assert.assertTrue("Should return empty list for EMPTY condition", result.isEmpty())
     }
 }


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
