### PR TITLE
DROID-4263 Notifications | Use chat name for Data space notification titles

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/device/NotificationBuilderImpl.kt
+++ b/app/src/main/java/com/anytypeio/anytype/device/NotificationBuilderImpl.kt
@@ -102,7 +102,9 @@ class NotificationBuilderImpl(
         // - For Data spaces: use the chat's name (each chat has its own name)
         // - For Chat spaces: use the space name (space and chat are the same)
         val notificationTitle = if (spaceView?.spaceUxType == SpaceUxType.DATA) {
-            chatsDetailsSubscriptionContainer.get(message.chatId)?.name?.trim()
+            chatsDetailsSubscriptionContainer.get(message.chatId)?.name
+                ?.trim()
+                ?.takeIf { it.isNotBlank() }
                 ?: message.spaceName.trim()  // Fallback to space name if chat name unavailable
         } else {
             message.spaceName.trim()

--- a/app/src/test/java/com/anytypeio/anytype/device/NotificationBuilderTest.kt
+++ b/app/src/test/java/com/anytypeio/anytype/device/NotificationBuilderTest.kt
@@ -511,4 +511,41 @@ class NotificationBuilderTest {
             title == chatNameTrimmed
         })
     }
+
+    @Test
+    fun `buildAndNotify should use Space name when chat name is blank`() = runBlocking {
+        // Given: A Data space with a chat that has a name with extra whitespace
+        val chatName = "   "
+        val spaceName = "My Workspace"
+
+        val spaceView = ObjectWrapper.SpaceView(
+            map = mapOf(
+                "id" to testSpaceId,
+                "name" to spaceName,
+                "spaceUxType" to SpaceUxType.DATA.code.toDouble()
+            )
+        )
+
+        val chatObject = ObjectWrapper.Basic(
+            map = mapOf(
+                "id" to testChatId,
+                "name" to chatName
+            )
+        )
+
+        whenever(spaceViewSubscriptionContainer.get(SpaceId(testSpaceId))).thenReturn(spaceView)
+        whenever(chatsDetailsSubscriptionContainer.get(testChatId)).thenReturn(chatObject)
+
+        val testMessage = message.copy(spaceName = spaceName)
+
+        // When
+        builder.buildAndNotify(testMessage, testSpaceId, testGroupId)
+
+        // Then: Notification should use space name when chat name is blank
+
+        verify(notificationManager).notify(eq(testGroupId), any(), argThat { notification ->
+            val title = notification.extras?.getCharSequence("android.title")?.toString()
+            title == spaceName
+        })
+    }
 }


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/open/blob/main/templates/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
