### PR TITLE
Migrate legacy create-object flow to feature-create-object module

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -132,6 +132,7 @@ android {
             shrinkResources true
             debuggable false
             buildConfigField "boolean", "SHOW_CHATS", "true"
+            buildConfigField "boolean", "USE_NEW_CREATE_OBJECT", "false"
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             buildConfigField("String", "AMPLITUDE_KEY", apikeyProperties['amplitude.release'])
             if (useReleaseKeystore) {
@@ -145,6 +146,7 @@ android {
             applicationIdSuffix ".dev"
             debuggable true
             buildConfigField "boolean", "SHOW_CHATS", "true"
+            buildConfigField "boolean", "USE_NEW_CREATE_OBJECT", "false"
             buildConfigField("String", "AMPLITUDE_KEY", apikeyProperties['amplitude.debug'])
             //signingConfig signingConfigs.debug
             firebaseAppDistribution {

--- a/app/src/main/java/com/anytypeio/anytype/di/feature/CreateObjectFeatureDI.kt
+++ b/app/src/main/java/com/anytypeio/anytype/di/feature/CreateObjectFeatureDI.kt
@@ -3,14 +3,20 @@ package com.anytypeio.anytype.di.feature
 import androidx.lifecycle.ViewModelProvider
 import com.anytypeio.anytype.core_utils.di.scope.PerScreen
 import com.anytypeio.anytype.di.common.ComponentDependencies
+import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
+import com.anytypeio.anytype.domain.block.repo.BlockRepository
+import com.anytypeio.anytype.domain.debugging.Logger
 import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
 import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
+import com.anytypeio.anytype.domain.page.CreateObjectByTypeAndTemplate
 import com.anytypeio.anytype.feature_create_object.presentation.CreateObjectViewModelFactory
 import com.anytypeio.anytype.feature_create_object.presentation.NewCreateObjectViewModel
+import com.anytypeio.anytype.ui.create.CreateObjectDialogFragment
 import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
+import dagger.Provides
 
 @Component(
     dependencies = [CreateObjectFeatureDependencies::class],
@@ -29,12 +35,25 @@ interface CreateObjectFeatureComponent {
         ): CreateObjectFeatureComponent
     }
 
-    // Inject method for future Fragment (when UI is wired up)
-    // fun inject(fragment: CreateObjectFragment)
+    fun inject(fragment: CreateObjectDialogFragment)
 }
 
 @Module
 object CreateObjectFeatureModule {
+
+    @JvmStatic
+    @Provides
+    @PerScreen
+    fun provideCreateObjectByTypeAndTemplate(
+        repo: BlockRepository,
+        logger: Logger,
+        dispatchers: AppCoroutineDispatchers
+    ): CreateObjectByTypeAndTemplate = CreateObjectByTypeAndTemplate(
+        repo = repo,
+        logger = logger,
+        dispatchers = dispatchers
+    )
+
     @Module
     interface Declarations {
         @PerScreen
@@ -48,4 +67,7 @@ object CreateObjectFeatureModule {
 interface CreateObjectFeatureDependencies : ComponentDependencies {
     fun storeOfObjectTypes(): StoreOfObjectTypes
     fun spaceViewSubscriptionContainer(): SpaceViewSubscriptionContainer
+    fun blockRepository(): BlockRepository
+    fun logger(): Logger
+    fun dispatchers(): AppCoroutineDispatchers
 }

--- a/app/src/main/java/com/anytypeio/anytype/ui/allcontent/AllContentFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/allcontent/AllContentFragment.kt
@@ -15,6 +15,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.fragment.findNavController
+import com.anytypeio.anytype.BuildConfig
 import com.anytypeio.anytype.R
 import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.core_models.ObjectWrapper
@@ -35,7 +36,11 @@ import com.anytypeio.anytype.presentation.widgets.collection.Subscription
 import com.anytypeio.anytype.ui.base.navigation
 import com.anytypeio.anytype.ui.home.WidgetsScreenFragment
 import com.anytypeio.anytype.ui.multiplayer.ShareSpaceFragment
+import com.anytypeio.anytype.ui.chats.ChatFragment
+import com.anytypeio.anytype.ui.create.CreateObjectDialogFragment
+import com.anytypeio.anytype.ui.editor.EditorFragment
 import com.anytypeio.anytype.ui.objects.creation.ObjectTypeSelectionFragment
+import com.anytypeio.anytype.ui.sets.ObjectSetFragment
 import com.anytypeio.anytype.ui.objects.types.pickers.ObjectTypeSelectionListener
 import com.anytypeio.anytype.ui.profile.ParticipantFragment
 import com.anytypeio.anytype.ui.search.GlobalSearchFragment
@@ -66,6 +71,28 @@ class AllContentFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        childFragmentManager.setFragmentResultListener(
+            CreateObjectDialogFragment.RESULT_KEY_NAVIGATION,
+            viewLifecycleOwner
+        ) { _, bundle ->
+            val navType = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_TYPE)
+            val id = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_ID) ?: return@setFragmentResultListener
+            val spaceStr = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_SPACE) ?: return@setFragmentResultListener
+            when (navType) {
+                "OpenEditor" -> findNavController().navigate(
+                    R.id.objectNavigation,
+                    EditorFragment.args(ctx = id, space = spaceStr)
+                )
+                "OpenSet" -> findNavController().navigate(
+                    R.id.dataViewNavigation,
+                    ObjectSetFragment.args(ctx = id, space = spaceStr)
+                )
+                "OpenChat" -> findNavController().navigate(
+                    R.id.chatScreen,
+                    ChatFragment.args(ctx = id, space = spaceStr)
+                )
+            }
+        }
         subscribe(vm.commands) { command ->
             when (command) {
                 is AllContentViewModel.Command.ExitToSpaceHome -> {
@@ -250,8 +277,13 @@ class AllContentFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
                     onGlobalSearchClicked = vm::onGlobalSearchClicked,
                     onAddDocClicked = vm::onAddDockClicked,
                     onCreateObjectLongClicked = {
-                        val dialog = ObjectTypeSelectionFragment.new(space = space)
-                        dialog.show(childFragmentManager, null)
+                        if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+                            val dialog = CreateObjectDialogFragment.new(space = space)
+                            dialog.show(childFragmentManager, CreateObjectDialogFragment.TAG)
+                        } else {
+                            val dialog = ObjectTypeSelectionFragment.new(space = space)
+                            dialog.show(childFragmentManager, null)
+                        }
                     },
                     onBackClicked = vm::onBackClicked,
                     moveToBin = vm::proceedWithMoveToBin,

--- a/app/src/main/java/com/anytypeio/anytype/ui/create/CreateObjectDialogFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/create/CreateObjectDialogFragment.kt
@@ -1,0 +1,121 @@
+package com.anytypeio.anytype.ui.create
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.os.bundleOf
+import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.anytypeio.anytype.core_models.Id
+import com.anytypeio.anytype.core_models.primitives.SpaceId
+import com.anytypeio.anytype.core_models.primitives.TypeKey
+import com.anytypeio.anytype.core_utils.ext.subscribe
+import com.anytypeio.anytype.core_utils.ui.BaseBottomSheetComposeFragment
+import com.anytypeio.anytype.di.common.componentManager
+import com.anytypeio.anytype.feature_create_object.presentation.CreateObjectAction
+import com.anytypeio.anytype.feature_create_object.presentation.CreateObjectNavigation
+import com.anytypeio.anytype.feature_create_object.presentation.NewCreateObjectViewModel
+import com.anytypeio.anytype.feature_create_object.ui.CreateObjectContent
+import javax.inject.Inject
+
+class CreateObjectDialogFragment : BaseBottomSheetComposeFragment() {
+
+    @Inject
+    lateinit var factory: ViewModelProvider.Factory
+    private val vm by viewModels<NewCreateObjectViewModel> { factory }
+
+    private val space: String get() = requireArguments().getString(ARG_SPACE, "")
+    private val typeKey: String? get() = requireArguments().getString(ARG_TYPE_KEY)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ) = ComposeView(requireContext()).apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent {
+            val state by vm.state.collectAsStateWithLifecycle()
+            CreateObjectContent(
+                state = state,
+                onAction = { action ->
+                    when (action) {
+                        is CreateObjectAction.SelectPhotos,
+                        is CreateObjectAction.TakePhoto,
+                        is CreateObjectAction.SelectFiles,
+                        is CreateObjectAction.AttachExistingObject -> {
+                            setFragmentResult(
+                                RESULT_KEY_ACTION,
+                                bundleOf(RESULT_ACTION_TYPE to action::class.java.simpleName)
+                            )
+                            dismiss()
+                        }
+                        else -> vm.onAction(action)
+                    }
+                }
+            )
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        jobs += lifecycleScope.subscribe(vm.navigation) { nav ->
+            setFragmentResult(
+                RESULT_KEY_NAVIGATION,
+                bundleOf(
+                    RESULT_NAV_TYPE to nav::class.java.simpleName,
+                    RESULT_NAV_ID to when (nav) {
+                        is CreateObjectNavigation.OpenEditor -> nav.id
+                        is CreateObjectNavigation.OpenSet -> nav.id
+                        is CreateObjectNavigation.OpenChat -> nav.id
+                    },
+                    RESULT_NAV_SPACE to when (nav) {
+                        is CreateObjectNavigation.OpenEditor -> nav.space.id
+                        is CreateObjectNavigation.OpenSet -> nav.space.id
+                        is CreateObjectNavigation.OpenChat -> nav.space.id
+                    }
+                )
+            )
+            dismiss()
+        }
+    }
+
+    override fun injectDependencies() {
+        val typeKeyParam = typeKey?.let { TypeKey(it) }
+        componentManager().createObjectFeatureComponent.get(
+            NewCreateObjectViewModel.VmParams(
+                spaceId = SpaceId(space),
+                typeKey = typeKeyParam
+            )
+        ).inject(this)
+    }
+
+    override fun releaseDependencies() {
+        componentManager().createObjectFeatureComponent.release()
+    }
+
+    companion object {
+        const val TAG = "CreateObjectDialogFragment"
+        private const val ARG_SPACE = "arg.create-object.space"
+        private const val ARG_TYPE_KEY = "arg.create-object.type-key"
+
+        const val RESULT_KEY_NAVIGATION = "result.create-object.navigation"
+        const val RESULT_KEY_ACTION = "result.create-object.action"
+        const val RESULT_NAV_TYPE = "result.nav.type"
+        const val RESULT_NAV_ID = "result.nav.id"
+        const val RESULT_NAV_SPACE = "result.nav.space"
+        const val RESULT_ACTION_TYPE = "result.action.type"
+
+        fun new(space: Id, typeKey: String? = null) = CreateObjectDialogFragment().apply {
+            arguments = bundleOf(
+                ARG_SPACE to space,
+                ARG_TYPE_KEY to typeKey
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/anytypeio/anytype/ui/date/DateObjectFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/date/DateObjectFragment.kt
@@ -20,6 +20,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
+import com.anytypeio.anytype.BuildConfig
 import com.anytypeio.anytype.R
 import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.core_models.ObjectWrapper
@@ -38,7 +39,11 @@ import com.anytypeio.anytype.feature_date.ui.DateMainScreen
 import com.anytypeio.anytype.feature_date.viewmodel.DateObjectCommand
 import com.anytypeio.anytype.feature_date.viewmodel.DateObjectVmParams
 import com.anytypeio.anytype.ui.base.navigation
+import com.anytypeio.anytype.ui.chats.ChatFragment
+import com.anytypeio.anytype.ui.create.CreateObjectDialogFragment
+import com.anytypeio.anytype.ui.editor.EditorFragment
 import com.anytypeio.anytype.ui.objects.creation.ObjectTypeSelectionFragment
+import com.anytypeio.anytype.ui.sets.ObjectSetFragment
 import com.anytypeio.anytype.ui.objects.types.pickers.ObjectTypeSelectionListener
 import com.anytypeio.anytype.ui.profile.ParticipantFragment
 import com.anytypeio.anytype.ui.search.GlobalSearchFragment
@@ -70,6 +75,28 @@ class DateObjectFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        childFragmentManager.setFragmentResultListener(
+            CreateObjectDialogFragment.RESULT_KEY_NAVIGATION,
+            viewLifecycleOwner
+        ) { _, bundle ->
+            val navType = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_TYPE)
+            val id = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_ID) ?: return@setFragmentResultListener
+            val spaceStr = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_SPACE) ?: return@setFragmentResultListener
+            when (navType) {
+                "OpenEditor" -> findNavController().navigate(
+                    R.id.objectNavigation,
+                    EditorFragment.args(ctx = id, space = spaceStr)
+                )
+                "OpenSet" -> findNavController().navigate(
+                    R.id.dataViewNavigation,
+                    ObjectSetFragment.args(ctx = id, space = spaceStr)
+                )
+                "OpenChat" -> findNavController().navigate(
+                    R.id.chatScreen,
+                    ChatFragment.args(ctx = id, space = spaceStr)
+                )
+            }
+        }
         subscribe(vm.effects) { effect ->
             Timber.d("Received date effect: $effect")
             when (effect) {
@@ -175,8 +202,13 @@ class DateObjectFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
                     toast(effect.message)
                 }
                 DateObjectCommand.TypeSelectionScreen -> {
-                    val dialog = ObjectTypeSelectionFragment.new(space = space)
-                    dialog.show(childFragmentManager, null)
+                    if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+                        val dialog = CreateObjectDialogFragment.new(space = space)
+                        dialog.show(childFragmentManager, CreateObjectDialogFragment.TAG)
+                    } else {
+                        val dialog = ObjectTypeSelectionFragment.new(space = space)
+                        dialog.show(childFragmentManager, null)
+                    }
                 }
                 is DateObjectCommand.NavigateToParticipant -> {
                     runCatching {

--- a/app/src/main/java/com/anytypeio/anytype/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/editor/EditorFragment.kt
@@ -169,7 +169,11 @@ import com.anytypeio.anytype.ui.moving.MoveToFragment
 import com.anytypeio.anytype.ui.moving.OnMoveToAction
 import com.anytypeio.anytype.ui.multiplayer.ShareSpaceFragment
 import com.anytypeio.anytype.ui.objects.appearance.ObjectAppearanceSettingFragment
+import com.anytypeio.anytype.BuildConfig
+import com.anytypeio.anytype.ui.chats.ChatFragment
+import com.anytypeio.anytype.ui.create.CreateObjectDialogFragment
 import com.anytypeio.anytype.ui.objects.creation.ObjectTypeSelectionFragment
+import com.anytypeio.anytype.ui.sets.ObjectSetFragment
 import com.anytypeio.anytype.ui.objects.types.pickers.EditorObjectTypeUpdateFragment
 import com.anytypeio.anytype.ui.objects.types.pickers.ObjectTypeSelectionListener
 import com.anytypeio.anytype.ui.objects.types.pickers.ObjectTypeUpdateListener
@@ -558,6 +562,29 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        childFragmentManager.setFragmentResultListener(
+            CreateObjectDialogFragment.RESULT_KEY_NAVIGATION,
+            viewLifecycleOwner
+        ) { _, bundle ->
+            val navType = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_TYPE)
+            val id = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_ID) ?: return@setFragmentResultListener
+            val spaceStr = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_SPACE) ?: return@setFragmentResultListener
+            when (navType) {
+                "OpenEditor" -> findNavController().navigate(
+                    R.id.objectNavigation,
+                    EditorFragment.args(ctx = id, space = spaceStr)
+                )
+                "OpenSet" -> findNavController().navigate(
+                    R.id.dataViewNavigation,
+                    ObjectSetFragment.args(ctx = id, space = spaceStr)
+                )
+                "OpenChat" -> findNavController().navigate(
+                    R.id.chatScreen,
+                    ChatFragment.args(ctx = id, space = spaceStr)
+                )
+            }
+        }
+
         setupWindowInsetAnimation()
 
         dndDelegate.init(blockAdapter, vm, this)
@@ -657,8 +684,13 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
             .btnAddDoc
             .longClicks(withHaptic = true)
             .onEach {
-                val dialog = ObjectTypeSelectionFragment.new(space = space)
-                dialog.show(childFragmentManager, "editor-create-object-of-type-dialog")
+                if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+                    val dialog = CreateObjectDialogFragment.new(space = space)
+                    dialog.show(childFragmentManager, CreateObjectDialogFragment.TAG)
+                } else {
+                    val dialog = ObjectTypeSelectionFragment.new(space = space)
+                    dialog.show(childFragmentManager, "editor-create-object-of-type-dialog")
+                }
             }
             .launchIn(lifecycleScope)
 

--- a/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreenFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreenFragment.kt
@@ -57,7 +57,12 @@ import com.anytypeio.anytype.ui.gallery.GalleryInstallationFragment
 import com.anytypeio.anytype.ui.multiplayer.LeaveSpaceWarning
 import com.anytypeio.anytype.ui.multiplayer.RequestJoinSpaceFragment
 import com.anytypeio.anytype.ui.multiplayer.ShareSpaceFragment
+import com.anytypeio.anytype.BuildConfig
+import com.anytypeio.anytype.ui.chats.ChatFragment
+import com.anytypeio.anytype.ui.create.CreateObjectDialogFragment
+import com.anytypeio.anytype.ui.editor.EditorFragment
 import com.anytypeio.anytype.ui.objects.creation.ObjectTypeSelectionFragment
+import com.anytypeio.anytype.ui.sets.ObjectSetFragment
 import com.anytypeio.anytype.ui.objects.creation.WidgetSourceTypeFragment
 import com.anytypeio.anytype.ui.objects.types.pickers.ObjectTypeSelectionListener
 import com.anytypeio.anytype.ui.objects.types.pickers.WidgetSourceTypeListener
@@ -256,6 +261,28 @@ class WidgetsScreenFragment : Fragment(),
                 launch { vm.toasts.collect { toast(it) } }
             }
         }
+        childFragmentManager.setFragmentResultListener(
+            CreateObjectDialogFragment.RESULT_KEY_NAVIGATION,
+            viewLifecycleOwner
+        ) { _, bundle ->
+            val navType = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_TYPE)
+            val id = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_ID) ?: return@setFragmentResultListener
+            val spaceStr = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_SPACE) ?: return@setFragmentResultListener
+            when (navType) {
+                "OpenEditor" -> findNavController().navigate(
+                    R.id.objectNavigation,
+                    EditorFragment.args(ctx = id, space = spaceStr)
+                )
+                "OpenSet" -> findNavController().navigate(
+                    R.id.dataViewNavigation,
+                    ObjectSetFragment.args(ctx = id, space = spaceStr)
+                )
+                "OpenChat" -> findNavController().navigate(
+                    R.id.chatScreen,
+                    ChatFragment.args(ctx = id, space = spaceStr)
+                )
+            }
+        }
     }
 
     override fun onResume() {
@@ -422,10 +449,15 @@ class WidgetsScreenFragment : Fragment(),
             }
 
             is Command.OpenObjectCreateDialog -> {
-                val dialog = ObjectTypeSelectionFragment.new(
-                    space = command.space.id
-                )
-                dialog.show(childFragmentManager, "object-create-dialog")
+                if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+                    val dialog = CreateObjectDialogFragment.new(space = command.space.id)
+                    dialog.show(childFragmentManager, CreateObjectDialogFragment.TAG)
+                } else {
+                    val dialog = ObjectTypeSelectionFragment.new(
+                        space = command.space.id
+                    )
+                    dialog.show(childFragmentManager, "object-create-dialog")
+                }
             }
 
             is Command.OpenGlobalSearchScreen -> {

--- a/app/src/main/java/com/anytypeio/anytype/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/main/MainActivity.kt
@@ -73,6 +73,7 @@ import com.anytypeio.anytype.presentation.sharing.SharingCommand
 import com.anytypeio.anytype.presentation.sharing.SharingViewModel
 import com.anytypeio.anytype.ui.chats.ChatFragment
 import com.anytypeio.anytype.ui.date.DateObjectFragment
+import com.anytypeio.anytype.ui.create.CreateObjectDialogFragment
 import com.anytypeio.anytype.ui.editor.CreateObjectFragment
 import com.anytypeio.anytype.ui.editor.EditorFragment
 import com.anytypeio.anytype.ui.gallery.GalleryInstallationFragment
@@ -167,13 +168,21 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), AppNavigation.Pr
                                 navigator.logout()
                             }
                             is Command.OpenCreateNewType -> {
-                                findNavController(R.id.fragment)
-                                    .navigate(
-                                        R.id.action_global_createObjectFragment,
-                                        bundleOf(
-                                            CreateObjectFragment.TYPE_KEY to command.type
-                                        )
+                                if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+                                    val dialog = CreateObjectDialogFragment.new(
+                                        space = command.space,
+                                        typeKey = command.type
                                     )
+                                    dialog.show(supportFragmentManager, CreateObjectDialogFragment.TAG)
+                                } else {
+                                    findNavController(R.id.fragment)
+                                        .navigate(
+                                            R.id.action_global_createObjectFragment,
+                                            bundleOf(
+                                                CreateObjectFragment.TYPE_KEY to command.type
+                                            )
+                                        )
+                                }
                             }
                             is Command.Error -> {
                                 toast(command.msg)
@@ -375,22 +384,60 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), AppNavigation.Pr
                             is Command.Deeplink.OpenCreateObjectFromOsWidget -> {
                                 // Navigate to CreateObjectFragment (space already switched)
                                 Timber.d("Command.Deeplink.OpenCreateObjectFromOsWidget received: typeKey=${command.typeKey}")
-                                runCatching {
-                                    Timber.d("Navigating to CreateObjectFragment with typeKey=${command.typeKey}")
-                                    findNavController(R.id.fragment).navigate(
-                                        R.id.action_global_createObjectFragment,
-                                        bundleOf(
-                                            CreateObjectFragment.TYPE_KEY to command.typeKey
+                                if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+                                    runCatching {
+                                        Timber.d("Showing CreateObjectDialogFragment with typeKey=${command.typeKey}")
+                                        val dialog = CreateObjectDialogFragment.new(
+                                            space = command.space,
+                                            typeKey = command.typeKey
                                         )
-                                    )
-                                    Timber.d("Navigation to CreateObjectFragment successful")
-                                }.onFailure {
-                                    Timber.e(it, "Error navigating to CreateObjectFragment from OS widget")
-                                    toast("Failed to create object")
+                                        dialog.show(supportFragmentManager, CreateObjectDialogFragment.TAG)
+                                    }.onFailure {
+                                        Timber.e(it, "Error showing CreateObjectDialogFragment from OS widget")
+                                        toast("Failed to create object")
+                                    }
+                                } else {
+                                    runCatching {
+                                        Timber.d("Navigating to CreateObjectFragment with typeKey=${command.typeKey}")
+                                        findNavController(R.id.fragment).navigate(
+                                            R.id.action_global_createObjectFragment,
+                                            bundleOf(
+                                                CreateObjectFragment.TYPE_KEY to command.typeKey
+                                            )
+                                        )
+                                        Timber.d("Navigation to CreateObjectFragment successful")
+                                    }.onFailure {
+                                        Timber.e(it, "Error navigating to CreateObjectFragment from OS widget")
+                                        toast("Failed to create object")
+                                    }
                                 }
                             }
                         }
                     }
