### PR TITLE
DROID-4363 Pass createdInContext for file uploads and object creation

### DIFF
--- a/core-models/src/main/java/com/anytypeio/anytype/core_models/Command.kt
+++ b/core-models/src/main/java/com/anytypeio/anytype/core_models/Command.kt
@@ -39,7 +39,9 @@ sealed class Command {
         val space: SpaceId,
         val path: String,
         val type: Block.Content.File.Type?,
-        val preloadFileId: Id? = null
+        val preloadFileId: Id? = null,
+        val createdInContext: Id? = null,
+        val createdInContextRef: String? = null
     )
 
     class PreloadFile(

--- a/core-models/src/main/java/com/anytypeio/anytype/core_models/Relations.kt
+++ b/core-models/src/main/java/com/anytypeio/anytype/core_models/Relations.kt
@@ -132,6 +132,9 @@ object Relations {
 
     const val ORDER_ID = "orderId"
 
+    const val CREATED_IN_CONTEXT = "createdInContext"
+    const val CREATED_IN_CONTEXT_REF = "createdInContextRef"
+
     val systemRelationKeys = listOf(
         "id",
         "name",

--- a/data/src/main/java/com/anytypeio/anytype/data/auth/repo/block/BlockDataRepository.kt
+++ b/data/src/main/java/com/anytypeio/anytype/data/auth/repo/block/BlockDataRepository.kt
@@ -1203,8 +1203,8 @@ class BlockDataRepository(
 
     override suspend fun getLinkPreview(url: Url): LinkPreview = remote.getLinkPreview(url)
 
-    override suspend fun createObjectFromUrl(space: SpaceId, url: Url): ObjectWrapper.Basic = 
-        remote.createObjectFromUrl(space = space, url = url)
+    override suspend fun createObjectFromUrl(space: SpaceId, url: Url, createdInContext: Id?): ObjectWrapper.Basic =
+        remote.createObjectFromUrl(space = space, url = url, createdInContext = createdInContext)
 
     override suspend fun setSpaceNotificationMode(spaceViewId: Id, mode: NotificationState) {
         remote.setSpaceNotificationMode(spaceViewId = spaceViewId, mode = mode)

--- a/data/src/main/java/com/anytypeio/anytype/data/auth/repo/block/BlockRemote.kt
+++ b/data/src/main/java/com/anytypeio/anytype/data/auth/repo/block/BlockRemote.kt
@@ -507,7 +507,7 @@ interface BlockRemote {
 
     suspend fun getLinkPreview(url: Url): LinkPreview
 
-    suspend fun createObjectFromUrl(space: SpaceId, url: Url): ObjectWrapper.Basic
+    suspend fun createObjectFromUrl(space: SpaceId, url: Url, createdInContext: Id? = null): ObjectWrapper.Basic
 
     suspend fun setSpaceNotificationMode(spaceViewId: Id, mode: com.anytypeio.anytype.core_models.chats.NotificationState)
 

--- a/data/src/main/java/com/anytypeio/anytype/data/auth/repo/unsplash/UnsplashDataRepository.kt
+++ b/data/src/main/java/com/anytypeio/anytype/data/auth/repo/unsplash/UnsplashDataRepository.kt
@@ -16,5 +16,15 @@ class UnsplashDataRepository(
         query = query,
         limit = limit
     )
-    override fun download(id: Id, space: SpaceId) : Hash = remote.download(id = id, space = space)
+    override fun download(
+        id: Id,
+        space: SpaceId,
+        createdInContext: Id?,
+        createdInContextRef: String?
+    ) : Hash = remote.download(
+        id = id,
+        space = space,
+        createdInContext = createdInContext,
+        createdInContextRef = createdInContextRef
+    )
 }

--- a/data/src/main/java/com/anytypeio/anytype/data/auth/repo/unsplash/UnsplashRemote.kt
+++ b/data/src/main/java/com/anytypeio/anytype/data/auth/repo/unsplash/UnsplashRemote.kt
@@ -7,5 +7,5 @@ import com.anytypeio.anytype.core_models.primitives.SpaceId
 
 interface UnsplashRemote {
     fun search(query: String, limit: Int) : List<UnsplashImage>
-    fun download(space: SpaceId, id: Id) : Hash
+    fun download(space: SpaceId, id: Id, createdInContext: Id? = null, createdInContextRef: String? = null) : Hash
 }

--- a/domain/src/main/java/com/anytypeio/anytype/domain/block/repo/BlockRepository.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/block/repo/BlockRepository.kt
@@ -555,7 +555,7 @@ interface BlockRepository {
 
     suspend fun getLinkPreview(url: Url): LinkPreview
 
-    suspend fun createObjectFromUrl(space: SpaceId, url: Url): ObjectWrapper.Basic
+    suspend fun createObjectFromUrl(space: SpaceId, url: Url, createdInContext: Id? = null): ObjectWrapper.Basic
 
     suspend fun setSpaceNotificationMode(spaceViewId: Id, mode: NotificationState)
 

--- a/domain/src/main/java/com/anytypeio/anytype/domain/cover/SetDocCoverImage.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/cover/SetDocCoverImage.kt
@@ -4,6 +4,7 @@ import com.anytypeio.anytype.core_models.Block
 import com.anytypeio.anytype.core_models.Command
 import com.anytypeio.anytype.core_models.Hash
 import com.anytypeio.anytype.core_models.Payload
+import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.core_models.primitives.SpaceId
 import com.anytypeio.anytype.domain.base.BaseUseCase
 import com.anytypeio.anytype.domain.block.repo.BlockRepository
@@ -19,7 +20,9 @@ class SetDocCoverImage(
                     command = Command.UploadFile(
                         path = params.path,
                         type = Block.Content.File.Type.IMAGE,
-                        space = params.space
+                        space = params.space,
+                        createdInContext = params.context,
+                        createdInContextRef = Relations.COVER_ID
                     )
                 )
                 repo.setDocumentCoverImage(

--- a/domain/src/main/java/com/anytypeio/anytype/domain/icon/SetDocumentImageIcon.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/icon/SetDocumentImageIcon.kt
@@ -3,6 +3,7 @@ package com.anytypeio.anytype.domain.icon
 import com.anytypeio.anytype.core_models.Block
 import com.anytypeio.anytype.core_models.Command
 import com.anytypeio.anytype.core_models.Id
+import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.domain.block.repo.BlockRepository
 import javax.inject.Inject
 
@@ -15,7 +16,9 @@ class SetDocumentImageIcon @Inject constructor(
             command = Command.UploadFile(
                 path = params.path,
                 type = Block.Content.File.Type.IMAGE,
-                space = params.spaceId
+                space = params.spaceId,
+                createdInContext = params.target,
+                createdInContextRef = Relations.ICON_IMAGE
             )
         )
         val payload = repo.setDocumentImageIcon(

--- a/domain/src/main/java/com/anytypeio/anytype/domain/icon/SetTextBlockImage.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/icon/SetTextBlockImage.kt
@@ -2,6 +2,7 @@ package com.anytypeio.anytype.domain.icon
 
 import com.anytypeio.anytype.core_models.Block
 import com.anytypeio.anytype.core_models.Command
+import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.domain.block.repo.BlockRepository
 
 class SetTextBlockImage(
@@ -15,7 +16,9 @@ class SetTextBlockImage(
             command = Command.UploadFile(
                 path = params.path,
                 type = Block.Content.File.Type.IMAGE,
-                space = params.spaceId
+                space = params.spaceId,
+                createdInContext = params.target.context,
+                createdInContextRef = Relations.ICON_IMAGE
             )
         )
         val payload = repo.setTextIcon(

--- a/domain/src/main/java/com/anytypeio/anytype/domain/media/UploadFile.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/media/UploadFile.kt
@@ -20,7 +20,9 @@ class UploadFile @Inject constructor(
             path = params.path,
             type = params.type,
             space = params.space,
-            preloadFileId = params.preloadFileId
+            preloadFileId = params.preloadFileId,
+            createdInContext = params.createdInContext,
+            createdInContextRef = params.createdInContextRef
         )
     )
 
@@ -28,6 +30,8 @@ class UploadFile @Inject constructor(
         val path: String,
         val space: SpaceId,
         val type: Block.Content.File.Type = Block.Content.File.Type.FILE,
-        val preloadFileId: Id? = null
+        val preloadFileId: Id? = null,
+        val createdInContext: Id? = null,
+        val createdInContextRef: String? = null
     )
 }

--- a/domain/src/main/java/com/anytypeio/anytype/domain/objects/CreateObjectFromUrl.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/objects/CreateObjectFromUrl.kt
@@ -1,5 +1,6 @@
 package com.anytypeio.anytype.domain.objects
 
+import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.core_models.ObjectWrapper
 import com.anytypeio.anytype.core_models.Url
 import com.anytypeio.anytype.core_models.primitives.SpaceId
@@ -16,12 +17,14 @@ class CreateObjectFromUrl @Inject constructor(
     override suspend fun doWork(params: Params): ObjectWrapper.Basic {
         return repository.createObjectFromUrl(
             space = params.space,
-            url = params.url
+            url = params.url,
+            createdInContext = params.createdInContext
         )
     }
 
     data class Params(
         val space: SpaceId,
-        val url: Url
+        val url: Url,
+        val createdInContext: Id? = null
     )
 }

--- a/domain/src/main/java/com/anytypeio/anytype/domain/relations/AddFileToObject.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/relations/AddFileToObject.kt
@@ -18,7 +18,9 @@ class AddFileToObject(
             command = Command.UploadFile(
                 path = params.path,
                 type = null,
-                space = params.space
+                space = params.space,
+                createdInContext = params.ctx,
+                createdInContextRef = params.relation
             )
         )
         val obj = params.obj

--- a/domain/src/main/java/com/anytypeio/anytype/domain/unsplash/DownloadUnsplashImage.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/unsplash/DownloadUnsplashImage.kt
@@ -12,9 +12,16 @@ class DownloadUnsplashImage(
     override suspend fun run(params: Params) = safe {
         repo.download(
             id = params.picture,
-            space = params.space
+            space = params.space,
+            createdInContext = params.createdInContext,
+            createdInContextRef = params.createdInContextRef
         )
     }
 
-    class Params(val picture: Id, val space: SpaceId)
+    class Params(
+        val picture: Id,
+        val space: SpaceId,
+        val createdInContext: Id? = null,
+        val createdInContextRef: String? = null
+    )
 }

--- a/domain/src/main/java/com/anytypeio/anytype/domain/unsplash/UnsplashRepository.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/unsplash/UnsplashRepository.kt
@@ -7,5 +7,5 @@ import com.anytypeio.anytype.core_models.primitives.SpaceId
 
 interface UnsplashRepository {
     fun search(query: String, limit: Int) : List<UnsplashImage>
-    fun download(id: Id, space: SpaceId) : Hash
+    fun download(id: Id, space: SpaceId, createdInContext: Id? = null, createdInContextRef: String? = null) : Hash
 }

--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/presentation/ChatViewModel.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/presentation/ChatViewModel.kt
@@ -839,7 +839,8 @@ class ChatViewModel @Inject constructor(
                                         Block.Content.File.Type.VIDEO
                                     else
                                         Block.Content.File.Type.IMAGE,
-                                    preloadFileId = preloadedFileId
+                                    preloadFileId = preloadedFileId,
+                                    createdInContext = vmParams.ctx
                                 )
                             ).onSuccess { file ->
                                 if (wasCopiedToCache) {
@@ -894,7 +895,8 @@ class ChatViewModel @Inject constructor(
                             createObjectFromUrl.async(
                                 params = CreateObjectFromUrl.Params(
                                     url = attachment.preview.url,
-                                    space = vmParams.space
+                                    space = vmParams.space,
+                                    createdInContext = vmParams.ctx
                                 )
                             ).onSuccess { obj ->
                                 if (obj.isValid) {
@@ -945,7 +947,8 @@ class ChatViewModel @Inject constructor(
                                     space = vmParams.space,
                                     path = path,
                                     type = Block.Content.File.Type.NONE,
-                                    preloadFileId = preloadedFileId
+                                    preloadFileId = preloadedFileId,
+                                    createdInContext = vmParams.ctx
                                 )
                             ).onSuccess { file ->
                                 copyFileToCacheDirectory.delete(path)
@@ -1866,7 +1869,9 @@ class ChatViewModel @Inject constructor(
                         UploadFile.Params(
                             path = icon.uri,
                             space = vmParams.space,
-                            type = Block.Content.File.Type.IMAGE
+                            type = Block.Content.File.Type.IMAGE,
+                            createdInContext = vmParams.ctx,
+                            createdInContextRef = Relations.ICON_IMAGE
                         )
                     ).onSuccess { file ->
                         setObjectDetails.async(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-middlewareVersion = "v0.47.2"
+middlewareVersion = "dee854f95c935867b19b843d30d02871c98cabb6"
 kotlinVersion = "2.2.10"
 kspVersion = "2.3.4"
 

--- a/libs/build.gradle
+++ b/libs/build.gradle
@@ -8,7 +8,7 @@ publishing {
             artifact(file('lib.aar'))
             groupId = 'io.anyproto'
             artifactId = 'anytype-heart-android'
-            version = '0.99'
+            version = 'dee854f95c935867b19b843d30d02871c98cabb6'
         }
     }
 }

--- a/middleware/src/main/java/com/anytypeio/anytype/middleware/UnsplashMiddleware.kt
+++ b/middleware/src/main/java/com/anytypeio/anytype/middleware/UnsplashMiddleware.kt
@@ -26,8 +26,18 @@ class UnsplashMiddleware @Inject constructor(
         return response.pictures.map { p -> p.core() }
     }
 
-    override fun download(space: SpaceId, id: Id): Hash {
-        val request = Download.Request(pictureId = id, spaceId = space.id).also {
+    override fun download(
+        space: SpaceId,
+        id: Id,
+        createdInContext: Id?,
+        createdInContextRef: String?
+    ): Hash {
+        val request = Download.Request(
+            pictureId = id,
+            spaceId = space.id,
+            createdInContext = createdInContext.orEmpty(),
+            createdInContextRef = createdInContextRef.orEmpty()
+        ).also {
             logger.logRequest(it)
         }
         val response = service.unsplashDownload(request = request).also { logger.logResponse(it) }

--- a/middleware/src/main/java/com/anytypeio/anytype/middleware/block/BlockMiddleware.kt
+++ b/middleware/src/main/java/com/anytypeio/anytype/middleware/block/BlockMiddleware.kt
@@ -1180,8 +1180,8 @@ class BlockMiddleware(
         return middleware.getLinkPreview(url)
     }
 
-    override suspend fun createObjectFromUrl(space: SpaceId, url: Url): ObjectWrapper.Basic {
-        return middleware.createObjectFromUrl(space = space, url = url)
+    override suspend fun createObjectFromUrl(space: SpaceId, url: Url, createdInContext: Id?): ObjectWrapper.Basic {
+        return middleware.createObjectFromUrl(space = space, url = url, createdInContext = createdInContext)
     }
 
     override suspend fun setSpaceNotificationMode(spaceViewId: Id, mode: com.anytypeio.anytype.core_models.chats.NotificationState) {

--- a/middleware/src/main/java/com/anytypeio/anytype/middleware/interactor/Middleware.kt
+++ b/middleware/src/main/java/com/anytypeio/anytype/middleware/interactor/Middleware.kt
@@ -835,7 +835,9 @@ class Middleware @Inject constructor(
             type = command.type.toMiddlewareModel(),
             spaceId = command.space.id,
             preloadFileId = command.preloadFileId.orEmpty(),
-            preloadOnly = false
+            preloadOnly = false,
+            createdInContext = command.createdInContext.orEmpty(),
+            createdInContextRef = command.createdInContextRef.orEmpty()
         )
         logRequestIfDebug(request)
         val (response, time) = measureTimedValue { service.fileUpload(request) }
@@ -3210,11 +3212,17 @@ class Middleware @Inject constructor(
     }
 
     @Throws(Exception::class)
-    fun createObjectFromUrl(space: SpaceId, url: Url) : ObjectWrapper.Basic {
+    fun createObjectFromUrl(space: SpaceId, url: Url, createdInContext: Id? = null) : ObjectWrapper.Basic {
+        val details: Map<String, Any?> = if (createdInContext != null) {
+            mapOf(Relations.CREATED_IN_CONTEXT to createdInContext)
+        } else {
+            emptyMap()
+        }
         val request = Rpc.Object.CreateFromUrl.Request(
             url = url,
             spaceId = space.id,
-            objectTypeUniqueKey = ObjectTypeUniqueKeys.BOOKMARK
+            objectTypeUniqueKey = ObjectTypeUniqueKeys.BOOKMARK,
+            details = details
         )
         logRequestIfDebug(request)
         val (response, time) = measureTimedValue { service.objectCreateFromUrl(request) }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
@@ -549,7 +549,9 @@ class EditorViewModel(
         downloadUnsplashImage(
             DownloadUnsplashImage.Params(
                 picture = action.img,
-                space = vmParams.space
+                space = vmParams.space,
+                createdInContext = vmParams.ctx,
+                createdInContextRef = Relations.COVER_ID
             )
         ).process(
             failure = {

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
@@ -547,7 +547,9 @@ class ObjectSetViewModel(
         downloadUnsplashImage(
             DownloadUnsplashImage.Params(
                 picture = action.img,
-                space = vmParams.space
+                space = vmParams.space,
+                createdInContext = vmParams.ctx,
+                createdInContextRef = Relations.COVER_ID
             )
         ).process(
             failure = {
@@ -1633,7 +1635,7 @@ class ObjectSetViewModel(
         val prefilled = viewer.prefillNewObjectDetails(
             storeOfRelations = storeOfRelations,
             dateProvider = dateProvider
-        )
+        ) + mapOf(Relations.CREATED_IN_CONTEXT to vmParams.ctx)
         val type = typeChosenByUser ?: defaultObjectTypeUniqueKey!!
         val createObjectParams = CreateDataViewObject.Params.Collection(
             template = validTemplateId,

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sharing/SharingViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sharing/SharingViewModel.kt
@@ -1033,7 +1033,8 @@ class SharingViewModel(
                 uploadMediaFile(
                     uri = content.uri,
                     type = content.type,
-                    spaceId = spaceId
+                    spaceId = spaceId,
+                    createdInContext = chatId
                 ) { fileId ->
                     val attachment = createMediaAttachment(fileId, content.type)
                     sendChatMessage(chatId, commentText, listOf(attachment))
@@ -1046,7 +1047,7 @@ class SharingViewModel(
                 batches.forEachIndexed { index, batch ->
                     val attachments = mutableListOf<Chat.Message.Attachment>()
                     batch.forEach { uri ->
-                        uploadMediaFile(uri, content.type, spaceId) { fileId ->
+                        uploadMediaFile(uri, content.type, spaceId, createdInContext = chatId) { fileId ->
                             attachments.add(createMediaAttachment(fileId, content.type))
                         }
                     }
@@ -1088,7 +1089,8 @@ class SharingViewModel(
     private suspend fun createBookmarkForChat(url: String, spaceId: SpaceId, chatId: String) {
         val params = CreateObjectFromUrl.Params(
             url = url,
-            space = spaceId
+            space = spaceId,
+            createdInContext = chatId
         )
         return createObjectFromUrl.async(params).fold(
             onSuccess = { obj ->
@@ -1115,6 +1117,7 @@ class SharingViewModel(
         uri: String,
         type: SharedContent.MediaType,
         spaceId: SpaceId,
+        createdInContext: Id? = null,
         onSuccess: suspend (Id) -> Unit
     ) {
         val path = try {
@@ -1141,7 +1144,8 @@ class SharingViewModel(
             UploadFile.Params(
                 space = spaceId,
                 path = path,
-                type = fileType
+                type = fileType,
+                createdInContext = createdInContext
             )
         ).fold(
             onSuccess = { file -> onSuccess(file.id) },

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/spaces/CreateSpaceViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/spaces/CreateSpaceViewModel.kt
@@ -194,7 +194,9 @@ class CreateSpaceViewModel(
             UploadFile.Params(
                 path = url,
                 space = Space(spaceId),
-                type = Block.Content.File.Type.IMAGE
+                type = Block.Content.File.Type.IMAGE,
+                createdInContext = spaceId,
+                createdInContextRef = Relations.ICON_IMAGE
             )
         ).fold(
             onSuccess = { file ->

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/spaces/SpaceSettingsViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/spaces/SpaceSettingsViewModel.kt
@@ -877,7 +877,9 @@ class SpaceSettingsViewModel(
                 params = UploadFile.Params(
                     path = path,
                     space = vmParams.space,
-                    type = Block.Content.File.Type.IMAGE
+                    type = Block.Content.File.Type.IMAGE,
+                    createdInContext = vmParams.space.id,
+                    createdInContextRef = Relations.ICON_IMAGE
                 )
             ).fold(
                 onSuccess = { file ->

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/widgets/CreateChatObjectViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/widgets/CreateChatObjectViewModel.kt
@@ -105,7 +105,9 @@ class CreateChatObjectViewModel(
             UploadFile.Params(
                 path = url,
                 space = Space(vmParams.space.id),
-                type = Block.Content.File.Type.IMAGE
+                type = Block.Content.File.Type.IMAGE,
+                createdInContext = objectId,
+                createdInContextRef = Relations.ICON_IMAGE
             )
         ).fold(
             onSuccess = { file ->

--- a/protocol/src/main/proto/changes.proto
+++ b/protocol/src/main/proto/changes.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 package anytype;
 option go_package = "pb";
 
-import "models.proto";
-import "events.proto";
+import "pkg/lib/pb/model/protos/models.proto";
+import "pb/protos/events.proto";
 import "google/protobuf/struct.proto";
 
 // the element of change tree used to store and internal apply smartBlock history

--- a/protocol/src/main/proto/commands.proto
+++ b/protocol/src/main/proto/commands.proto
@@ -2,10 +2,10 @@ syntax = "proto3";
 package anytype;
 option go_package = "pb";
 
-import "models.proto";
-import "localstore.proto";
+import "pkg/lib/pb/model/protos/models.proto";
+import "pkg/lib/pb/model/protos/localstore.proto";
 
-import "events.proto";
+import "pb/protos/events.proto";
 import "google/protobuf/struct.proto";
 
 
@@ -550,6 +550,25 @@ message Rpc {
                 }
             }
         }
+
+        message DeleteCorruptedBackup {
+            message Request {
+                string backupPath = 1;
+            }
+            message Response {
+                Error error = 1;
+                message Error {
+                    Code code = 1;
+                    string description = 2;
+                    enum Code {
+                        NULL = 0;
+                        UNKNOWN_ERROR = 1;
+                        BAD_INPUT = 2;
+                    }
+                }
+            }
+        }
+
         message SetOrder {
             message Request {
                 string spaceViewId = 1;
@@ -588,6 +607,33 @@ message Rpc {
                         NULL = 0;
                         UNKNOWN_ERROR = 1;
                         BAD_INPUT = 2;
+                    }
+                }
+            }
+        }
+        message ChangeOwnership {
+            message Request {
+                string spaceId = 1;
+                string newOwnerIdentity = 2;
+                model.ParticipantPermissions oldOwnerPermissions = 3;
+            }
+            message Response {
+                Error error = 1;
+
+                message Error {
+                    Code code = 1;
+                    string description = 2;
+
+                    enum Code {
+                        NULL = 0;
+                        UNKNOWN_ERROR = 1;
+                        BAD_INPUT = 2;
+
+                        NO_SUCH_SPACE = 101;
+                        SPACE_IS_DELETED = 102;
+                        REQUEST_FAILED = 103;
+                        PARTICIPANT_NOT_FOUND = 105;
+                        INCORRECT_PERMISSIONS = 106;
                     }
                 }
             }
@@ -1410,6 +1456,7 @@ message Rpc {
             message Response {
                 Error error = 1;
                 model.Account.Info info = 2;
+                repeated string corruptedBackupPaths = 3; // backup paths for corrupted space storage
                 message Error {
                     Code code = 1;
                     string description = 2;
@@ -3962,6 +4009,8 @@ message Rpc {
                 anytype.model.ImageKind imageKind = 9;
                 bool preloadOnly = 10; // if true, only async preload the file without creating object
                 string preloadFileId = 11; // if set, reuse already preloaded file with this id. May block if async preload operation is not finished yet
+                string createdInContext = 12; // Object ID where the file was initially created
+                string createdInContextRef = 13; // Block ID where the file was initially created
             }
 
             message Response {
@@ -4028,6 +4077,7 @@ message Rpc {
                 string contextId = 1;
                 string dropTargetId = 2; // id of the simple block to insert considering position
                 anytype.model.Block.Position position = 3;  // position relatively to the dropTargetId simple block
+                anytype.model.Block.Content.File.Style style = 5;
                 repeated string localFilePaths = 4;
             }
             message Response {
@@ -4377,6 +4427,8 @@ message Rpc {
                 string pictureId = 1;
                 string spaceId = 2;
                 anytype.model.ImageKind imageKind = 3;
+                string createdInContext = 4; // Object ID where the file was initially created
+                string createdInContextRef = 5; // Block ID where the file was initially created
             }
 
             message Response {
@@ -8406,6 +8458,34 @@ message Rpc {
                 }
             }
         }
+
+        message SubscribeToUpdates {
+            message Request {
+                string email = 1;
+                anytype.model.MembershipV2.Platform platform = 2;
+                // if false - unsubscribe
+                bool subscribe = 3;
+                // additional data
+                string context = 4;
+            }
+
+            message Response {
+                Error error = 1;
+
+                message Error {
+                    Code code = 1;
+                    string description = 2;
+
+                    enum Code {
+                        NULL = 0;
+                        UNKNOWN_ERROR = 1;
+                        BAD_INPUT = 2; 
+                        CAN_NOT_CONNECT = 3;
+                        PLATFORM_NOT_SUPPORTED = 4;        
+                    }
+                }
+            }
+        }
     }
 
     message NameService {
@@ -8966,6 +9046,31 @@ message Rpc {
                         UNKNOWN_ERROR = 1;
                         BAD_INPUT = 2;
                         // ...
+                    }
+                }
+            }
+        }
+
+        message Search {
+            message Request {
+                string spaceId = 1;
+                string chatId = 2;
+                repeated anytype.model.Search.Message.Sort sorts = 3;
+                string fullText = 4;
+                int32 offset = 5;
+                int32 limit = 6;
+            }
+
+            message Response {
+                Error error = 1;
+                repeated model.Search.Message.Result results = 2;
+                message Error {
+                    Code code = 1;
+                    string description = 2;
+                    enum Code {
+                        NULL = 0;
+                        UNKNOWN_ERROR = 1;
+                        BAD_INPUT = 2;
                     }
                 }
             }

--- a/protocol/src/main/proto/events.proto
+++ b/protocol/src/main/proto/events.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package anytype;
 option go_package = "pb";
 
-import "models.proto";
+import "pkg/lib/pb/model/protos/models.proto";
 import "google/protobuf/struct.proto";
 
 /*
@@ -717,6 +717,7 @@ message Event {
               15; // Default object type that is chosen for new object created
                   // within the view
           bool wrapContent = 17; // Wrap content in view
+          anytype.model.Block.Content.Dataview.View.ListSize listSize = 18; // List view size setting
         }
 
         message Filter {

--- a/protocol/src/main/proto/localstore.proto
+++ b/protocol/src/main/proto/localstore.proto
@@ -3,7 +3,7 @@ package anytype.model;
 option go_package = "pkg/lib/pb/model";
 
 import "google/protobuf/struct.proto";
-import "models.proto";
+import "pkg/lib/pb/model/protos/models.proto";
 
 message ObjectInfo {
     string id = 1;
@@ -66,4 +66,6 @@ message ObjectStoreChecksums {
     int32 reindexDeletedObjects = 16;
     int32 reindexParticipants = 17;
     int32 reindexChats = 18;
+    int32 reindexFulltextChatMessages = 19;
+    int32 invalidateObjectsIndex = 20;
 }

--- a/protocol/src/main/proto/models.proto
+++ b/protocol/src/main/proto/models.proto
@@ -70,6 +70,35 @@ message Search {
         string relationKey = 4; // relation key of the block where the highlight has been found
         google.protobuf.Struct relationDetails = 5; // contains details for dependent object. E.g. relation option or type. todo: rename to dependantDetails
     }
+
+    message Message {
+        message Sort {
+            Key key = 1;
+            Type type = 2;
+
+            enum Key {
+                ORDER_ID = 0;
+                SCORE = 1;
+                CREATED_AT = 2;
+                MODIFIED_AT = 3;
+            }
+
+            enum Type {
+                Asc = 0;
+                Desc = 1;
+            }
+        }
+
+        message Result {
+            string chatId = 1;
+            string messageId = 2;
+            int64 score = 3;
+            string highlight = 4; // truncated text with highlights
+            repeated Range highlightRanges = 5; // ranges of the highlight in the text (using utf-16 runes)
+            ChatMessage message = 6;
+        }
+    }
+
 }
 
 message Block {
@@ -365,6 +394,7 @@ message Block {
                 string defaultObjectTypeId = 15; // Default object type that is chosen for new object created within the view
                 string endRelationKey = 16; // Group view by this relationKey
                 bool wrapContent = 17; // Wrap content in view
+                ListSize listSize = 18; // List view size setting
 
                 enum Type {
                     Table = 0;
@@ -379,6 +409,11 @@ message Block {
                     Small = 0;
                     Medium = 1;
                     Large = 2;
+                }
+
+                enum ListSize {
+                    Compact = 0;  // Single-line display (default)
+                    Regular = 1;  // Two-line display with description
                 }
             }
 
@@ -1423,6 +1458,14 @@ message MembershipV2 {
         int64 amountCents = 2;
     }
 
+    enum Platform {
+        Unknown = 0;
+        Desktop = 1;
+        MobileIOS = 2;
+        MobileAndroid = 3;
+        Web = 4;
+    }
+
     enum PaymentProvider {
         None = 0;
         Stripe = 1;
@@ -1628,4 +1671,9 @@ enum SyncError {
     SyncErrorIncompatibleVersion = 2;
     SyncErrorNetworkError        = 3;
     SyncErrorOversized           = 4;
+}
+
+enum TemplateNamePrefillType {
+    Empty = 0;
+    FromTemplateName = 1;
 }

--- a/protocol/src/main/proto/snapshot.proto
+++ b/protocol/src/main/proto/snapshot.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+package anytype;
+option go_package = "pb";
+
+import "pkg/lib/pb/model/protos/models.proto";
+import "pb/protos/changes.proto";
+
+message SnapshotWithType {
+  anytype.model.SmartBlockType sbType = 1;
+  anytype.Change.Snapshot snapshot = 2;
+}
+
+message Profile {
+  string name = 1;
+  string avatar = 2;
+  string address = 4;
+  string spaceDashboardId = 5;
+  string profileId = 6;
+  string analyticsId = 7;
+  string startingPage = 8; // deprecated
+  repeated WidgetBlock widgets = 9;
+}
+
+message WidgetBlock {
+  model.Block.Content.Widget.Layout layout = 1;
+  string targetObjectId = 2;
+  int32 objectLimit = 3;
+}


### PR DESCRIPTION
## Summary
- Pass `createdInContext` (parent object ID) and `createdInContextRef` (block ID / relation key) when uploading files, downloading Unsplash images, and creating objects from URL
- Enables middleware garbage collection of orphaned files by tracking where files were originally created
- Threaded through all layers: core-models → domain → data → middleware → presentation

## Where context is set
- **Chat**: uploads, bookmark creation, icon upload → `chatId`
- **Editor/Set**: Unsplash cover → `ctx` + `coverId`
- **Document icon**: upload → `target` + `iconImage`
- **Text block icon**: upload → `context` + `iconImage`
- **File relation**: upload → `ctx` + relation key
- **Cover from path**: upload → `context` + `coverId`
- **Space icon**: upload → `spaceId` + `iconImage`
- **Collection new object**: prefilled details → `ctx`
- **Share to chat**: media upload + bookmark → `chatId`

## Where context is NOT set
- Set/Query dataview objects (Sets don't own results)
- Standalone object creation (sharing to objects/pages)
- `BlockLink.CreateWithObject` (middleware handles internally)
- `filePreload` (context set on final upload)

## Test plan
- [ ] Upload image/file in chat → verify `createdInContext` = chat ID
- [ ] Set cover from device/Unsplash → verify context = page ID, ref = coverId
- [ ] Set icon from device → verify context = object ID, ref = iconImage
- [ ] Create object in collection → verify details include createdInContext
- [ ] Create object in Set → verify NO createdInContext
- [ ] Share media to chat → verify createdInContext = chat ID
- [ ] Share media to object → verify NO createdInContext