### PR TITLE
#2810 | Fix | Add back monochrome icon with new logo path

### DIFF
--- a/app/src/debug/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/debug/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:name="vector"
+    android:width="110dp"
+    android:height="110dp"
+    android:viewportWidth="110"
+    android:viewportHeight="110"
+>
+    <path
+        android:pathData="M 48.5 51.5 C 54.02 51.5 58.5 55.98 58.5 61.5 C 58.5 67.02 54.02 71.5 48.5 71.5 C 42.98 71.5 38.5 67.02 38.5 61.5 C 38.5 55.98 42.98 51.5 48.5 51.5 Z M 68.25 46 C 69.22 46 70 46.78 70 47.75 L 70 69.25 C 70 70.22 69.22 71 68.25 71 L 63.75 71 C 62.78 71 62 70.22 62 69.25 L 62 47.75 C 62 46.78 62.78 46 63.75 46 L 68.25 46 Z M 60.25 38 C 61.22 38 62 38.78 62 39.75 L 62 44.25 C 62 45.22 61.22 46 60.25 46 L 45.25 46 C 44.28 46 43.5 45.22 43.5 44.25 L 43.5 39.75 C 43.5 38.78 44.28 38 45.25 38 L 60.25 38 Z"
+        android:fillColor="#000000"
+    />
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
Closes #2810 

### Mobile & Desktop Screenshots/Recordings
| Before | After |
|--------|-------|
| <img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/6646983a-427b-4536-abfe-820a42664842" /> | <img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/e78f3bc3-0d8b-43a2-b71b-272659d17838" /> |

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