+                }
+            }
+        }
+        if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+            supportFragmentManager.setFragmentResultListener(
+                CreateObjectDialogFragment.RESULT_KEY_NAVIGATION,
+                this
+            ) { _, bundle ->
+                val navType = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_TYPE)
+                val id = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_ID) ?: return@setFragmentResultListener
+                val space = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_SPACE) ?: return@setFragmentResultListener
+                when (navType) {
+                    "OpenEditor" -> findNavController(R.id.fragment).navigate(
+                        R.id.objectNavigation,
+                        EditorFragment.args(ctx = id, space = space)
+                    )
+                    "OpenSet" -> findNavController(R.id.fragment).navigate(
+                        R.id.dataViewNavigation,
+                        ObjectSetFragment.args(ctx = id, space = space)
+                    )
+                    "OpenChat" -> findNavController(R.id.fragment).navigate(
+                        R.id.chatScreen,
+                        ChatFragment.args(ctx = id, space = space)
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/anytypeio/anytype/ui/oswidgets/CreateObjectWidgetConfigActivity.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/oswidgets/CreateObjectWidgetConfigActivity.kt
@@ -101,6 +101,9 @@ class CreateObjectWidgetConfigActivity : AppCompatActivity(), ObjectTypeSelectio
         )
     }
 
+    // Note: This call site intentionally stays on ObjectTypeSelectionFragment.
+    // The widget config activity selects a type for future creation (stored in preferences),
+    // it does not create an object immediately. See create-object-migration spec.
     private fun showTypeSelectionDialog(spaceId: String) {
         val dialog = ObjectTypeSelectionFragment.new(space = spaceId)
         dialog.show(supportFragmentManager, "object-type-selection")

--- a/app/src/main/java/com/anytypeio/anytype/ui/sets/ObjectSetFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/sets/ObjectSetFragment.kt
@@ -47,6 +47,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.RecyclerView
 import coil3.load
+import com.anytypeio.anytype.BuildConfig
 import com.anytypeio.anytype.R
 import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.core_models.Key
@@ -122,6 +123,9 @@ import com.anytypeio.anytype.ui.editor.cover.SelectCoverObjectSetFragment
 import com.anytypeio.anytype.ui.editor.modals.IconPickerFragmentBase
 import com.anytypeio.anytype.ui.editor.sheets.ObjectMenuBaseFragment
 import com.anytypeio.anytype.ui.objects.BaseObjectTypeChangeFragment
+import com.anytypeio.anytype.ui.chats.ChatFragment
+import com.anytypeio.anytype.ui.create.CreateObjectDialogFragment
+import com.anytypeio.anytype.ui.editor.EditorFragment
 import com.anytypeio.anytype.ui.objects.creation.ObjectTypeSelectionFragment
 import com.anytypeio.anytype.ui.objects.types.pickers.CollectionAddObjectTypeFragment
 import com.anytypeio.anytype.ui.objects.types.pickers.CollectionObjectTypeSelectionListener
@@ -269,6 +273,29 @@ open class ObjectSetFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        childFragmentManager.setFragmentResultListener(
+            CreateObjectDialogFragment.RESULT_KEY_NAVIGATION,
+            viewLifecycleOwner
+        ) { _, bundle ->
+            val navType = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_TYPE)
+            val id = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_ID) ?: return@setFragmentResultListener
+            val spaceStr = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_SPACE) ?: return@setFragmentResultListener
+            when (navType) {
+                "OpenEditor" -> findNavController().navigate(
+                    R.id.objectNavigation,
+                    EditorFragment.args(ctx = id, space = spaceStr)
+                )
+                "OpenSet" -> findNavController().navigate(
+                    R.id.dataViewNavigation,
+                    ObjectSetFragment.args(ctx = id, space = spaceStr)
+                )
+                "OpenChat" -> findNavController().navigate(
+                    R.id.chatScreen,
+                    ChatFragment.args(ctx = id, space = spaceStr)
+                )
+            }
+        }
+
         hideSoftInput()
         setupWindowInsetAnimation()
 
@@ -351,8 +378,13 @@ open class ObjectSetFragment :
                 .btnAddDoc
                 .longClicks(withHaptic = true)
                 .onEach {
-                    val dialog = ObjectTypeSelectionFragment.new(space = space)
-                    dialog.show(childFragmentManager, "set-create-object-of-type-dialog")
+                    if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+                        val dialog = CreateObjectDialogFragment.new(space = space)
+                        dialog.show(childFragmentManager, CreateObjectDialogFragment.TAG)
+                    } else {
+                        val dialog = ObjectTypeSelectionFragment.new(space = space)
+                        dialog.show(childFragmentManager, "set-create-object-of-type-dialog")
+                    }
                 }
                 .launchIn(lifecycleScope)
         }

--- a/app/src/main/java/com/anytypeio/anytype/ui/widgets/collection/CollectionFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/widgets/collection/CollectionFragment.kt
@@ -12,7 +12,12 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import android.view.View
 import com.anytypeio.anytype.BuildConfig
+import com.anytypeio.anytype.ui.chats.ChatFragment
+import com.anytypeio.anytype.ui.create.CreateObjectDialogFragment
+import com.anytypeio.anytype.ui.editor.EditorFragment
+import com.anytypeio.anytype.ui.sets.ObjectSetFragment
 import com.anytypeio.anytype.R
 import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.core_models.ObjectWrapper
