### PR TITLE
DROID-4283 Editor | Fix long-press to select block

### DIFF
--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/EditorTouchProcessor.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/EditorTouchProcessor.kt
@@ -9,7 +9,6 @@ import android.text.style.ClickableSpan
 import android.view.HapticFeedbackConstants
 import android.view.MotionEvent
 import android.view.View
-import com.anytypeio.anytype.core_ui.extensions.disable
 import com.anytypeio.anytype.core_ui.widgets.text.TextInputWidget
 import timber.log.Timber
 import kotlin.math.abs
@@ -51,7 +50,8 @@ class EditorTouchProcessor(
 
     fun process(v: View, event: MotionEvent?): Boolean {
         event ?: return fallback(null)
-        lastEvent = event
+        lastEvent?.recycle()
+        lastEvent = MotionEvent.obtain(event)
 
         when (event.action) {
             MotionEvent.ACTION_DOWN -> {
@@ -77,6 +77,7 @@ class EditorTouchProcessor(
                             Timber.d("Triggering drag: movement detected after long press")
                             actionHandler.removeCallbacksAndMessages(null)
                             dndTriggered = true
+                            v.emulateHapticFeedback()
                             onDragAndDropTrigger(event)
                         }
                     }

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/EditorTouchProcessor.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/EditorTouchProcessor.kt
@@ -34,20 +34,18 @@ class EditorTouchProcessor(
     private var actionUpStartInMillis: Long = 0
     private var lastEvent: MotionEvent? = null
     private var isDragging: Boolean = false
+    private var dndTriggered: Boolean = false
+
+    private val dragSlop get() = touchSlop * DRAG_SLOP_MULTIPLIER
 
     private val dragAndDropTimeoutRunnable = Runnable {
-        val delta = if (moves.size > 1) abs(moves.last() - moves.first()) else 0f
-
-        if (!isDragging && delta <= touchSlop) {
-            Timber.d("Triggering drag due to long press without movement")
-            onDragAndDropTrigger(lastEvent)
-        } else if (isDragging) {
+        if (isDragging) {
             Timber.d("Triggering drag due to long press with movement")
+            dndTriggered = true
             onDragAndDropTrigger(lastEvent)
         } else {
-            Timber.d("Skipping drag trigger")
+            Timber.d("Long press without movement, selection will be handled on ACTION_UP")
         }
-
         moves.clear()
     }
 
@@ -60,6 +58,7 @@ class EditorTouchProcessor(
                 Timber.d("ACTION DOWN")
                 actionUpStartInMillis = SystemClock.elapsedRealtime()
                 isDragging = false
+                dndTriggered = false
                 moves.clear()
                 actionHandler.postDelayed(dragAndDropTimeoutRunnable, DND_TIMEOUT)
             }
@@ -71,8 +70,15 @@ class EditorTouchProcessor(
                 if (moves.size > 1) {
                     val delta = abs(moves.last() - moves.first())
                     Timber.d("ACTION MOVE DELTA: $delta")
-                    if (delta > touchSlop) {
+                    if (delta > dragSlop && !isDragging) {
                         isDragging = true
+                        val elapsed = actionUpStartInMillis.untilNow()
+                        if (elapsed >= LONG_PRESS_TIMEOUT && !dndTriggered) {
+                            Timber.d("Triggering drag: movement detected after long press")
+                            actionHandler.removeCallbacksAndMessages(null)
+                            dndTriggered = true
+                            onDragAndDropTrigger(event)
+                        }
                     }
                 }
             }
@@ -128,6 +134,7 @@ class EditorTouchProcessor(
     companion object {
         val LONG_PRESS_TIMEOUT: Long = android.view.ViewConfiguration.getLongPressTimeout().toLong()
         val DND_TIMEOUT: Long = 2 * LONG_PRESS_TIMEOUT
+        private const val DRAG_SLOP_MULTIPLIER = 2
     }
 
     private fun View.emulateHapticFeedback() {

--- a/core-ui/src/test/java/com/anytypeio/anytype/core_ui/features/editor/EditorTouchProcessorTest.kt
+++ b/core-ui/src/test/java/com/anytypeio/anytype/core_ui/features/editor/EditorTouchProcessorTest.kt
@@ -1,0 +1,214 @@
+package com.anytypeio.anytype.core_ui.features.editor
+
+import android.os.Build
+import android.os.SystemClock
+import android.view.MotionEvent
+import android.view.View
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import android.os.Looper
+import java.time.Duration
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@Config(sdk = [Build.VERSION_CODES.P])
+@RunWith(RobolectricTestRunner::class)
+class EditorTouchProcessorTest {
+
+    private lateinit var processor: EditorTouchProcessor
+    private lateinit var view: View
+
+    private var longClickCount = 0
+    private var dndTriggerCount = 0
+    private var fallbackCount = 0
+
+    private val touchSlop = 10
+
+    @Before
+    fun setup() {
+        longClickCount = 0
+        dndTriggerCount = 0
+        fallbackCount = 0
+
+        processor = EditorTouchProcessor(
+            touchSlop = touchSlop,
+            fallback = { fallbackCount++; false },
+            onLongClick = { longClickCount++ },
+            onDragAndDropTrigger = { dndTriggerCount++ }
+        )
+
+        view = View(ApplicationProvider.getApplicationContext()).apply {
+            setOnLongClickListener { true }
+        }
+    }
+
+    // -- Helpers --
+
+    private fun downEvent(y: Float = 100f): MotionEvent {
+        val time = SystemClock.uptimeMillis()
+        return MotionEvent.obtain(time, time, MotionEvent.ACTION_DOWN, 0f, y, 0)
+    }
+
+    private fun moveEvent(y: Float): MotionEvent {
+        val time = SystemClock.uptimeMillis()
+        return MotionEvent.obtain(time, time, MotionEvent.ACTION_MOVE, 0f, y, 0)
+    }
+
+    private fun upEvent(y: Float = 100f): MotionEvent {
+        val time = SystemClock.uptimeMillis()
+        return MotionEvent.obtain(time, time, MotionEvent.ACTION_UP, 0f, y, 0)
+    }
+
+    private fun advanceTime(millis: Long) {
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(millis))
+    }
+
+    // -- Tests --
+
+    @Test
+    fun `hold still for 500ms then release triggers selection`() {
+        processor.process(view, downEvent())
+
+        advanceTime(EditorTouchProcessor.LONG_PRESS_TIMEOUT)
+
+        processor.process(view, upEvent())
+
+        assertEquals(1, longClickCount, "onLongClick should have been called")
+        assertEquals(0, dndTriggerCount, "onDragAndDropTrigger should not have been called")
+    }
+
+    @Test
+    fun `hold still for more than DND_TIMEOUT then release triggers selection not drag`() {
+        processor.process(view, downEvent())
+
+        // Advance past DND_TIMEOUT — the timeout runnable fires but should NOT trigger DnD
+        advanceTime(EditorTouchProcessor.DND_TIMEOUT + 100)
+
+        processor.process(view, upEvent())
+
+        assertEquals(1, longClickCount, "onLongClick should have been called")
+        assertEquals(0, dndTriggerCount, "onDragAndDropTrigger should not have been called")
+    }
+
+    @Test
+    fun `micro-trembling within drag slop treated as still hold - triggers selection`() {
+        val dragSlop = touchSlop * 2
+        val microMovement = (dragSlop - 1).toFloat()
+
+        processor.process(view, downEvent(y = 100f))
+
+        // Simulate small finger movements within drag slop
+        advanceTime(100)
+        processor.process(view, moveEvent(y = 100f + microMovement / 2))
+        advanceTime(100)
+        processor.process(view, moveEvent(y = 100f + microMovement))
+
+        // Wait past long press timeout
+        advanceTime(EditorTouchProcessor.DND_TIMEOUT)
+
+        processor.process(view, upEvent(y = 100f + microMovement))
+
+        assertEquals(1, longClickCount, "onLongClick should have been called")
+        assertEquals(0, dndTriggerCount, "Micro-trembling should not trigger drag")
+    }
+
+    @Test
+    fun `deliberate movement beyond drag slop after long press triggers drag`() {
+        val dragSlop = touchSlop * 2
+        val bigMovement = (dragSlop + 5).toFloat()
+
+        processor.process(view, downEvent(y = 100f))
+
+        // Wait past long press timeout
+        advanceTime(EditorTouchProcessor.LONG_PRESS_TIMEOUT + 100)
+
+        // First move to register baseline
+        processor.process(view, moveEvent(y = 100f))
+        // Big move beyond drag slop
+        processor.process(view, moveEvent(y = 100f + bigMovement))
+
+        assertEquals(1, dndTriggerCount, "onDragAndDropTrigger should have been called")
+        assertEquals(0, longClickCount, "onLongClick should not have been called")
+    }
+
+    @Test
+    fun `movement beyond drag slop before long press timeout - drag starts at timeout`() {
+        val dragSlop = touchSlop * 2
+        val bigMovement = (dragSlop + 5).toFloat()
+
+        processor.process(view, downEvent(y = 100f))
+
+        // Move beyond threshold quickly (before LONG_PRESS_TIMEOUT)
+        advanceTime(100)
+        processor.process(view, moveEvent(y = 100f))
+        processor.process(view, moveEvent(y = 100f + bigMovement))
+
+        // DnD should not have triggered yet (long press not elapsed)
+        assertEquals(0, dndTriggerCount, "DnD should not trigger before long press timeout")
+
+        // Now let the DND_TIMEOUT fire
+        advanceTime(EditorTouchProcessor.DND_TIMEOUT)
+
+        assertEquals(1, dndTriggerCount, "DnD should trigger when timeout fires with isDragging=true")
+        assertEquals(0, longClickCount, "onLongClick should not have been called")
+    }
+
+    @Test
+    fun `quick tap does not trigger selection or drag`() {
+        processor.process(view, downEvent())
+
+        // Release quickly (before LONG_PRESS_TIMEOUT)
+        advanceTime(100)
+
+        processor.process(view, upEvent())
+
+        assertEquals(0, longClickCount, "Quick tap should not trigger selection")
+        assertEquals(0, dndTriggerCount, "Quick tap should not trigger drag")
+        assertTrue(fallbackCount > 0, "Quick tap should fall through to fallback")
+    }
+
+    @Test
+    fun `drag is not double-triggered by both timeout and ACTION_MOVE`() {
+        val dragSlop = touchSlop * 2
+        val bigMovement = (dragSlop + 5).toFloat()
+
+        processor.process(view, downEvent(y = 100f))
+
+        // Move beyond threshold early
+        advanceTime(100)
+        processor.process(view, moveEvent(y = 100f))
+        processor.process(view, moveEvent(y = 100f + bigMovement))
+
+        // Let timeout fire (isDragging is true, so timeout also triggers DnD)
+        advanceTime(EditorTouchProcessor.DND_TIMEOUT)
+
+        // Only one DnD trigger should have happened total
+        assertEquals(1, dndTriggerCount, "DnD should only be triggered once")
+    }
+
+    @Test
+    fun `hold still past DND_TIMEOUT then move triggers drag immediately`() {
+        val dragSlop = touchSlop * 2
+        val bigMovement = (dragSlop + 5).toFloat()
+
+        processor.process(view, downEvent(y = 100f))
+
+        // Hold still past DND_TIMEOUT
+        advanceTime(EditorTouchProcessor.DND_TIMEOUT + 100)
+
+        assertEquals(0, dndTriggerCount, "No DnD yet — finger hasn't moved")
+
+        // Now start moving
+        processor.process(view, moveEvent(y = 100f))
+        processor.process(view, moveEvent(y = 100f + bigMovement))
+
+        assertEquals(1, dndTriggerCount, "DnD should trigger immediately on movement")
+        assertEquals(0, longClickCount, "onLongClick should not have been called")
+    }
+}


### PR DESCRIPTION
## Summary
- Long-press without movement now always triggers block selection, regardless of hold duration (previously, holding >1s started drag mode)
- Increased drag detection threshold to 2x system touch slop (~16dp) to prevent natural finger trembling from triggering drag
- Drag-and-drop now only starts when the user deliberately moves their finger during a long press

## Test plan
- [ ] Long-press a text block, hold still for 1s, release → block should be selected
- [ ] Long-press a text block, hold still for 3s, release → block should still be selected
- [ ] Long-press and deliberately drag → drag-and-drop should work
- [ ] Micro-trembling during hold → should NOT trigger drag
- [ ] Long-press in multi-select mode → should toggle selection
- [ ] Verify haptic feedback works on long press
- [ ] Quick tap on block → should behave as before (focus/edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)