### PR TITLE
Notifications | Fix | Show "Space name - Chat name" format for Data space notifications 

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/device/NotificationBuilderImpl.kt
+++ b/app/src/main/java/com/anytypeio/anytype/device/NotificationBuilderImpl.kt
@@ -99,13 +99,17 @@ class NotificationBuilderImpl(
         }
 
         // Determine notification title:
-        // - For Data spaces: use the chat's name (each chat has its own name)
+        // - For Data spaces: use "Space name - Chat name" format
         // - For Chat spaces: use the space name (space and chat are the same)
         val notificationTitle = if (spaceView?.spaceUxType == SpaceUxType.DATA) {
-            chatsDetailsSubscriptionContainer.get(message.chatId)?.name
+            val chatName = chatsDetailsSubscriptionContainer.get(message.chatId)?.name
                 ?.trim()
                 ?.takeIf { it.isNotBlank() }
-                ?: message.spaceName.trim()  // Fallback to space name if chat name unavailable
+            if (chatName != null) {
+                "${message.spaceName.trim()} - $chatName"
+            } else {
+                message.spaceName.trim()  // Fallback to space name only if chat name unavailable
+            }
         } else {
             message.spaceName.trim()
         }

--- a/app/src/test/java/com/anytypeio/anytype/device/NotificationBuilderTest.kt
+++ b/app/src/test/java/com/anytypeio/anytype/device/NotificationBuilderTest.kt
@@ -330,10 +330,11 @@ class NotificationBuilderTest {
     }
 
     @Test
-    fun `buildAndNotify should use chat name for Data space notifications`() = runBlocking {
+    fun `buildAndNotify should use space name and chat name for Data space notifications`() = runBlocking {
         // Given: A Data space with a chat that has a specific name
         val chatName = "Team Discussion"
         val spaceName = "My Workspace"
+        val expectedTitle = "$spaceName - $chatName"
 
         val spaceView = ObjectWrapper.SpaceView(
             map = mapOf(
@@ -358,11 +359,11 @@ class NotificationBuilderTest {
         // When
         builder.buildAndNotify(testMessage, testSpaceId, testGroupId)
 
-        // Then: Notification should use chat name, not space name
+        // Then: Notification should use "Space name - Chat name" format
         verify(notificationManager).notify(eq(testGroupId), any(), argThat { notification ->
             // Extract title from notification extras
             val title = notification.extras?.getCharSequence("android.title")?.toString()
-            title == chatName
+            title == expectedTitle
         })
     }
 
@@ -481,6 +482,7 @@ class NotificationBuilderTest {
         val chatNameWithWhitespace = "  Team Discussion  "
         val chatNameTrimmed = "Team Discussion"
         val spaceName = "My Workspace"
+        val expectedTitle = "$spaceName - $chatNameTrimmed"
 
         val spaceView = ObjectWrapper.SpaceView(
             map = mapOf(
@@ -505,10 +507,10 @@ class NotificationBuilderTest {
         // When
         builder.buildAndNotify(testMessage, testSpaceId, testGroupId)
 
-        // Then: Notification should use trimmed chat name
+        // Then: Notification should use "Space name - trimmed chat name" format
         verify(notificationManager).notify(eq(testGroupId), any(), argThat { notification ->
             val title = notification.extras?.getCharSequence("android.title")?.toString()
-            title == chatNameTrimmed
+            title == expectedTitle
         })
     }
 


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/open/blob/main/templates/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