@@ -69,14 +74,45 @@ class CollectionFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
                     CollectionScreen(
                         vm = vm,
                         onCreateObjectLongClicked = {
-                            val dialog = ObjectTypeSelectionFragment.new(space = space)
-                            dialog.show(childFragmentManager, "fullscreen-widget-create-object-type-dialog")
+                            if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+                                val dialog = CreateObjectDialogFragment.new(space = space)
+                                dialog.show(childFragmentManager, CreateObjectDialogFragment.TAG)
+                            } else {
+                                val dialog = ObjectTypeSelectionFragment.new(space = space)
+                                dialog.show(childFragmentManager, "fullscreen-widget-create-object-type-dialog")
+                            }
                         },
                         onSearchClicked = {
                             vm.onSearchClicked(space)
                         }
                     )
                 }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        childFragmentManager.setFragmentResultListener(
+            CreateObjectDialogFragment.RESULT_KEY_NAVIGATION,
+            viewLifecycleOwner
+        ) { _, bundle ->
+            val navType = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_TYPE)
+            val id = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_ID) ?: return@setFragmentResultListener
+            val spaceStr = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_SPACE) ?: return@setFragmentResultListener
+            when (navType) {
+                "OpenEditor" -> findNavController().navigate(
+                    R.id.objectNavigation,
+                    EditorFragment.args(ctx = id, space = spaceStr)
+                )
+                "OpenSet" -> findNavController().navigate(
+                    R.id.dataViewNavigation,
+                    ObjectSetFragment.args(ctx = id, space = spaceStr)
+                )
+                "OpenChat" -> findNavController().navigate(
+                    R.id.chatScreen,
+                    ChatFragment.args(ctx = id, space = spaceStr)
+                )
             }
         }
     }

--- a/app/src/main/java/com/anytypeio/anytype/ui/widgets/collection/CollectionFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/widgets/collection/CollectionFragment.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import android.view.View
 import com.anytypeio.anytype.BuildConfig
 import com.anytypeio.anytype.ui.chats.ChatFragment
 import com.anytypeio.anytype.ui.create.CreateObjectDialogFragment

