### PR TITLE
DROID-4445 Editor | Fix keyboard not opening on new objects

### DIFF
--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/holders/other/Code.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/holders/other/Code.kt
@@ -218,12 +218,12 @@ class Code(
             post {
                 if (!hasFocus()) {
                     if (requestFocus()) {
-                        context.imm().showSoftInput(this, InputMethodManager.SHOW_FORCED)
+                        context.imm().showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
                     } else {
                         Timber.d("Couldn't gain focus")
                     }
                 } else {
-                    Timber.d("Already had focus")
+                    context.imm().showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
                 }
             }
         }

--- a/core-utils/src/main/java/com/anytypeio/anytype/core_utils/ext/ViewExtensions.kt
+++ b/core-utils/src/main/java/com/anytypeio/anytype/core_utils/ext/ViewExtensions.kt
@@ -121,12 +121,12 @@ fun EditText.showKeyboard() {
         this.apply {
             if (!hasFocus()) {
                 if (requestFocus()) {
-                    context.imm().showSoftInput(this, InputMethodManager.SHOW_FORCED)
+                    context.imm().showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
                 } else {
                     Timber.d("Couldn't gain focus")
                 }
             } else {
-                Timber.d("Already had focus")
+                context.imm().showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
             }
         }
     }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
@@ -1175,7 +1175,7 @@ class EditorViewModel(
     }
 
     //TODO need refactoring, logic must depend on Object Layouts
-    private fun onStartFocusing(payload: Payload) {
+    private suspend fun onStartFocusing(payload: Payload) {
         val event = payload.events.find { it is Event.Command.ShowObject }
         if (event is Event.Command.ShowObject) {
             val root = event.blocks.find { it.id == context }
@@ -1195,7 +1195,7 @@ class EditorViewModel(
                                     target = Editor.Focus.Target.Block(title.id),
                                     cursor = Editor.Cursor.End
                                 )
-                                viewModelScope.launch { orchestrator.stores.focus.update(focus) }
+                                orchestrator.stores.focus.update(focus)
                             } else {
                                 Timber.d("Skipping initial focusing. Title is not empty or is null")
                             }
@@ -1213,7 +1213,7 @@ class EditorViewModel(
                                 target = Editor.Focus.Target.Block(block.id),
                                 cursor = Editor.Cursor.End
                             )
-                            viewModelScope.launch { orchestrator.stores.focus.update(focus) }
+                            orchestrator.stores.focus.update(focus)
                         }
                     }
                 }
@@ -3227,8 +3227,10 @@ class EditorViewModel(
                                     target = Editor.Focus.Target.Block(last.id),
                                     cursor = null
                                 )
-                                viewModelScope.launch { orchestrator.stores.focus.update(focus) }
-                                viewModelScope.launch { refresh() }
+                                viewModelScope.launch {
+                                    orchestrator.stores.focus.update(focus)
+                                    refresh()
+                                }
                             } else {
                                 Timber.d("Outside click is ignored because focus is not empty")
                             }


### PR DESCRIPTION
## Summary
- Fix race condition in `EditorViewModel.onStartFocusing()` where focus store update was launched in a separate coroutine, racing with the render pipeline — the first render could have empty focus, so no block was focused and no keyboard appeared
- Fix same race pattern in `onOutsideClicked` where `focus.update()` and `refresh()` were in separate coroutines
- Fix `showKeyboard()` and `Code.focus()` to call `showSoftInput` even when the view already has focus, and replace deprecated `SHOW_FORCED` with `SHOW_IMPLICIT`

## Test plan
- [ ] Create a new Note → keyboard should auto-open when content loads
- [ ] Tap on empty area below blocks → keyboard should open immediately
- [ ] Tap on a code block that already has focus → keyboard should re-appear
- [ ] Verify existing editor focus/keyboard behavior is not regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)