### PR TITLE
Show all action buttons without horizontal scrolling

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -198,6 +198,7 @@ dependencies {
     implementation libs.appcompat
     implementation libs.design
     implementation libs.recyclerView
+    implementation libs.flexbox
     implementation libs.constraintLayout
     implementation libs.composeConstraintLayout
     implementation libs.coilCompose

--- a/app/src/main/java/com/anytypeio/anytype/ui/editor/sheets/ObjectMenuBaseFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/editor/sheets/ObjectMenuBaseFragment.kt
@@ -9,14 +9,12 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.os.bundleOf
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.fragment.findNavController
-import androidx.recyclerview.widget.LinearLayoutManager
 import com.anytypeio.anytype.R
 import com.anytypeio.anytype.analytics.BuildConfig
 import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.core_models.ObjectType
 import com.anytypeio.anytype.core_models.primitives.SpaceId
 import com.anytypeio.anytype.core_ui.features.objects.ObjectActionAdapter
-import com.anytypeio.anytype.core_ui.layout.SpacingItemDecoration
 import com.anytypeio.anytype.core_ui.reactive.click
 import com.anytypeio.anytype.core_utils.ext.arg
 import com.anytypeio.anytype.core_utils.ext.argOrNull
@@ -43,6 +41,8 @@ import com.anytypeio.anytype.ui.linking.BacklinkOrAddToObjectFragment
 import com.anytypeio.anytype.ui.moving.OnMoveToAction
 import com.anytypeio.anytype.ui.primitives.ObjectFieldsFragment
 import com.anytypeio.anytype.ui.publishtoweb.PublishToWebFragment
+import com.google.android.flexbox.FlexDirection
+import com.google.android.flexbox.FlexboxLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import timber.log.Timber
 
@@ -75,14 +75,12 @@ abstract class ObjectMenuBaseFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.rvActions.apply {
-            layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
+            layoutManager = FlexboxLayoutManager(context).apply {
+                flexDirection = FlexDirection.ROW
+                flexWrap = com.google.android.flexbox.FlexWrap.WRAP
+                alignItems = com.google.android.flexbox.AlignItems.FLEX_START
+            }
             adapter = actionAdapter
-            addItemDecoration(
-                SpacingItemDecoration(
-                    firstItemSpacingStart = resources.getDimension(R.dimen.dp_8).toInt(),
-                    lastItemSpacingEnd = resources.getDimension(R.dimen.dp_8).toInt()
-                )
-            )
         }
         binding.objectLayoutConflictScreen.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)

--- a/app/src/main/res/layout/fragment_object_menu.xml
+++ b/app/src/main/res/layout/fragment_object_menu.xml
@@ -203,8 +203,9 @@
         <FrameLayout
             android:id="@+id/rvContainer"
             android:layout_width="match_parent"
-            android:layout_height="108dp"
+            android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
+            android:layout_marginBottom="8dp"
             android:layout_weight="0">
 
             <androidx.recyclerview.widget.RecyclerView

--- a/core-ui/src/main/res/layout/item_object_menu_action.xml
+++ b/core-ui/src/main/res/layout/item_object_menu_action.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="78dp"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:layout_marginStart="8dp"
+    android:layout_marginEnd="8dp"
+    android:layout_marginBottom="8dp"
+    android:minHeight="80dp"
     android:orientation="vertical">
 
     <FrameLayout
@@ -10,6 +14,7 @@
         android:layout_width="52dp"
         android:layout_height="52dp"
         android:layout_gravity="center_horizontal"
+        android:layout_marginBottom="8dp"
         android:background="@drawable/rectangle_object_menu_action_ripple">
 
         <ImageView
@@ -27,7 +32,6 @@
         style="@style/TextView.UXStyle.Captions.2.Regular"
         android:layout_gravity="center_horizontal"
         android:textAlignment="center"
-        android:layout_marginTop="5dp"
         android:textColor="@color/text_secondary"
         tools:text="Undo/Redo" />
 </LinearLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,7 @@ firebaseBomVersion = "33.13.0"
 
 composeQrCodeVersion = '1.0.1'
 fragmentComposeVersion = "1.8.6"
+flexboxVersion = "3.0.0"
 
 [libraries]
 middleware = { module = "io.anyproto:anytype-heart-android", version.ref = "middlewareVersion" }
@@ -162,6 +163,7 @@ firebaseBom = { module = "com.google.firebase:firebase-bom", version.ref = "fire
 firebaseMessaging = { module = "com.google.firebase:firebase-messaging"}
 customTabs = { module = "androidx.browser:browser", version.ref = "customTabsVersion" }
 anyCrypto = { module = "com.github.anyproto:any-crypto-kotlin", version = "1.0.2" }
+flexbox = { module = "com.google.android.flexbox:flexbox", version.ref = "flexboxVersion" }
 
 [bundles]
 


### PR DESCRIPTION
---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

### Description

The object action buttons are now shown in horizontal rows and do not require horizontal scrolling.

Please see if horizontal spacing between buttons matches the overall app styling.

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

- https://community.anytype.io/t/show-all-object-actions-without-horizontal-scroll/29440

### Mobile & Desktop Screenshots/Recordings

<img width="490" height="1025" alt="image" src="https://github.com/user-attachments/assets/ec44771c-e727-4dfd-8ed2-ed864af3e1c2" />


### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