--- a/docs/superpowers/plans/2026-03-24-create-object-migration.md
+++ b/docs/superpowers/plans/2026-03-24-create-object-migration.md
@@ -1,0 +1,1155 @@
+# Create-Object Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the legacy `CreateObjectFragment`/`SelectObjectTypeBaseFragment` flow with the new `feature-create-object` module across all call sites, behind a `BuildConfig.USE_NEW_CREATE_OBJECT` feature flag.
+
+**Architecture:** Expand `NewCreateObjectViewModel` with object creation and navigation capabilities. Create a `CreateObjectDialogFragment` wrapper to host the Compose bottom sheet in Fragment-based screens. Branch on `BuildConfig` at each of the 8 UI call sites + 2 deeplink call sites.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Dagger 2, Navigation Component, Coroutines/Flow, FragmentResult API
+
+**Spec:** `docs/superpowers/specs/2026-03-24-create-object-migration-design.md`
+
+---
+
+## File Map
+
+### New Files
+| File | Responsibility |
+|------|---------------|
+| `feature-create-object/src/main/java/.../presentation/CreateObjectNavigation.kt` | Navigation result sealed class |
+| `app/src/main/java/.../ui/create/CreateObjectDialogFragment.kt` | Bottom sheet dialog fragment wrapper |
+
+### Modified Files
+| File | Changes |
+|------|---------|
+| `app/build.gradle` | Add `USE_NEW_CREATE_OBJECT` BuildConfig field |
+| `feature-create-object/src/main/java/.../presentation/NewCreateObjectViewModel.kt` | Add creation logic, navigation channel, VmParams.typeKey |
+| `feature-create-object/src/main/java/.../presentation/CreateObjectViewModelFactory.kt` | Add new constructor params |
+| `app/src/main/java/.../di/feature/CreateObjectFeatureDI.kt` | Add module, expand dependencies, add inject method |
+| `app/src/main/java/.../ui/home/WidgetsScreenFragment.kt` | Branch on flag |
+| `app/src/main/java/.../ui/editor/EditorFragment.kt` | Branch on flag |
+| `app/src/main/java/.../ui/widgets/collection/CollectionFragment.kt` | Branch on flag |
+| `app/src/main/java/.../ui/allcontent/AllContentFragment.kt` | Branch on flag |
+| `app/src/main/java/.../ui/date/DateObjectFragment.kt` | Branch on flag |
+| `app/src/main/java/.../ui/sets/ObjectSetFragment.kt` | Branch on flag |
+| `app/src/main/java/.../ui/settings/space/SpaceSettingsFragment.kt` | Branch on flag |
+| `app/src/main/java/.../ui/oswidgets/CreateObjectWidgetConfigActivity.kt` | Branch on flag |
+| `app/src/main/java/.../ui/main/MainActivity.kt` | Branch on flag for deeplinks |
+| `feature-create-object/src/test/.../presentation/NewCreateObjectViewModelTest.kt` | Add creation/navigation tests |
+
+---
+
+### Task 1: Add BuildConfig Feature Flag
+
+**Files:**
+- Modify: `app/build.gradle:129-170` (buildTypes section)
+
+- [ ] **Step 1: Add buildConfigField to debug buildType**
+
+In `app/build.gradle`, inside the `debug` block (after line 151 `buildConfigField "boolean", "SHOW_CHATS", "true"`), add:
+
+```groovy
+buildConfigField "boolean", "USE_NEW_CREATE_OBJECT", "false"
+```
+
+- [ ] **Step 2: Add buildConfigField to release buildType**
+
+In `app/build.gradle`, inside the `release` block (after line 134 `buildConfigField "boolean", "SHOW_CHATS", "true"`), add:
+
+```groovy
+buildConfigField "boolean", "USE_NEW_CREATE_OBJECT", "false"
+```
+
+- [ ] **Step 3: Verify build compiles**
+
+Run: `./gradlew :app:assembleDebug --dry-run`
+Expected: BUILD SUCCESSFUL (no compilation errors from the new field)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/build.gradle
+git commit -m "feat: add USE_NEW_CREATE_OBJECT BuildConfig feature flag"
+```
+
+---
+
+### Task 2: Add CreateObjectNavigation Sealed Class
+
+**Files:**
+- Create: `feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/CreateObjectNavigation.kt`
+
+- [ ] **Step 1: Create the navigation result file**
+
+```kotlin
+package com.anytypeio.anytype.feature_create_object.presentation
+
+import com.anytypeio.anytype.core_models.Id
+import com.anytypeio.anytype.core_models.primitives.SpaceId
+
+sealed class CreateObjectNavigation {
+    data class OpenEditor(val id: Id, val space: SpaceId) : CreateObjectNavigation()
+    data class OpenSet(val id: Id, val space: SpaceId) : CreateObjectNavigation()
+    data class OpenChat(val id: Id, val space: SpaceId) : CreateObjectNavigation()
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew :feature-create-object:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/CreateObjectNavigation.kt
+git commit -m "feat: add CreateObjectNavigation sealed class for post-creation routing"
+```
+
+---
+
+### Task 3: Expand NewCreateObjectViewModel with Creation Logic
+
+**Files:**
+- Modify: `feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModel.kt`
+- Modify: `feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/CreateObjectViewModelFactory.kt`
+
+- [ ] **Step 1: Write failing tests for object creation**
+
+Add to `feature-create-object/src/test/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModelTest.kt`:
+
+```kotlin
+@Test
+fun `should emit OpenEditor navigation when object with basic layout is created`() = runTest {
+    // Given
+    val createdObjectId = "created-obj-123"
+    val spaceId = SpaceId("test-space")
+    val typeKey = TypeKey("ot-page")
+    val createResult = CreateObjectByTypeAndTemplate.Result.Success(
+        objectId = createdObjectId,
+        event = Payload(context = "", events = emptyList()),
+        typeKey = typeKey,
+        obj = ObjectWrapper.Basic(
+            mapOf(
+                Relations.ID to createdObjectId,
+                Relations.LAYOUT to ObjectType.Layout.BASIC.code.toDouble()
+            )
+        )
+    )
+    val createObject = mock<CreateObjectByTypeAndTemplate>()
+    whenever(createObject.async(any())).thenReturn(Resultat.success(createResult))
+
+    val vm = NewCreateObjectViewModel(
+        storeOfObjectTypes = storeOfObjectTypes,
+        spaceViewContainer = spaceViewContainer,
+        vmParams = NewCreateObjectViewModel.VmParams(spaceId = spaceId),
+        createObjectByTypeAndTemplate = createObject
+    )
+
+    // When & Then
+    vm.navigation.test {
+        vm.onAction(CreateObjectAction.CreateObjectOfType(typeKey = typeKey.key, typeName = "Page"))
+        val nav = awaitItem()
+        assertIs<CreateObjectNavigation.OpenEditor>(nav)
+        assertEquals(createdObjectId, nav.id)
+        assertEquals(spaceId, nav.space)
+    }
+}
+
+@Test
+fun `should emit OpenSet navigation when collection layout object is created`() = runTest {
+    val createdObjectId = "created-collection-123"
+    val spaceId = SpaceId("test-space")
+    val typeKey = TypeKey("ot-collection")
+    val createResult = CreateObjectByTypeAndTemplate.Result.Success(
+        objectId = createdObjectId,
+        event = Payload(context = "", events = emptyList()),
+        typeKey = typeKey,
+        obj = ObjectWrapper.Basic(
+            mapOf(
+                Relations.ID to createdObjectId,
+                Relations.LAYOUT to ObjectType.Layout.COLLECTION.code.toDouble()
+            )
+        )
+    )
+    val createObject = mock<CreateObjectByTypeAndTemplate>()
+    whenever(createObject.async(any())).thenReturn(Resultat.success(createResult))
+
+    val vm = NewCreateObjectViewModel(
+        storeOfObjectTypes = storeOfObjectTypes,
+        spaceViewContainer = spaceViewContainer,
+        vmParams = NewCreateObjectViewModel.VmParams(spaceId = spaceId),
+        createObjectByTypeAndTemplate = createObject
+    )
+
+    vm.navigation.test {
+        vm.onAction(CreateObjectAction.CreateObjectOfType(typeKey = typeKey.key, typeName = "Collection"))
+        val nav = awaitItem()
+        assertIs<CreateObjectNavigation.OpenSet>(nav)
+    }
+}
+
+@Test
+fun `should emit OpenChat navigation when chat layout object is created`() = runTest {
+    val createdObjectId = "created-chat-123"
+    val spaceId = SpaceId("test-space")
+    val typeKey = TypeKey("ot-chat")
+    val createResult = CreateObjectByTypeAndTemplate.Result.Success(
+        objectId = createdObjectId,
+        event = Payload(context = "", events = emptyList()),
+        typeKey = typeKey,
+        obj = ObjectWrapper.Basic(
+            mapOf(
+                Relations.ID to createdObjectId,
+                Relations.LAYOUT to ObjectType.Layout.CHAT.code.toDouble()
+            )
+        )
+    )
+    val createObject = mock<CreateObjectByTypeAndTemplate>()
+    whenever(createObject.async(any())).thenReturn(Resultat.success(createResult))
+
+    val vm = NewCreateObjectViewModel(
+        storeOfObjectTypes = storeOfObjectTypes,
+        spaceViewContainer = spaceViewContainer,
+        vmParams = NewCreateObjectViewModel.VmParams(spaceId = spaceId),
+        createObjectByTypeAndTemplate = createObject
+    )
+
+    vm.navigation.test {
+        vm.onAction(CreateObjectAction.CreateObjectOfType(typeKey = typeKey.key, typeName = "Chat"))
+        val nav = awaitItem()
+        assertIs<CreateObjectNavigation.OpenChat>(nav)
+    }
+}
+
+@Test
+fun `should show error state when object creation fails`() = runTest {
+    val spaceId = SpaceId("test-space")
+    val typeKey = TypeKey("ot-page")
+    val createObject = mock<CreateObjectByTypeAndTemplate>()
+    whenever(createObject.async(any())).thenReturn(Resultat.failure(RuntimeException("Creation failed")))
+
+    val vm = NewCreateObjectViewModel(
+        storeOfObjectTypes = storeOfObjectTypes,
+        spaceViewContainer = spaceViewContainer,
+        vmParams = NewCreateObjectViewModel.VmParams(spaceId = spaceId),
+        createObjectByTypeAndTemplate = createObject
+    )
+
+    vm.onAction(CreateObjectAction.CreateObjectOfType(typeKey = typeKey.key, typeName = "Page"))
+
+    vm.state.test {
+        val state = awaitItem()
+        assertNotNull(state.error)
+    }
+}
+
+@Test
+fun `should immediately create object when typeKey is pre-selected`() = runTest {
+    val createdObjectId = "created-preselected-123"
+    val spaceId = SpaceId("test-space")
+    val typeKey = TypeKey("ot-note")
+    val createResult = CreateObjectByTypeAndTemplate.Result.Success(
+        objectId = createdObjectId,
+        event = Payload(context = "", events = emptyList()),
+        typeKey = typeKey,
+        obj = ObjectWrapper.Basic(
+            mapOf(
+                Relations.ID to createdObjectId,
+                Relations.LAYOUT to ObjectType.Layout.NOTE.code.toDouble()
+            )
+        )
+    )
+    val createObject = mock<CreateObjectByTypeAndTemplate>()
+    whenever(createObject.async(any())).thenReturn(Resultat.success(createResult))
+
+    val vm = NewCreateObjectViewModel(
+        storeOfObjectTypes = storeOfObjectTypes,
+        spaceViewContainer = spaceViewContainer,
+        vmParams = NewCreateObjectViewModel.VmParams(spaceId = spaceId, typeKey = typeKey),
+        createObjectByTypeAndTemplate = createObject
+    )
+
+    // VM should auto-create on init due to pre-selected typeKey
+    vm.navigation.test {
+        val nav = awaitItem()
+        assertIs<CreateObjectNavigation.OpenEditor>(nav)
+        assertEquals(createdObjectId, nav.id)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :feature-create-object:testDebugUnitTest`
+Expected: FAIL — `NewCreateObjectViewModel` constructor doesn't accept new parameters yet
+
+- [ ] **Step 3: Update VmParams with optional typeKey**
+
+In `NewCreateObjectViewModel.kt`, update the `VmParams` data class (line 173-175):
+
+```kotlin
+data class VmParams(
+    val spaceId: SpaceId,
+    val typeKey: TypeKey? = null
+)
+```
+
+Add the import: `import com.anytypeio.anytype.core_models.primitives.TypeKey`
+
+- [ ] **Step 4: Add new constructor parameters to ViewModel**
+
+Update the constructor (lines 34-38) to:
+
+```kotlin
+class NewCreateObjectViewModel @Inject constructor(
+    private val storeOfObjectTypes: StoreOfObjectTypes,
+    private val spaceViewContainer: SpaceViewSubscriptionContainer,
+    private val vmParams: VmParams,
+    private val createObjectByTypeAndTemplate: CreateObjectByTypeAndTemplate
+) : ViewModel()
+```
+
+Note: `SpaceManager` is NOT needed — we use `vmParams.spaceId` which is always available.
+
+Add imports:
+```kotlin
+import com.anytypeio.anytype.domain.page.CreateObjectByTypeAndTemplate
+import com.anytypeio.anytype.core_models.ObjectType
+import com.anytypeio.anytype.core_models.primitives.TypeKey
+import com.anytypeio.anytype.core_models.primitives.SpaceId
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+```
+
+- [ ] **Step 5: Add navigation channel and creation logic**
+
+After the `_state` declaration (around line 41), add:
+
+```kotlin
+private val _navigation = Channel<CreateObjectNavigation>(Channel.BUFFERED)
+val navigation = _navigation.receiveAsFlow()
+```
+
+Replace the `onAction` method (lines 159-167) with:
+
+```kotlin
+fun onAction(action: CreateObjectAction) {
+    when (action) {
+        is CreateObjectAction.UpdateSearch -> onSearchQueryChanged(action.query)
+        is CreateObjectAction.Retry -> retry()
+        is CreateObjectAction.CreateObjectOfType -> onCreateObject(
+            typeKey = TypeKey(action.typeKey),
+            typeName = action.typeName
+        )
+        else -> { /* Media actions handled by parent component */ }
+    }
+}
+
+private fun onCreateObject(typeKey: TypeKey, typeName: String) {
+    viewModelScope.launch {
+        createObjectByTypeAndTemplate.async(
+            CreateObjectByTypeAndTemplate.Param(
+                typeKey = typeKey,
+                space = vmParams.spaceId,
+                keys = emptyList()
+            )
+        ).fold(
+            onSuccess = { result ->
+                when (result) {
+                    is CreateObjectByTypeAndTemplate.Result.Success -> {
+                        val layout = result.obj.layout
+                        val nav = when (layout) {
+                            ObjectType.Layout.COLLECTION,
+                            ObjectType.Layout.SET -> CreateObjectNavigation.OpenSet(
+                                id = result.objectId,
+                                space = vmParams.spaceId
+                            )
+                            ObjectType.Layout.CHAT,
+                            ObjectType.Layout.CHAT_DERIVED -> CreateObjectNavigation.OpenChat(
+                                id = result.objectId,
+                                space = vmParams.spaceId
+                            )
+                            else -> CreateObjectNavigation.OpenEditor(
+                                id = result.objectId,
+                                space = vmParams.spaceId
+                            )
+                        }
+                        _navigation.send(nav)
+                    }
+                    is CreateObjectByTypeAndTemplate.Result.ObjectTypeNotFound -> {
+                        _state.update { it.copy(error = "Object type not found") }
+                    }
+                }
+            },
+            onFailure = { e ->
+                _state.update { it.copy(error = e.message ?: "Failed to create object") }
+            }
+        )
+    }
+}
+```
+
+Note: `async()` returns `Resultat<Result>`, so we use `.fold()` to unwrap. This matches the pattern used by the legacy `CreateObjectViewModel`. We use `vmParams.spaceId` consistently (not `spaceManager.get()`) since the space is known at construction time.
+
+- [ ] **Step 6: Add init block for pre-selected typeKey**
+
+At the end of the existing `init` block, add:
+
+```kotlin
+vmParams.typeKey?.let { key ->
+    onCreateObject(typeKey = key, typeName = "")
+}
+```
+
+- [ ] **Step 7: Update CreateObjectViewModelFactory**
+
+Update `CreateObjectViewModelFactory.kt` to include the new parameter:
+
+```kotlin
+class CreateObjectViewModelFactory @Inject constructor(
+    private val storeOfObjectTypes: StoreOfObjectTypes,
+    private val spaceViewContainer: SpaceViewSubscriptionContainer,
+    private val vmParams: NewCreateObjectViewModel.VmParams,
+    private val createObjectByTypeAndTemplate: CreateObjectByTypeAndTemplate
+) : ViewModelProvider.Factory {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return NewCreateObjectViewModel(
+            storeOfObjectTypes = storeOfObjectTypes,
+            spaceViewContainer = spaceViewContainer,
+            vmParams = vmParams,
+            createObjectByTypeAndTemplate = createObjectByTypeAndTemplate
+        ) as T
+    }
+}
+```
+
+Add import:
+```kotlin
+import com.anytypeio.anytype.domain.page.CreateObjectByTypeAndTemplate
+```
+
+- [ ] **Step 8: Fix existing tests to pass new parameters**
+
+In `NewCreateObjectViewModelTest.kt`, update the test helper that creates the ViewModel. Find where `NewCreateObjectViewModel` is instantiated in existing tests and add the new parameters with mocks:
+
+```kotlin
+// Add as class-level test double:
+private val createObjectByTypeAndTemplate = mock<CreateObjectByTypeAndTemplate>()
+```
+
+Update all existing VM instantiations to include:
+```kotlin
+createObjectByTypeAndTemplate = createObjectByTypeAndTemplate
+```
+
+- [ ] **Step 9: Run all tests**
+
+Run: `./gradlew :feature-create-object:testDebugUnitTest`
+Expected: ALL PASS (existing + new tests)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModel.kt \
+      feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/CreateObjectViewModelFactory.kt \
+      feature-create-object/src/test/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModelTest.kt
+git commit -m "feat: expand NewCreateObjectViewModel with object creation and navigation"
+```
+
+---
+
+### Task 4: Update DI — CreateObjectFeatureDI
+
+**Files:**
+- Modify: `app/src/main/java/com/anytypeio/anytype/di/feature/CreateObjectFeatureDI.kt`
+
+- [ ] **Step 1: Expand CreateObjectFeatureDependencies interface**
+
+Replace the existing `CreateObjectFeatureDependencies` interface (lines 49-52) with:
+
+```kotlin
+interface CreateObjectFeatureDependencies : ComponentDependencies {
+    fun storeOfObjectTypes(): StoreOfObjectTypes
+    fun spaceViewSubscriptionContainer(): SpaceViewSubscriptionContainer
+    fun blockRepository(): BlockRepository
+    fun logger(): Logger
+    fun dispatchers(): AppCoroutineDispatchers
+}
+```
+
+Note: `SpaceManager` is NOT needed — the VM uses `vmParams.spaceId` directly.
+
+Add imports:
+```kotlin
+import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
+import com.anytypeio.anytype.domain.block.repo.BlockRepository
+import com.anytypeio.anytype.domain.debugging.Logger
+import com.anytypeio.anytype.domain.page.CreateObjectByTypeAndTemplate
+```
+
+- [ ] **Step 2: Add CreateObjectFeatureModule @Provides method**
+
+Replace the existing `CreateObjectFeatureModule` (lines 38-47) with:
+
+```kotlin
+@Module
+object CreateObjectFeatureModule {
+
+    @JvmStatic
+    @Provides
+    @PerScreen
+    fun provideCreateObjectByTypeAndTemplate(
+        repo: BlockRepository,
+        logger: Logger,
+        dispatchers: AppCoroutineDispatchers
+    ): CreateObjectByTypeAndTemplate = CreateObjectByTypeAndTemplate(
+        repo = repo,
+        logger = logger,
+        dispatchers = dispatchers
+    )
+
+    @Module
+    interface Declarations {
+        @PerScreen
+        @Binds
+        fun bindViewModelFactory(
+            factory: CreateObjectViewModelFactory
+        ): ViewModelProvider.Factory
+    }
+}
+```
+
+Note: `BlockRepository`, `Logger`, and `AppCoroutineDispatchers` are resolved by Dagger from the component dependencies interface automatically. No explicit re-provides needed.
+
+- [ ] **Step 3: Add inject method for CreateObjectDialogFragment**
+
+In the `CreateObjectFeatureComponent` interface (line 23), uncomment/replace the commented inject method:
+
+```kotlin
+fun inject(fragment: CreateObjectDialogFragment)
+```
+
+Add import:
+```kotlin
+import com.anytypeio.anytype.ui.create.CreateObjectDialogFragment
+```
+
+Note: Task 5 must be completed before this step compiles. Commit Tasks 4 and 5 together, or do Task 5 first if working sequentially.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/anytypeio/anytype/di/feature/CreateObjectFeatureDI.kt
+git commit -m "feat: expand CreateObjectFeatureComponent with creation use case and dependencies"
+```
+
+---
+
+### Task 5: Create CreateObjectDialogFragment
+
+**Files:**
+- Create: `app/src/main/java/com/anytypeio/anytype/ui/create/CreateObjectDialogFragment.kt`
+
+- [ ] **Step 1: Create the dialog fragment**
+
+```kotlin
+package com.anytypeio.anytype.ui.create
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.os.bundleOf
+import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.anytypeio.anytype.core_models.Id
+import com.anytypeio.anytype.core_models.primitives.SpaceId
+import com.anytypeio.anytype.core_models.primitives.TypeKey
+import com.anytypeio.anytype.core_utils.ext.subscribe
+import com.anytypeio.anytype.core_utils.ui.BaseBottomSheetComposeFragment
+import com.anytypeio.anytype.di.common.componentManager
+import com.anytypeio.anytype.feature_create_object.presentation.CreateObjectAction
+import com.anytypeio.anytype.feature_create_object.presentation.CreateObjectNavigation
+import com.anytypeio.anytype.feature_create_object.presentation.NewCreateObjectViewModel
+import com.anytypeio.anytype.feature_create_object.ui.CreateObjectContent
+import javax.inject.Inject
+
+class CreateObjectDialogFragment : BaseBottomSheetComposeFragment() {
+
+    @Inject
+    lateinit var factory: ViewModelProvider.Factory
+    private val vm by viewModels<NewCreateObjectViewModel> { factory }
+
+    private val space: String get() = requireArguments().getString(ARG_SPACE, "")
+    private val typeKey: String? get() = requireArguments().getString(ARG_TYPE_KEY)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ) = ComposeView(requireContext()).apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent {
+            val state by vm.state.collectAsStateWithLifecycle()
+            // Use CreateObjectContent directly — NOT CreateObjectBottomSheet.
+            // The fragment itself IS the bottom sheet (BaseBottomSheetComposeFragment),
+            // so wrapping in ModalBottomSheet would create a double bottom sheet.
+            CreateObjectContent(
+                state = state,
+                onAction = { action ->
+                    when (action) {
+                        is CreateObjectAction.SelectPhotos,
+                        is CreateObjectAction.TakePhoto,
+                        is CreateObjectAction.SelectFiles,
+                        is CreateObjectAction.AttachExistingObject -> {
+                            setFragmentResult(
+                                RESULT_KEY_ACTION,
+                                bundleOf(RESULT_ACTION_TYPE to action::class.java.simpleName)
+                            )
+                            dismiss()
+                        }
+                        else -> vm.onAction(action)
+                    }
+                }
+            )
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        jobs += lifecycleScope.subscribe(vm.navigation) { nav ->
+            setFragmentResult(
+                RESULT_KEY_NAVIGATION,
+                bundleOf(
+                    RESULT_NAV_TYPE to nav::class.java.simpleName,
+                    RESULT_NAV_ID to when (nav) {
+                        is CreateObjectNavigation.OpenEditor -> nav.id
+                        is CreateObjectNavigation.OpenSet -> nav.id
+                        is CreateObjectNavigation.OpenChat -> nav.id
+                    },
+                    RESULT_NAV_SPACE to when (nav) {
+                        is CreateObjectNavigation.OpenEditor -> nav.space.id
+                        is CreateObjectNavigation.OpenSet -> nav.space.id
+                        is CreateObjectNavigation.OpenChat -> nav.space.id
+                    }
+                )
+            )
+            dismiss()
+        }
+    }
+
+    override fun injectDependencies() {
+        val typeKeyParam = typeKey?.let { TypeKey(it) }
+        componentManager().createObjectFeatureComponent.get(
+            NewCreateObjectViewModel.VmParams(
+                spaceId = SpaceId(space),
+                typeKey = typeKeyParam
+            )
+        ).inject(this)
+    }
+
+    override fun releaseDependencies() {
+        componentManager().createObjectFeatureComponent.release()
+    }
+
+    companion object {
+        const val TAG = "CreateObjectDialogFragment"
+        private const val ARG_SPACE = "arg.create-object.space"
+        private const val ARG_TYPE_KEY = "arg.create-object.type-key"
+
+        const val RESULT_KEY_NAVIGATION = "result.create-object.navigation"
+        const val RESULT_KEY_ACTION = "result.create-object.action"
+        const val RESULT_NAV_TYPE = "result.nav.type"
+        const val RESULT_NAV_ID = "result.nav.id"
+        const val RESULT_NAV_SPACE = "result.nav.space"
+        const val RESULT_ACTION_TYPE = "result.action.type"
+
+        fun new(space: Id, typeKey: String? = null) = CreateObjectDialogFragment().apply {
+            arguments = bundleOf(
+                ARG_SPACE to space,
+                ARG_TYPE_KEY to typeKey
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify build compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/anytypeio/anytype/ui/create/CreateObjectDialogFragment.kt
+git commit -m "feat: add CreateObjectDialogFragment wrapper for Compose bottom sheet"
+```
+
+---
+
+### Task 6: Migrate WidgetsScreenFragment
+
+**Files:**
+- Modify: `app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreenFragment.kt:425-428,642-644`
+
+- [ ] **Step 1: Add imports**
+
+Add at the top of the file:
+
+```kotlin
+import com.anytypeio.anytype.BuildConfig
+import com.anytypeio.anytype.ui.create.CreateObjectDialogFragment
+```
+
+- [ ] **Step 2: Branch the dialog show site**
+
+Replace lines 425-428:
+
+```kotlin
+is Command.OpenObjectCreateDialog -> {
+    val dialog = ObjectTypeSelectionFragment.new(
+        space = command.space.id
+    )
+    dialog.show(childFragmentManager, "object-create-dialog")
+}
+```
+
+With:
+
+```kotlin
+is Command.OpenObjectCreateDialog -> {
+    if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+        val dialog = CreateObjectDialogFragment.new(space = command.space.id)
+        dialog.show(childFragmentManager, CreateObjectDialogFragment.TAG)
+    } else {
+        val dialog = ObjectTypeSelectionFragment.new(
+            space = command.space.id
+        )
+        dialog.show(childFragmentManager, "object-create-dialog")
+    }
+}
+```
+
+- [ ] **Step 3: Add FragmentResultListener for navigation**
+
+In the `onViewCreated` or `onStart` method, register a result listener. Find the appropriate lifecycle method and add:
+
+```kotlin
+childFragmentManager.setFragmentResultListener(
+    CreateObjectDialogFragment.RESULT_KEY_NAVIGATION,
+    viewLifecycleOwner
+) { _, bundle ->
+    val navType = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_TYPE)
+    val id = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_ID) ?: return@setFragmentResultListener
+    val space = bundle.getString(CreateObjectDialogFragment.RESULT_NAV_SPACE) ?: return@setFragmentResultListener
+    when (navType) {
+        "OpenEditor" -> navigateToEditor(id, space)
+        "OpenSet" -> navigateToDataView(id, space)
+        "OpenChat" -> navigateToChat(id, space)
+    }
+}
+```
+
+Note: The exact navigation methods (`navigateToEditor`, `navigateToDataView`, `navigateToChat`) must match the existing navigation patterns in this fragment. Check the fragment for existing navigation helpers and adapt accordingly.
+
+- [ ] **Step 4: Verify build compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreenFragment.kt
+git commit -m "feat: migrate WidgetsScreenFragment to new create-object flow behind flag"
+```
+
+---
+
+### Task 7: Migrate EditorFragment
+
+**Files:**
+- Modify: `app/src/main/java/com/anytypeio/anytype/ui/editor/EditorFragment.kt:655-663,2357-2359`
+
+- [ ] **Step 1: Add imports**
+
+```kotlin
+import com.anytypeio.anytype.BuildConfig
+import com.anytypeio.anytype.ui.create.CreateObjectDialogFragment
+```
+
+- [ ] **Step 2: Branch the dialog show site**
+
+Replace lines 660-661 (inside the `longClicks` handler):
+
+```kotlin
+val dialog = ObjectTypeSelectionFragment.new(space = space)
+dialog.show(childFragmentManager, "editor-create-object-of-type-dialog")
+```
+
+With:
+
+```kotlin
+if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+    val dialog = CreateObjectDialogFragment.new(space = space)
+    dialog.show(childFragmentManager, CreateObjectDialogFragment.TAG)
+} else {
+    val dialog = ObjectTypeSelectionFragment.new(space = space)
+    dialog.show(childFragmentManager, "editor-create-object-of-type-dialog")
+}
+```
+
+- [ ] **Step 3: Add FragmentResultListener for navigation**
+
+Register the result listener in the appropriate lifecycle method, following the same pattern as Task 6 Step 3 but using this fragment's navigation methods.
+
+- [ ] **Step 4: Verify build compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/anytypeio/anytype/ui/editor/EditorFragment.kt
+git commit -m "feat: migrate EditorFragment to new create-object flow behind flag"
+```
+
+---
+
+### Task 8: Migrate CollectionFragment
+
+**Files:**
+- Modify: `app/src/main/java/com/anytypeio/anytype/ui/widgets/collection/CollectionFragment.kt:71-74,207-209`
+
+- [ ] **Step 1: Add imports**
+
+```kotlin
+import com.anytypeio.anytype.BuildConfig
+import com.anytypeio.anytype.ui.create.CreateObjectDialogFragment
+```
+
+- [ ] **Step 2: Branch the dialog show site (lines 71-74)**
+
+Replace:
+
+```kotlin
+onCreateObjectLongClicked = {
+    val dialog = ObjectTypeSelectionFragment.new(space = space)
+    dialog.show(childFragmentManager, "fullscreen-widget-create-object-type-dialog")
+},
+```
+
+With:
+
+```kotlin
+onCreateObjectLongClicked = {
+    if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+        val dialog = CreateObjectDialogFragment.new(space = space)
+        dialog.show(childFragmentManager, CreateObjectDialogFragment.TAG)
+    } else {
+        val dialog = ObjectTypeSelectionFragment.new(space = space)
+        dialog.show(childFragmentManager, "fullscreen-widget-create-object-type-dialog")
+    }
+},
+```
+
+- [ ] **Step 3: Add FragmentResultListener**
+
+Same pattern as Task 6 Step 3, adapted to this fragment's navigation.
+
+- [ ] **Step 4: Verify build compiles and commit**
+
+```bash
+git add app/src/main/java/com/anytypeio/anytype/ui/widgets/collection/CollectionFragment.kt
+git commit -m "feat: migrate CollectionFragment to new create-object flow behind flag"
+```
+
+---
+
+### Task 9: Migrate AllContentFragment
+
+**Files:**
+- Modify: `app/src/main/java/com/anytypeio/anytype/ui/allcontent/AllContentFragment.kt:252-254,279-281`
+
+- [ ] **Step 1: Add imports and branch dialog show site (lines 252-254)**
+
+Replace:
+
+```kotlin
+onCreateObjectLongClicked = {
+    val dialog = ObjectTypeSelectionFragment.new(space = space)
+    dialog.show(childFragmentManager, null)
+},
+```
+
+With:
+
+```kotlin
+onCreateObjectLongClicked = {
+    if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+        val dialog = CreateObjectDialogFragment.new(space = space)
+        dialog.show(childFragmentManager, CreateObjectDialogFragment.TAG)
+    } else {
+        val dialog = ObjectTypeSelectionFragment.new(space = space)
+        dialog.show(childFragmentManager, null)
+    }
+},
+```
+
+- [ ] **Step 2: Add FragmentResultListener**
+
+Same pattern as Task 6 Step 3.
+
+- [ ] **Step 3: Verify build compiles and commit**
+
+```bash
+git add app/src/main/java/com/anytypeio/anytype/ui/allcontent/AllContentFragment.kt
+git commit -m "feat: migrate AllContentFragment to new create-object flow behind flag"
+```
+
+---
+
+### Task 10: Migrate DateObjectFragment
+
+**Files:**
+- Modify: `app/src/main/java/com/anytypeio/anytype/ui/date/DateObjectFragment.kt:177-179,210-212`
+
+- [ ] **Step 1: Add imports and branch dialog show site (lines 177-179)**
+
+Replace:
+
+```kotlin
+DateObjectCommand.TypeSelectionScreen -> {
+    val dialog = ObjectTypeSelectionFragment.new(space = space)
+    dialog.show(childFragmentManager, null)
+}
+```
+
+With:
+
+```kotlin
+DateObjectCommand.TypeSelectionScreen -> {
+    if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+        val dialog = CreateObjectDialogFragment.new(space = space)
+        dialog.show(childFragmentManager, CreateObjectDialogFragment.TAG)
+    } else {
+        val dialog = ObjectTypeSelectionFragment.new(space = space)
+        dialog.show(childFragmentManager, null)
+    }
+}
+```
+
+- [ ] **Step 2: Add FragmentResultListener and commit**
+
+```bash
+git add app/src/main/java/com/anytypeio/anytype/ui/date/DateObjectFragment.kt
+git commit -m "feat: migrate DateObjectFragment to new create-object flow behind flag"
+```
+
+---
+
+### Task 11: Migrate ObjectSetFragment
+
+**Files:**
+- Modify: `app/src/main/java/com/anytypeio/anytype/ui/sets/ObjectSetFragment.kt:349-357,1594-1596`
+
+Note: Only migrate the `ObjectTypeSelectionListener` path. The `CollectionObjectTypeSelectionListener` / `CollectionAddObjectTypeFragment` path is out of scope.
+
+- [ ] **Step 1: Add imports and branch dialog show site (lines 354-355)**
+
+Replace:
+
+```kotlin
+val dialog = ObjectTypeSelectionFragment.new(space = space)
+dialog.show(childFragmentManager, "set-create-object-of-type-dialog")
+```
+
+With:
+
+```kotlin
+if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+    val dialog = CreateObjectDialogFragment.new(space = space)
+    dialog.show(childFragmentManager, CreateObjectDialogFragment.TAG)
+} else {
+    val dialog = ObjectTypeSelectionFragment.new(space = space)
+    dialog.show(childFragmentManager, "set-create-object-of-type-dialog")
+}
+```
+
+- [ ] **Step 2: Add FragmentResultListener and commit**
+
+```bash
+git add app/src/main/java/com/anytypeio/anytype/ui/sets/ObjectSetFragment.kt
+git commit -m "feat: migrate ObjectSetFragment to new create-object flow behind flag"
+```
+
+---
+
+### Task 12: Migrate SpaceSettingsFragment
+
+**Files:**
+- Modify: `app/src/main/java/com/anytypeio/anytype/ui/settings/space/SpaceSettingsFragment.kt:383-385`
+
+Note: This fragment implements `ObjectTypeSelectionListener` but doesn't directly show `ObjectTypeSelectionFragment` — it's shown by a child. The callback at line 383 needs branching.
+
+- [ ] **Step 1: Investigate how the dialog is triggered**
+
+Read the fragment to find where `ObjectTypeSelectionFragment` is shown. It may be triggered by a child fragment or composable. Adapt the branching accordingly — the migration may only need a flag check at the callback level or may need to intercept the dialog show.
+
+- [ ] **Step 2: Apply appropriate branching and commit**
+
+```bash
+git add app/src/main/java/com/anytypeio/anytype/ui/settings/space/SpaceSettingsFragment.kt
+git commit -m "feat: migrate SpaceSettingsFragment to new create-object flow behind flag"
+```
+
+---
+
+### Task 13: Migrate CreateObjectWidgetConfigActivity
+
+**Files:**
+- Modify: `app/src/main/java/com/anytypeio/anytype/ui/oswidgets/CreateObjectWidgetConfigActivity.kt:104-106,109-111`
+
+**Important:** This activity has fundamentally different behavior from other call sites. It uses the type picker to CONFIGURE a widget (store the type selection), not to CREATE an object. The `CreateObjectDialogFragment` creates objects immediately on type selection, which is wrong here.
+
+**Decision:** Exclude this call site from migration. The OS widget config activity stays on the legacy `ObjectTypeSelectionFragment` path. It is already documented as out-of-scope for the `CreateObjectWidgetConfigDI` in the spec, and the activity's use of `ObjectTypeSelectionFragment` is really "type selection for widget config," not "create an object."
+
+- [ ] **Step 1: Add a code comment documenting the exclusion**
+
+At the top of `showTypeSelectionDialog` in `CreateObjectWidgetConfigActivity.kt`, add:
+
+```kotlin
+// Note: This call site intentionally stays on ObjectTypeSelectionFragment.
+// The widget config activity selects a type for future creation (stored in preferences),
+// it does not create an object immediately. See create-object-migration spec.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/src/main/java/com/anytypeio/anytype/ui/oswidgets/CreateObjectWidgetConfigActivity.kt
+git commit -m "docs: document CreateObjectWidgetConfigActivity exclusion from create-object migration"
+```
+
+---
+
+### Task 14: Migrate MainActivity Deeplink Handling
+
+**Files:**
+- Modify: `app/src/main/java/com/anytypeio/anytype/ui/main/MainActivity.kt:169-176,375-391`
+
+- [ ] **Step 1: Add imports**
+
+```kotlin
+import com.anytypeio.anytype.BuildConfig
+import com.anytypeio.anytype.ui.create.CreateObjectDialogFragment
+```
+
+- [ ] **Step 2: Branch Command.OpenCreateNewType (lines 169-176)**
+
+Replace:
+
+```kotlin
+is Command.OpenCreateNewType -> {
+    findNavController(R.id.fragment)
+        .navigate(
+            R.id.action_global_createObjectFragment,
+            bundleOf(
+                CreateObjectFragment.TYPE_KEY to command.type
+            )
+        )
+}
+```
+
+With:
+
+```kotlin
+is Command.OpenCreateNewType -> {
+    if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+        val dialog = CreateObjectDialogFragment.new(
+            space = vm.getCurrentSpaceId(),
+            typeKey = command.type
+        )
+        dialog.show(supportFragmentManager, CreateObjectDialogFragment.TAG)
+    } else {
+        findNavController(R.id.fragment)
+            .navigate(
+                R.id.action_global_createObjectFragment,
+                bundleOf(
+                    CreateObjectFragment.TYPE_KEY to command.type
+                )
+            )
+    }
+}
+```
+
+Note: The exact method name `vm.getCurrentSpaceId()` may differ — check `MainViewModel` for how to get the current space ID.
+
+- [ ] **Step 3: Branch Command.Deeplink.OpenCreateObjectFromOsWidget (lines 375-391)**
+
+Apply the same branching pattern. The new path uses `CreateObjectDialogFragment.new(space = ..., typeKey = command.typeKey)` which will auto-create via the pre-selected typeKey in VmParams.
+
+- [ ] **Step 4: Add FragmentResultListener for navigation results**
+
+Register a result listener in the Activity that navigates to editor/set/chat using the nav controller, matching the existing navigation patterns.
+
+- [ ] **Step 5: Verify build compiles and commit**
+
+```bash
+git add app/src/main/java/com/anytypeio/anytype/ui/main/MainActivity.kt
+git commit -m "feat: migrate MainActivity deeplink handling to new create-object flow behind flag"
+```
+
+---
+
+### Task 15: Final Integration Test
+
+- [ ] **Step 1: Run all unit tests**
+
+Run: `./gradlew :feature-create-object:testDebugUnitTest`
+Expected: ALL PASS
+
+- [ ] **Step 2: Run full app compilation**
+
+Run: `./gradlew :app:assembleDebug`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Run lint check**
+
+Run: `./gradlew :app:lintDebug :feature-create-object:lintDebug`
+Expected: No new errors
+
+- [ ] **Step 4: Verify flag=false path (default)**
+
+Build and run the app. All create-object flows should behave identically to before (legacy path). Verify at least: home screen create, editor create, collection create.
+
+- [ ] **Step 5: Verify flag=true path**
+
+Change `USE_NEW_CREATE_OBJECT` to `true` in `app/build.gradle`, rebuild, and test:
+- Home screen → new bottom sheet appears
+- Pick a type → object created → navigated to editor
+- Pick a collection type → navigated to set view
+- Pick a chat type → navigated to chat
+
+- [ ] **Step 6: Reset flag to false and final commit**
+
+Reset `USE_NEW_CREATE_OBJECT` back to `false` in both build types, then:
+
+```bash
+git add app/build.gradle
+git commit -m "chore: reset USE_NEW_CREATE_OBJECT flag to false after validation"
+```

--- a/docs/superpowers/specs/2026-03-24-create-object-migration-design.md
+++ b/docs/superpowers/specs/2026-03-24-create-object-migration-design.md
@@ -1,0 +1,188 @@
+# Migrate Legacy Create-Object Flow to feature-create-object Module
+
+**Date:** 2026-03-24
+**Status:** Approved
+
+## Goal
+
+Replace the legacy `CreateObjectFragment`/`CreateObjectViewModel`/`SelectObjectTypeBaseFragment` flow with the new `feature-create-object` module across all call sites, behind a `BuildConfig` feature flag.
+
+## Context
+
+The `feature-create-object` module was introduced in commit `20822f0c4` (DROID-4201) with a redesigned UI (Compose-based bottom sheet and popup). It is fully built but not wired into any screen. The legacy flow is spread across 8+ screens via fragment-based listener interfaces.
+
+**Legacy code to replace:**
+- `CreateObjectFragment` + `CreateObjectViewModel` (creation + post-creation navigation)
+- `SelectObjectTypeBaseFragment` subclasses (`ObjectTypeSelectionFragment`, `WidgetSourceTypeFragment` — note: `WidgetSourceTypeFragment` is out of scope, different use case)
+- `SelectObjectTypeViewModel` (type listing with pin/default features — dropped in new flow)
+- Listener interfaces: `ObjectTypeSelectionListener`, `CollectionObjectTypeSelectionListener`
+- DI: `CreateObjectSubComponent`, `SelectObjectTypeComponent`
+- Nav graph: `action_global_createObjectFragment`
+
+**New code:**
+- `NewCreateObjectViewModel` (type listing + filtering + creation + navigation)
+- `CreateObjectBottomSheet` / `CreateObjectPopup` (Compose UI)
+- `CreateObjectFeatureComponent` (DI)
+
+## Design Decisions
+
+- **Templates:** Skip template picker — use default template via `CreateObjectByTypeAndTemplate` internally
+- **Pin/default type features:** Dropped — widget sort order is sufficient
+- **Feature flag:** `BuildConfig.USE_NEW_CREATE_OBJECT` (compile-time, rebuild to toggle)
+- **Cleanup:** Legacy code removed after one release cycle with flag set to `true`
+
+## Section 1: Feature Flag
+
+Add `USE_NEW_CREATE_OBJECT` boolean `buildConfigField` in `app/build.gradle`:
+
+```groovy
+buildTypes {
+    debug {
+        buildConfigField "boolean", "USE_NEW_CREATE_OBJECT", "false"
+    }
+    release {
+        buildConfigField "boolean", "USE_NEW_CREATE_OBJECT", "false"
+    }
+}
+```
+
+All branching uses `BuildConfig.USE_NEW_CREATE_OBJECT`.
+
+## Section 2: NewCreateObjectViewModel Expansion
+
+The VM currently handles type listing/filtering only. It must gain:
+
+### 2.1 Object Creation
+
+Add `CreateObjectByTypeAndTemplate` use case as a dependency. When `CreateObjectAction.CreateObjectOfType` is dispatched, the VM:
+1. Calls `CreateObjectByTypeAndTemplate` with the selected type key
+2. Emits a navigation result based on the created object's layout
+
+### 2.2 Navigation Result
+
+New sealed class emitted via `SharedFlow<CreateObjectNavigation>`:
+
+```kotlin
+sealed class CreateObjectNavigation {
+    data class OpenEditor(val id: Id, val space: SpaceId) : CreateObjectNavigation()
+    data class OpenSet(val id: Id, val space: SpaceId) : CreateObjectNavigation()
+    data class OpenChat(val id: Id, val space: SpaceId) : CreateObjectNavigation()
+}
+```
+
+Layout-to-destination mapping mirrors `CreateObjectFragment`'s existing logic:
+- `COLLECTION`, `SET` → `OpenSet`
+- `CHAT` → `OpenChat`
+- Everything else → `OpenEditor`
+
+### 2.3 VmParams Expansion
+
+Add optional `typeKey: Key?` parameter for pre-selected type scenarios (OS widget deeplinks).
+
+When `typeKey` is provided, the VM skips the type list and immediately creates the object.
+
+### 2.4 Dependencies
+
+`CreateObjectFeatureDependencies` interface gains:
+
+```kotlin
+fun createObjectByTypeAndTemplate(): CreateObjectByTypeAndTemplate
+fun spaceManager(): SpaceManager
+fun awaitAccountStartManager(): AwaitAccountStartManager
+```
+
+## Section 3: Call Site Migration
+
+Each screen branches on the flag. The 8 call sites:
+
+| Screen | File | Current | New |
+|--------|------|---------|-----|
+| WidgetsScreenFragment | `app/.../ui/home/WidgetsScreenFragment.kt` | `ObjectTypeSelectionFragment` | `CreateObjectBottomSheet` |
+| EditorFragment | `app/.../ui/editor/EditorFragment.kt` | `ObjectTypeSelectionFragment` | `CreateObjectBottomSheet` |
+| CollectionFragment | `app/.../ui/widgets/collection/CollectionFragment.kt` | `ObjectTypeSelectionFragment` | `CreateObjectBottomSheet` |
+| AllContentFragment | `app/.../ui/allcontent/AllContentFragment.kt` | `ObjectTypeSelectionFragment` | `CreateObjectBottomSheet` |
+| DateObjectFragment | `app/.../ui/date/DateObjectFragment.kt` | `ObjectTypeSelectionFragment` | `CreateObjectBottomSheet` |
+| ObjectSetFragment | `app/.../ui/sets/ObjectSetFragment.kt` | `ObjectTypeSelectionFragment` | `CreateObjectBottomSheet` |
+| SpaceSettingsFragment | `app/.../ui/settings/space/SpaceSettingsFragment.kt` | `ObjectTypeSelectionFragment` | `CreateObjectBottomSheet` |
+| CreateObjectWidgetConfigActivity | `app/.../ui/oswidgets/CreateObjectWidgetConfigActivity.kt` | `ObjectTypeSelectionFragment` | `CreateObjectBottomSheet` |
+
+### Migration pattern per call site:
+
+```kotlin
+if (BuildConfig.USE_NEW_CREATE_OBJECT) {
+    // 1. Get/create CreateObjectFeatureComponent from ComponentManager
+    // 2. Show CreateObjectBottomSheet (Compose in ComposeView or existing Compose host)
+    // 3. Collect CreateObjectNavigation from VM → navigate to editor/set/chat
+} else {
+    // Existing fragment-based flow (unchanged)
+}
+```
+
+### MainActivity deeplink handling (2 call sites):
+
+- `Command.OpenCreateNewType`: Branch on flag — new path launches bottom sheet with `VmParams(typeKey = typeKey)`
+- `Command.Deeplink.OpenCreateObjectFromOsWidget`: Same branching
+
+### Media actions forwarding:
+
+`SelectPhotos`, `TakePhoto`, `SelectFiles`, `AttachExistingObject` actions are forwarded from the bottom sheet to the calling screen via the action callback lambda. The calling screen handles them (camera intent, file picker, etc.).
+
+### Out of scope:
+
+- `WidgetSourceTypeFragment` / `WidgetSourceTypeListener` — different use case (selecting widget source type, not creating objects)
+
+## Section 4: DI Changes
+
+### CreateObjectFeatureComponent expansion:
+
+```kotlin
+@Component(dependencies = [CreateObjectFeatureDependencies::class])
+@PerScreen
+interface CreateObjectFeatureComponent {
+    // Factory stays the same, VmParams expanded
+}
+
+interface CreateObjectFeatureDependencies : ComponentDependencies {
+    fun storeOfObjectTypes(): StoreOfObjectTypes                    // existing
+    fun spaceViewSubscription(): SpaceViewSubscriptionContainer     // existing
+    fun createObjectByTypeAndTemplate(): CreateObjectByTypeAndTemplate // new
+    fun spaceManager(): SpaceManager                                 // new
+    fun awaitAccountStartManager(): AwaitAccountStartManager         // new
+}
+```
+
+### ComponentManager:
+
+Existing `createObjectFeatureComponent` entry unchanged structurally — `findComponentDependencies()` resolves new dependencies from `MainComponent` which already provides them.
+
+### No new components:
+
+Legacy `CreateObjectSubComponent` and `SelectObjectTypeComponent` remain for the old path behind the flag.
+
+## Section 5: Testing
+
+### Unit tests:
+
+Expand `NewCreateObjectViewModelTest` to cover:
+- Object creation success → correct `CreateObjectNavigation` emitted per layout type
+- Object creation failure → error state
+- Pre-selected `typeKey` → immediate creation without type list
+- No new test classes needed
+
+### Flag lifecycle:
+
+1. Ship with `USE_NEW_CREATE_OBJECT = false`
+2. QA validates with `true` in debug builds
+3. Flip to `true` for release after QA sign-off
+4. After one stable release cycle, remove:
+   - `BuildConfig` field
+   - All `if/else` branches (keep new path only)
+   - `CreateObjectFragment`, `CreateObjectViewModel`, `CreateObjectSubComponent`
+   - `SelectObjectTypeBaseFragment`, `ObjectTypeSelectionFragment`, `SelectObjectTypeViewModel`, `SelectObjectTypeComponent`
+   - `ObjectTypeSelectionListener`, `CollectionObjectTypeSelectionListener` interfaces
+   - Nav graph entry `createObjectFragment` and `action_global_createObjectFragment`
+
+### Permanently retained:
+
+- `WidgetSourceTypeFragment` / `WidgetSourceTypeListener`
+- `CreateObjectWidgetConfigDI` (OS widget config)

--- a/docs/superpowers/specs/2026-03-24-create-object-migration-design.md
+++ b/docs/superpowers/specs/2026-03-24-create-object-migration-design.md
@@ -60,7 +60,7 @@ Add `CreateObjectByTypeAndTemplate` use case as a dependency. When `CreateObject
 
 ### 2.2 Navigation Result
 
-New sealed class emitted via `SharedFlow<CreateObjectNavigation>`:
+New sealed class emitted via `Channel(Channel.BUFFERED)` exposed as `Flow` via `receiveAsFlow()` (not `SharedFlow`, to avoid losing one-shot events during config changes):
 
 ```kotlin
 sealed class CreateObjectNavigation {
@@ -72,24 +72,44 @@ sealed class CreateObjectNavigation {
 
 Layout-to-destination mapping mirrors `CreateObjectFragment`'s existing logic:
 - `COLLECTION`, `SET` → `OpenSet`
-- `CHAT` → `OpenChat`
+- `CHAT`, `CHAT_DERIVED` → `OpenChat`
 - Everything else → `OpenEditor`
+
+**Dismiss behavior:** The bottom sheet auto-dismisses before navigation to avoid remaining visible on back press. On creation failure, an error state is shown within the bottom sheet with a retry option (matching the existing error/retry pattern in `NewCreateObjectViewModel`).
 
 ### 2.3 VmParams Expansion
 
-Add optional `typeKey: Key?` parameter for pre-selected type scenarios (OS widget deeplinks).
+Add optional `typeKey: TypeKey?` parameter for pre-selected type scenarios (OS widget deeplinks). Note: use `TypeKey` wrapper class (not the `Key` string typealias) to match `CreateObjectByTypeAndTemplate.Param`.
 
 When `typeKey` is provided, the VM skips the type list and immediately creates the object.
 
 ### 2.4 Dependencies
 
+The VM needs `CreateObjectByTypeAndTemplate`, `SpaceManager`, and `AppCoroutineDispatchers`. These are provided via a **Dagger module inside the component** (not via the dependencies interface), matching the existing pattern in `CreateObjectDI.kt` (lines 37-46) where use cases are instantiated per-screen from lower-level deps.
+
+New `CreateObjectFeatureModule` added to the component:
+
+```kotlin
+@Module
+object CreateObjectFeatureModule {
+    @Provides
+    @PerScreen
+    fun provideCreateObjectByTypeAndTemplate(
+        repo: BlockRepository,
+        dispatchers: AppCoroutineDispatchers
+    ): CreateObjectByTypeAndTemplate = CreateObjectByTypeAndTemplate(repo, dispatchers)
+}
+```
+
 `CreateObjectFeatureDependencies` interface gains:
 
 ```kotlin
-fun createObjectByTypeAndTemplate(): CreateObjectByTypeAndTemplate
-fun spaceManager(): SpaceManager
-fun awaitAccountStartManager(): AwaitAccountStartManager
+fun blockRepository(): BlockRepository           // new — provided by MainComponent
+fun dispatchers(): AppCoroutineDispatchers        // new — provided by MainComponent
+fun spaceManager(): SpaceManager                  // new — provided by MainComponent
 ```
+
+`AwaitAccountStartManager` is **not** needed — the new VM is only used from within active screens where the account is already started. The OS widget deeplink path goes through `MainActivity` which already awaits account start before dispatching commands.
 
 ## Section 3: Call Site Migration
 
@@ -106,37 +126,57 @@ Each screen branches on the flag. The 8 call sites:
 | SpaceSettingsFragment | `app/.../ui/settings/space/SpaceSettingsFragment.kt` | `ObjectTypeSelectionFragment` | `CreateObjectBottomSheet` |
 | CreateObjectWidgetConfigActivity | `app/.../ui/oswidgets/CreateObjectWidgetConfigActivity.kt` | `ObjectTypeSelectionFragment` | `CreateObjectBottomSheet` |
 
+### Compose hosting approach — `CreateObjectDialogFragment` wrapper:
+
+Create a new `CreateObjectDialogFragment` (extends `BaseBottomSheetComposeFragment`) that:
+1. Hosts the `CreateObjectBottomSheet` composable
+2. Owns the `NewCreateObjectViewModel` (is the `ViewModelStoreOwner`)
+3. Injects via `ComponentManager.createObjectFeatureComponent`
+4. Releases the component in `onDestroy()`
+5. Communicates results back to the caller via `FragmentResult` API (`setFragmentResult`)
+
+This matches the existing pattern used by `ObjectTypeSelectionFragment` (which also extends a base compose fragment and is shown via `dialog.show(childFragmentManager, ...)`). All 8 call sites show this wrapper fragment the same way, regardless of whether the host is View-based or Compose-based.
+
 ### Migration pattern per call site:
 
 ```kotlin
 if (BuildConfig.USE_NEW_CREATE_OBJECT) {
-    // 1. Get/create CreateObjectFeatureComponent from ComponentManager
-    // 2. Show CreateObjectBottomSheet (Compose in ComposeView or existing Compose host)
-    // 3. Collect CreateObjectNavigation from VM → navigate to editor/set/chat
+    val dialog = CreateObjectDialogFragment.new(space = spaceId)
+    dialog.show(childFragmentManager, TAG)
+    // Listen for results via FragmentResultListener:
+    //   - CreateObjectNavigation → navigate to editor/set/chat
+    //   - CreateObjectAction (media) → handle camera/file picker
 } else {
     // Existing fragment-based flow (unchanged)
 }
 ```
 
-### MainActivity deeplink handling (2 call sites):
+### MainActivity deeplink handling (2 additional call sites):
 
-- `Command.OpenCreateNewType`: Branch on flag — new path launches bottom sheet with `VmParams(typeKey = typeKey)`
+These are distinct from the 8 UI call sites — they don't show a type picker. They directly create an object with a pre-known type.
+
+- `Command.OpenCreateNewType`: Branch on flag — new path instantiates `NewCreateObjectViewModel` with `VmParams(typeKey = typeKey)` for immediate creation, then navigates based on the result
 - `Command.Deeplink.OpenCreateObjectFromOsWidget`: Same branching
 
 ### Media actions forwarding:
 
-`SelectPhotos`, `TakePhoto`, `SelectFiles`, `AttachExistingObject` actions are forwarded from the bottom sheet to the calling screen via the action callback lambda. The calling screen handles them (camera intent, file picker, etc.).
+`SelectPhotos`, `TakePhoto`, `SelectFiles`, `AttachExistingObject` actions are forwarded from the dialog to the calling screen via `FragmentResult`. The calling screen handles them (camera intent, file picker, etc.).
 
 ### Out of scope:
 
 - `WidgetSourceTypeFragment` / `WidgetSourceTypeListener` — different use case (selecting widget source type, not creating objects)
+- `CollectionAddObjectTypeFragment` / `CollectionObjectTypeSelectionListener` — used by `ObjectSetFragment` for a different action (selecting a type for collection view filtering, not creating objects). Remains on the legacy path.
+- `AppDefaultObjectTypeFragment` — used by `SpaceSettingsFragment` for setting the default object type, not creating objects. Remains on the legacy path.
 
 ## Section 4: DI Changes
 
 ### CreateObjectFeatureComponent expansion:
 
 ```kotlin
-@Component(dependencies = [CreateObjectFeatureDependencies::class])
+@Component(
+    dependencies = [CreateObjectFeatureDependencies::class],
+    modules = [CreateObjectFeatureModule::class]
+)
 @PerScreen
 interface CreateObjectFeatureComponent {
     // Factory stays the same, VmParams expanded
@@ -145,15 +185,21 @@ interface CreateObjectFeatureComponent {
 interface CreateObjectFeatureDependencies : ComponentDependencies {
     fun storeOfObjectTypes(): StoreOfObjectTypes                    // existing
     fun spaceViewSubscription(): SpaceViewSubscriptionContainer     // existing
-    fun createObjectByTypeAndTemplate(): CreateObjectByTypeAndTemplate // new
-    fun spaceManager(): SpaceManager                                 // new
-    fun awaitAccountStartManager(): AwaitAccountStartManager         // new
+    fun blockRepository(): BlockRepository                          // new
+    fun dispatchers(): AppCoroutineDispatchers                      // new
+    fun spaceManager(): SpaceManager                                // new
 }
 ```
 
+All new dependencies (`BlockRepository`, `AppCoroutineDispatchers`, `SpaceManager`) are already provided by `MainComponent` and resolved via `findComponentDependencies()`.
+
 ### ComponentManager:
 
-Existing `createObjectFeatureComponent` entry unchanged structurally — `findComponentDependencies()` resolves new dependencies from `MainComponent` which already provides them.
+Existing `createObjectFeatureComponent` entry unchanged structurally — `findComponentDependencies()` resolves the new dependencies from `MainComponent`.
+
+### VM lifecycle and ownership:
+
+The `NewCreateObjectViewModel` is scoped to a new `CreateObjectDialogFragment` wrapper (see Section 3). The wrapper Fragment is the `ViewModelStoreOwner`. `ComponentManager.createObjectFeatureComponent.release()` is called in the wrapper's `onDestroy()`.
 
 ### No new components:
 
@@ -185,4 +231,8 @@ Expand `NewCreateObjectViewModelTest` to cover:
 ### Permanently retained:
 
 - `WidgetSourceTypeFragment` / `WidgetSourceTypeListener`
+- `CollectionAddObjectTypeFragment` / `CollectionObjectTypeSelectionListener`
+- `AppDefaultObjectTypeFragment`
 - `CreateObjectWidgetConfigDI` (OS widget config)
+
+Note: `ObjectTypeSelectionListener` interface is shared by some retained fragments. During cleanup, verify which listeners are still referenced before deleting.

--- a/docs/superpowers/specs/2026-03-24-create-object-migration-design.md
+++ b/docs/superpowers/specs/2026-03-24-create-object-migration-design.md
@@ -96,8 +96,9 @@ object CreateObjectFeatureModule {
     @PerScreen
     fun provideCreateObjectByTypeAndTemplate(
         repo: BlockRepository,
+        logger: Logger,
         dispatchers: AppCoroutineDispatchers
-    ): CreateObjectByTypeAndTemplate = CreateObjectByTypeAndTemplate(repo, dispatchers)
+    ): CreateObjectByTypeAndTemplate = CreateObjectByTypeAndTemplate(repo, logger, dispatchers)
 }
 ```
 
@@ -105,6 +106,7 @@ object CreateObjectFeatureModule {
 
 ```kotlin
 fun blockRepository(): BlockRepository           // new — provided by MainComponent
+fun logger(): Logger                             // new — provided by MainComponent
 fun dispatchers(): AppCoroutineDispatchers        // new — provided by MainComponent
 fun spaceManager(): SpaceManager                  // new — provided by MainComponent
 ```
@@ -186,6 +188,7 @@ interface CreateObjectFeatureDependencies : ComponentDependencies {
     fun storeOfObjectTypes(): StoreOfObjectTypes                    // existing
     fun spaceViewSubscription(): SpaceViewSubscriptionContainer     // existing
     fun blockRepository(): BlockRepository                          // new
+    fun logger(): Logger                                            // new
     fun dispatchers(): AppCoroutineDispatchers                      // new
     fun spaceManager(): SpaceManager                                // new
 }

--- a/docs/superpowers/specs/2026-03-24-create-object-migration-design.md
+++ b/docs/superpowers/specs/2026-03-24-create-object-migration-design.md
@@ -108,7 +108,6 @@ object CreateObjectFeatureModule {
 fun blockRepository(): BlockRepository           // new — provided by MainComponent
 fun logger(): Logger                             // new — provided by MainComponent
 fun dispatchers(): AppCoroutineDispatchers        // new — provided by MainComponent
-fun spaceManager(): SpaceManager                  // new — provided by MainComponent
 ```
 
 `AwaitAccountStartManager` is **not** needed — the new VM is only used from within active screens where the account is already started. The OS widget deeplink path goes through `MainActivity` which already awaits account start before dispatching commands.

--- a/docs/superpowers/specs/2026-03-24-create-object-migration-design.md
+++ b/docs/superpowers/specs/2026-03-24-create-object-migration-design.md
@@ -85,7 +85,7 @@ When `typeKey` is provided, the VM skips the type list and immediately creates t
 
 ### 2.4 Dependencies
 
-The VM needs `CreateObjectByTypeAndTemplate`, `SpaceManager`, and `AppCoroutineDispatchers`. These are provided via a **Dagger module inside the component** (not via the dependencies interface), matching the existing pattern in `CreateObjectDI.kt` (lines 37-46) where use cases are instantiated per-screen from lower-level deps.
+The VM needs `CreateObjectByTypeAndTemplate` and uses `vmParams.spaceId` directly (no `SpaceManager` needed). The use case is provided via a **Dagger module inside the component** (not via the dependencies interface), matching the existing pattern in `CreateObjectDI.kt` (lines 37-46) where use cases are instantiated per-screen from lower-level deps.
 
 New `CreateObjectFeatureModule` added to the component:
 
@@ -189,7 +189,6 @@ interface CreateObjectFeatureDependencies : ComponentDependencies {
     fun blockRepository(): BlockRepository                          // new
     fun logger(): Logger                                            // new
     fun dispatchers(): AppCoroutineDispatchers                      // new
-    fun spaceManager(): SpaceManager                                // new
 }
 ```
 

--- a/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/CreateObjectNavigation.kt
+++ b/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/CreateObjectNavigation.kt
@@ -1,0 +1,10 @@
+package com.anytypeio.anytype.feature_create_object.presentation
+
+import com.anytypeio.anytype.core_models.Id
+import com.anytypeio.anytype.core_models.primitives.SpaceId
+
+sealed class CreateObjectNavigation {
+    data class OpenEditor(val id: Id, val space: SpaceId) : CreateObjectNavigation()
+    data class OpenSet(val id: Id, val space: SpaceId) : CreateObjectNavigation()
+    data class OpenChat(val id: Id, val space: SpaceId) : CreateObjectNavigation()
+}

--- a/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/CreateObjectViewModelFactory.kt
+++ b/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/CreateObjectViewModelFactory.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
 import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
+import com.anytypeio.anytype.domain.page.CreateObjectByTypeAndTemplate
 import javax.inject.Inject
 
 /**
@@ -12,11 +13,13 @@ import javax.inject.Inject
  * @param storeOfObjectTypes Store for fetching object types
  * @param spaceViewContainer Container for observing space properties (needed for sort order)
  * @param vmParams Parameters including the current space ID
+ * @param createObjectByTypeAndTemplate Use case for creating objects by type and template
  */
 class CreateObjectViewModelFactory @Inject constructor(
     private val storeOfObjectTypes: StoreOfObjectTypes,
     private val spaceViewContainer: SpaceViewSubscriptionContainer,
-    private val vmParams: NewCreateObjectViewModel.VmParams
+    private val vmParams: NewCreateObjectViewModel.VmParams,
+    private val createObjectByTypeAndTemplate: CreateObjectByTypeAndTemplate
 ) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
@@ -24,7 +27,8 @@ class CreateObjectViewModelFactory @Inject constructor(
         return NewCreateObjectViewModel(
             storeOfObjectTypes = storeOfObjectTypes,
             spaceViewContainer = spaceViewContainer,
-            vmParams = vmParams
+            vmParams = vmParams,
+            createObjectByTypeAndTemplate = createObjectByTypeAndTemplate
         ) as T
     }
 }

--- a/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModel.kt
+++ b/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModel.kt
@@ -8,15 +8,20 @@ import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.core_models.SupportedLayouts
 import com.anytypeio.anytype.core_models.multiplayer.SpaceUxType
 import com.anytypeio.anytype.core_models.primitives.SpaceId
+import com.anytypeio.anytype.core_models.primitives.TypeKey
 import com.anytypeio.anytype.core_models.ui.objectIcon
+import com.anytypeio.anytype.domain.base.Resultat
 import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
 import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
+import com.anytypeio.anytype.domain.page.CreateObjectByTypeAndTemplate
 import com.anytypeio.anytype.presentation.objects.sortByTypePriority
 import javax.inject.Inject
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -30,18 +35,26 @@ import timber.log.Timber
  * @param storeOfObjectTypes Store containing all available object types
  * @param spaceViewContainer Container for observing space view properties
  * @param vmParams Parameters including the current space ID
+ * @param createObjectByTypeAndTemplate Use case for creating objects
  */
 class NewCreateObjectViewModel @Inject constructor(
     private val storeOfObjectTypes: StoreOfObjectTypes,
     private val spaceViewContainer: SpaceViewSubscriptionContainer,
-    private val vmParams: VmParams
+    private val vmParams: VmParams,
+    private val createObjectByTypeAndTemplate: CreateObjectByTypeAndTemplate
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(NewCreateObjectState())
     val state: StateFlow<NewCreateObjectState> = _state.asStateFlow()
 
+    private val _navigation = Channel<CreateObjectNavigation>(Channel.BUFFERED)
+    val navigation = _navigation.receiveAsFlow()
+
     init {
         observeObjectTypes()
+        vmParams.typeKey?.let { key ->
+            onCreateObject(typeKey = key, typeName = "")
+        }
     }
 
     /**
@@ -152,7 +165,6 @@ class NewCreateObjectViewModel @Inject constructor(
 
     /**
      * Handles actions from the UI.
-     * Only processes search actions internally; other actions are handled by parent components.
      *
      * @param action The action to process
      */
@@ -160,8 +172,59 @@ class NewCreateObjectViewModel @Inject constructor(
         when (action) {
             is CreateObjectAction.UpdateSearch -> onSearchQueryChanged(action.query)
             is CreateObjectAction.Retry -> retry()
-            // Other actions (media, create object, attach) are handled by the parent component
-            else -> { /* No-op */
+            is CreateObjectAction.CreateObjectOfType -> onCreateObject(
+                typeKey = TypeKey(action.typeKey),
+                typeName = action.typeName
+            )
+            else -> { /* Media actions handled by parent component */ }
+        }
+    }
+
+    private fun onCreateObject(typeKey: TypeKey, typeName: String) {
+        viewModelScope.launch {
+            val resultat = createObjectByTypeAndTemplate.async(
+                CreateObjectByTypeAndTemplate.Param(
+                    typeKey = typeKey,
+                    space = vmParams.spaceId,
+                    keys = emptyList()
+                )
+            )
+            when (resultat) {
+                is Resultat.Success -> {
+                    when (val result = resultat.value) {
+                        is CreateObjectByTypeAndTemplate.Result.Success -> {
+                            val layout = result.obj.layout
+                            val nav = when (layout) {
+                                ObjectType.Layout.COLLECTION,
+                                ObjectType.Layout.SET -> CreateObjectNavigation.OpenSet(
+                                    id = result.objectId,
+                                    space = vmParams.spaceId
+                                )
+                                ObjectType.Layout.CHAT,
+                                ObjectType.Layout.CHAT_DERIVED -> CreateObjectNavigation.OpenChat(
+                                    id = result.objectId,
+                                    space = vmParams.spaceId
+                                )
+                                else -> CreateObjectNavigation.OpenEditor(
+                                    id = result.objectId,
+                                    space = vmParams.spaceId
+                                )
+                            }
+                            _navigation.send(nav)
+                        }
+                        is CreateObjectByTypeAndTemplate.Result.ObjectTypeNotFound -> {
+                            _state.update { it.copy(error = "Object type not found") }
+                        }
+                    }
+                }
+                is Resultat.Failure -> {
+                    _state.update {
+                        it.copy(error = resultat.exception.message ?: "Failed to create object")
+                    }
+                }
+                is Resultat.Loading -> {
+                    // no-op: loading state not expected from async()
+                }
             }
         }
     }
@@ -169,8 +232,10 @@ class NewCreateObjectViewModel @Inject constructor(
     /**
      * Parameters for the ViewModel.
      * @param spaceId The current space ID, used to determine space type for sorting
+     * @param typeKey Optional pre-selected type key; if provided, object creation is triggered immediately
      */
     data class VmParams(
-        val spaceId: SpaceId
+        val spaceId: SpaceId,
+        val typeKey: TypeKey? = null
     )
 }

--- a/feature-create-object/src/test/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModelTest.kt
+++ b/feature-create-object/src/test/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModelTest.kt
@@ -4,11 +4,15 @@ import app.cash.turbine.test
 import com.anytypeio.anytype.core_models.ObjectType
 import com.anytypeio.anytype.core_models.ObjectTypeIds
 import com.anytypeio.anytype.core_models.ObjectWrapper
+import com.anytypeio.anytype.core_models.Payload
 import com.anytypeio.anytype.core_models.StubObjectType
 import com.anytypeio.anytype.core_models.multiplayer.SpaceUxType
 import com.anytypeio.anytype.core_models.primitives.SpaceId
+import com.anytypeio.anytype.core_models.primitives.TypeKey
+import com.anytypeio.anytype.domain.base.Resultat
 import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
 import com.anytypeio.anytype.domain.objects.DefaultStoreOfObjectTypes
+import com.anytypeio.anytype.domain.page.CreateObjectByTypeAndTemplate
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -21,6 +25,9 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -33,6 +40,7 @@ class NewCreateObjectViewModelTest {
 
     private lateinit var storeOfObjectTypes: DefaultStoreOfObjectTypes
     private lateinit var spaceViewContainer: FakeSpaceViewSubscriptionContainer
+    private val createObjectByTypeAndTemplate = mock<CreateObjectByTypeAndTemplate>()
 
     @Before
     fun setUp() {
@@ -442,14 +450,194 @@ class NewCreateObjectViewModelTest {
 
     // endregion
 
+    // region: Object Creation Navigation
+
+    @Test
+    fun `should emit OpenEditor navigation when object with basic layout is created`() = runTest {
+        // Arrange
+        spaceViewContainer.setSpaceUxType(SpaceUxType.DATA)
+        val objectId = "new-object-id"
+        val typeKey = TypeKey("ot-page")
+        val createdObj = ObjectWrapper.Basic(
+            mapOf(
+                "id" to objectId,
+                "layout" to ObjectType.Layout.BASIC.code.toDouble()
+            )
+        )
+        val createResult = CreateObjectByTypeAndTemplate.Result.Success(
+            objectId = objectId,
+            event = Payload(context = objectId, events = emptyList()),
+            typeKey = typeKey,
+            obj = createdObj
+        )
+        whenever(createObjectByTypeAndTemplate.async(any())).thenReturn(
+            Resultat.success(createResult)
+        )
+
+        val vm = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Act
+        vm.onAction(CreateObjectAction.CreateObjectOfType(typeKey = typeKey.key, typeName = "Page"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Assert
+        vm.navigation.test {
+            val nav = awaitItem()
+            assertTrue(nav is CreateObjectNavigation.OpenEditor)
+            assertEquals(objectId, (nav as CreateObjectNavigation.OpenEditor).id)
+            assertEquals(spaceId, nav.space)
+        }
+    }
+
+    @Test
+    fun `should emit OpenSet navigation when collection layout object is created`() = runTest {
+        // Arrange
+        spaceViewContainer.setSpaceUxType(SpaceUxType.DATA)
+        val objectId = "new-collection-id"
+        val typeKey = TypeKey("ot-collection")
+        val createdObj = ObjectWrapper.Basic(
+            mapOf(
+                "id" to objectId,
+                "layout" to ObjectType.Layout.COLLECTION.code.toDouble()
+            )
+        )
+        val createResult = CreateObjectByTypeAndTemplate.Result.Success(
+            objectId = objectId,
+            event = Payload(context = objectId, events = emptyList()),
+            typeKey = typeKey,
+            obj = createdObj
+        )
+        whenever(createObjectByTypeAndTemplate.async(any())).thenReturn(
+            Resultat.success(createResult)
+        )
+
+        val vm = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Act
+        vm.onAction(CreateObjectAction.CreateObjectOfType(typeKey = typeKey.key, typeName = "Collection"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Assert
+        vm.navigation.test {
+            val nav = awaitItem()
+            assertTrue(nav is CreateObjectNavigation.OpenSet)
+            assertEquals(objectId, (nav as CreateObjectNavigation.OpenSet).id)
+            assertEquals(spaceId, nav.space)
+        }
+    }
+
+    @Test
+    fun `should emit OpenChat navigation when chat layout object is created`() = runTest {
+        // Arrange
+        spaceViewContainer.setSpaceUxType(SpaceUxType.DATA)
+        val objectId = "new-chat-id"
+        val typeKey = TypeKey("ot-chat")
+        val createdObj = ObjectWrapper.Basic(
+            mapOf(
+                "id" to objectId,
+                "layout" to ObjectType.Layout.CHAT.code.toDouble()
+            )
+        )
+        val createResult = CreateObjectByTypeAndTemplate.Result.Success(
+            objectId = objectId,
+            event = Payload(context = objectId, events = emptyList()),
+            typeKey = typeKey,
+            obj = createdObj
+        )
+        whenever(createObjectByTypeAndTemplate.async(any())).thenReturn(
+            Resultat.success(createResult)
+        )
+
+        val vm = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Act
+        vm.onAction(CreateObjectAction.CreateObjectOfType(typeKey = typeKey.key, typeName = "Chat"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Assert
+        vm.navigation.test {
+            val nav = awaitItem()
+            assertTrue(nav is CreateObjectNavigation.OpenChat)
+            assertEquals(objectId, (nav as CreateObjectNavigation.OpenChat).id)
+            assertEquals(spaceId, nav.space)
+        }
+    }
+
+    @Test
+    fun `should show error state when object creation fails`() = runTest {
+        // Arrange
+        spaceViewContainer.setSpaceUxType(SpaceUxType.DATA)
+        val errorMessage = "Network error"
+        whenever(createObjectByTypeAndTemplate.async(any())).thenReturn(
+            Resultat.failure(RuntimeException(errorMessage))
+        )
+
+        val vm = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Act
+        vm.onAction(CreateObjectAction.CreateObjectOfType(typeKey = "ot-page", typeName = "Page"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Assert
+        vm.state.test {
+            val state = awaitItem()
+            assertEquals(errorMessage, state.error)
+        }
+    }
+
+    @Test
+    fun `should immediately create object when typeKey is pre-selected`() = runTest {
+        // Arrange
+        spaceViewContainer.setSpaceUxType(SpaceUxType.DATA)
+        val objectId = "pre-created-object-id"
+        val preSelectedTypeKey = TypeKey("ot-note")
+        val createdObj = ObjectWrapper.Basic(
+            mapOf(
+                "id" to objectId,
+                "layout" to ObjectType.Layout.NOTE.code.toDouble()
+            )
+        )
+        val createResult = CreateObjectByTypeAndTemplate.Result.Success(
+            objectId = objectId,
+            event = Payload(context = objectId, events = emptyList()),
+            typeKey = preSelectedTypeKey,
+            obj = createdObj
+        )
+        whenever(createObjectByTypeAndTemplate.async(any())).thenReturn(
+            Resultat.success(createResult)
+        )
+
+        // Act - create VM with pre-selected typeKey
+        val vm = createViewModel(typeKey = preSelectedTypeKey)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Assert - navigation is triggered automatically without any user action
+        vm.navigation.test {
+            val nav = awaitItem()
+            assertTrue(nav is CreateObjectNavigation.OpenEditor)
+            assertEquals(objectId, (nav as CreateObjectNavigation.OpenEditor).id)
+            assertEquals(spaceId, nav.space)
+        }
+    }
+
+    // endregion
+
     // region: Helpers
 
-    private fun createViewModel(): NewCreateObjectViewModel {
-        val vmParams = NewCreateObjectViewModel.VmParams(spaceId = spaceId)
+    private fun createViewModel(typeKey: TypeKey? = null): NewCreateObjectViewModel {
+        val vmParams = NewCreateObjectViewModel.VmParams(
+            spaceId = spaceId,
+            typeKey = typeKey
+        )
         return NewCreateObjectViewModel(
             storeOfObjectTypes = storeOfObjectTypes,
             spaceViewContainer = spaceViewContainer,
-            vmParams = vmParams
+            vmParams = vmParams,
+            createObjectByTypeAndTemplate = createObjectByTypeAndTemplate
         )
     }
 

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/main/MainViewModel.kt
@@ -351,7 +351,8 @@ class MainViewModel(
                 onFailure = { e -> Timber.e(e, "Error while checking auth status") },
                 onSuccess = { (status, account) ->
                     if (status == AuthStatus.AUTHORIZED) {
-                        commands.emit(Command.OpenCreateNewType(type))
+                        val space = spaceManager.get()
+                        commands.emit(Command.OpenCreateNewType(type = type, space = space))
                     }
                 }
             )
@@ -374,7 +375,7 @@ class MainViewModel(
                     .onSuccess { config ->
                         Timber.d("onCreateObjectFromWidget: switched to space $spaceId successfully, config=$config")
                         Timber.d("onCreateObjectFromWidget: emitting OpenCreateObjectFromOsWidget with typeKey=$typeKey")
-                        commands.emit(Command.Deeplink.OpenCreateObjectFromOsWidget(typeKey = typeKey))
+                        commands.emit(Command.Deeplink.OpenCreateObjectFromOsWidget(space = spaceId, typeKey = typeKey))
                     }
                     .onFailure { e ->
                         Timber.e(e, "onCreateObjectFromWidget: failed to switch space to $spaceId")
@@ -382,7 +383,7 @@ class MainViewModel(
                     }
             } else {
                 Timber.d("onCreateObjectFromWidget: already in space $spaceId, emitting create command")
-                commands.emit(Command.Deeplink.OpenCreateObjectFromOsWidget(typeKey = typeKey))
+                commands.emit(Command.Deeplink.OpenCreateObjectFromOsWidget(space = spaceId, typeKey = typeKey))
             }
         }
     }
@@ -895,7 +896,7 @@ class MainViewModel(
     sealed class Command {
         data class ShowDeletedAccountScreen(val deadline: Long) : Command()
         data object LogoutDueToAccountDeletion : Command()
-        class OpenCreateNewType(val type: Id) : Command()
+        class OpenCreateNewType(val type: Id, val space: Id) : Command()
         data class Error(val msg: String) : Command()
 
         data object Notifications : Command()
@@ -974,6 +975,7 @@ class MainViewModel(
              * Emitted by onCreateObjectFromWidget after successful space switch.
              */
             data class OpenCreateObjectFromOsWidget(
+                val space: Id,
                 val typeKey: String
             ) : Deeplink()
         }


### PR DESCRIPTION
## Summary

- Replaces the legacy `CreateObjectFragment`/`SelectObjectTypeBaseFragment` flow with the new Compose-based `feature-create-object` module across all call sites
- Gated behind `BuildConfig.USE_NEW_CREATE_OBJECT` feature flag (default `false`) for safe rollout
- Expands `NewCreateObjectViewModel` with end-to-end object creation + navigation (type selection → create → route to editor/set/chat)

## Changes

- **Feature flag**: `USE_NEW_CREATE_OBJECT` in `app/build.gradle` (debug + release)
- **ViewModel**: Added `CreateObjectByTypeAndTemplate` use case, `Channel`-based navigation events, pre-selected `typeKey` support
- **DI**: Expanded `CreateObjectFeatureComponent` with `CreateObjectFeatureModule` providing the use case
- **Dialog wrapper**: New `CreateObjectDialogFragment` hosting `CreateObjectContent` composable via `BaseBottomSheetComposeFragment`
- **6 call sites migrated**: WidgetsScreen, Editor, Collection, AllContent, DateObject, ObjectSet fragments
- **2 deeplink call sites migrated**: `MainActivity` `OpenCreateNewType` + `OpenCreateObjectFromOsWidget`
- **Excluded** (documented): `CreateObjectWidgetConfigActivity` (different use case — type selection for widget config, not object creation), `SpaceSettingsFragment` (uses `AppDefaultObjectTypeFragment`)

## Out of scope

- `WidgetSourceTypeFragment` / `WidgetSourceTypeListener` (widget source selection)
- `CollectionAddObjectTypeFragment` / `CollectionObjectTypeSelectionListener` (collection view filtering)
- `AppDefaultObjectTypeFragment` (default type setting)
- Template picker (uses default template via `CreateObjectByTypeAndTemplate`)

## Test plan

- [ ] Verify with flag `false` (default): all create-object flows work identically to before
- [ ] Set flag to `true`, rebuild: verify new bottom sheet appears on home, editor, collection, all-content, date, set screens
- [ ] With flag `true`: create a Page → opens editor; create a Collection → opens set view; create a Chat → opens chat
- [ ] With flag `true`: test OS widget deeplink creates object correctly
- [ ] Run `./gradlew :feature-create-object:testDebugUnitTest` — 21 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)