### PR TITLE
DROID-4318 Navigation | Fix | Skip widget injection when homepage is an explicit object

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/di/feature/AllContentDI.kt
+++ b/app/src/main/java/com/anytypeio/anytype/di/feature/AllContentDI.kt
@@ -10,6 +10,7 @@ import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
 import com.anytypeio.anytype.domain.block.repo.BlockRepository
 import com.anytypeio.anytype.domain.config.UserSettingsRepository
 import com.anytypeio.anytype.domain.debugging.Logger
+import com.anytypeio.anytype.domain.event.interactor.SpaceSyncAndP2PStatusProvider
 import com.anytypeio.anytype.domain.launch.GetDefaultObjectType
 import com.anytypeio.anytype.domain.library.StorelessSubscriptionContainer
 import com.anytypeio.anytype.domain.misc.LocaleProvider
@@ -161,4 +162,5 @@ interface AllContentDependencies : ComponentDependencies {
     fun searchObjects(): SearchObjects
     fun fieldsProvider(): FieldParser
     fun spaceViews(): SpaceViewSubscriptionContainer
+    fun provideSpaceSyncAndP2PStatusProvider(): SpaceSyncAndP2PStatusProvider
 }

--- a/app/src/main/java/com/anytypeio/anytype/di/feature/MainEntryDI.kt
+++ b/app/src/main/java/com/anytypeio/anytype/di/feature/MainEntryDI.kt
@@ -27,6 +27,7 @@ import com.anytypeio.anytype.domain.multiplayer.SpaceInviteResolver
 import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
 import com.anytypeio.anytype.domain.notifications.SystemNotificationService
 import com.anytypeio.anytype.domain.platform.InitialParamsProvider
+import com.anytypeio.anytype.domain.spaces.ResolveSpaceHomepage
 import com.anytypeio.anytype.domain.subscriptions.GlobalSubscriptionManager
 import com.anytypeio.anytype.domain.theme.GetTheme
 import com.anytypeio.anytype.domain.vault.SetSpacesIntroductionShown
@@ -102,6 +103,7 @@ object MainEntryModule {
         chatsDetailsSubscriptionContainer: ChatsDetailsSubscriptionContainer,
         participantSubscriptionContainer: ParticipantSubscriptionContainer,
         userSettingsRepository: UserSettingsRepository,
+        resolveSpaceHomepage: ResolveSpaceHomepage,
         debugRunProfiler: DebugRunProfiler
     ): MainViewModelFactory = MainViewModelFactory(
         resumeAccount = resumeAccount,
@@ -133,6 +135,7 @@ object MainEntryModule {
         chatsDetailsSubscriptionContainer = chatsDetailsSubscriptionContainer,
         participantSubscriptionContainer = participantSubscriptionContainer,
         userSettingsRepository = userSettingsRepository,
+        resolveSpaceHomepage = resolveSpaceHomepage,
         debugRunProfiler = debugRunProfiler
     )
 

--- a/app/src/main/java/com/anytypeio/anytype/ui/allcontent/AllContentFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/allcontent/AllContentFragment.kt
@@ -5,8 +5,20 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
@@ -24,16 +36,17 @@ import com.anytypeio.anytype.core_utils.ext.subscribe
 import com.anytypeio.anytype.core_utils.ext.toast
 import com.anytypeio.anytype.core_utils.insets.EDGE_TO_EDGE_MIN_SDK
 import com.anytypeio.anytype.core_utils.intents.ActivityCustomTabsHelper
+import com.anytypeio.anytype.core_ui.syncstatus.SpaceSyncStatusScreen
 import com.anytypeio.anytype.core_utils.ui.BaseComposeFragment
 import com.anytypeio.anytype.di.common.componentManager
 import com.anytypeio.anytype.feature_allcontent.presentation.AllContentViewModel
 import com.anytypeio.anytype.feature_allcontent.presentation.AllContentViewModelFactory
 import com.anytypeio.anytype.feature_allcontent.ui.AllContentNavigation.ALL_CONTENT_MAIN
 import com.anytypeio.anytype.feature_allcontent.ui.AllContentWrapperScreen
-import com.anytypeio.anytype.presentation.navigation.NavPanelState
+import com.anytypeio.anytype.presentation.sync.SyncStatusWidgetState
 import com.anytypeio.anytype.presentation.widgets.collection.Subscription
 import com.anytypeio.anytype.ui.base.navigation
-import com.anytypeio.anytype.ui.home.WidgetsScreenFragment
+import com.anytypeio.anytype.ui.home.WidgetOverlayFragment
 import com.anytypeio.anytype.ui.multiplayer.ShareSpaceFragment
 import com.anytypeio.anytype.ui.objects.creation.ObjectTypeSelectionFragment
 import com.anytypeio.anytype.ui.objects.types.pickers.ObjectTypeSelectionListener
@@ -220,6 +233,16 @@ class AllContentFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
                         toast("Failed to open URL")
                     }
                 }
+                AllContentViewModel.Command.OpenWidgets -> {
+                    runCatching {
+                        WidgetOverlayFragment.show(
+                            parentFragmentManager,
+                            space
+                        )
+                    }.onFailure { e ->
+                        Timber.e(e, "Error opening widget overlay from All Objects screen")
+                    }
+                }
             }
         }
     }
@@ -239,6 +262,8 @@ class AllContentFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
                     uiTitleState = vm.uiTitleState.collectAsStateWithLifecycle().value,
                     uiMenuState = vm.uiMenuState.collectAsStateWithLifecycle().value,
                     uiSnackbarState = vm.uiSnackbarState.collectAsStateWithLifecycle().value,
+                    uiSyncStatusBadgeState = vm.uiSyncStatusBadgeState
+                        .collectAsStateWithLifecycle().value,
                     onSortClick = vm::onSortClicked,
                     onModeClick = vm::onAllContentModeClicked,
                     onItemClicked = vm::onItemClicked,
@@ -247,30 +272,23 @@ class AllContentFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
                     canPaginate = vm.canPaginate.collectAsStateWithLifecycle().value,
                     onUpdateLimitSearch = vm::updateLimit,
                     uiContentState = vm.uiContentState.collectAsStateWithLifecycle().value,
-                    onGlobalSearchClicked = vm::onGlobalSearchClicked,
                     onAddDocClicked = vm::onAddDockClicked,
                     onCreateObjectLongClicked = {
                         val dialog = ObjectTypeSelectionFragment.new(space = space)
                         dialog.show(childFragmentManager, null)
                     },
                     onBackClicked = vm::onBackClicked,
+                    onTitleClick = vm::onTopBarTitleClicked,
+                    onSyncStatusClick = vm::onSyncStatusBadgeClicked,
                     moveToBin = vm::proceedWithMoveToBin,
-                    onBackLongClicked = {
-                        // Currently not used.
-                        runCatching {
-                            findNavController().navigate(
-                                R.id.actionExitToSpaceWidgets,
-                                WidgetsScreenFragment.args(space = space)
-                            )
-                        }.onFailure {
-                            Timber.e(it, "Error while opening space switcher from all-content screen")
-                        }
-                    },
                     undoMoveToBin = vm::proceedWithUndoMoveToBin,
-                    onDismissSnackbar = vm::proceedWithDismissSnackbar,
-                    uiBottomMenu = vm.navPanelState.collectAsStateWithLifecycle(NavPanelState.Init).value,
-                    onShareButtonClicked = vm::onMemberButtonClicked,
-                    onHomeButtonClicked = vm::onHomeClicked
+                    onDismissSnackbar = vm::proceedWithDismissSnackbar
+                )
+                val syncStatusWidgetState by vm.uiSyncStatusWidgetState
+                    .collectAsStateWithLifecycle()
+                BottomSyncStatus(
+                    uiSyncStatusState = syncStatusWidgetState,
+                    onDismiss = vm::onSyncStatusDismiss
                 )
             }
         }
@@ -312,5 +330,27 @@ class AllContentFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
 
         const val ARG_SPACE = "arg.all.content.space"
         fun args(space: Id): Bundle = bundleOf(ARG_SPACE to space)
+    }
+}
+
+@Composable
+private fun BottomSyncStatus(
+    uiSyncStatusState: SyncStatusWidgetState,
+    onDismiss: () -> Unit
+) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.BottomCenter
+    ) {
+        SpaceSyncStatusScreen(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
+                .windowInsetsPadding(WindowInsets.navigationBars),
+            modifierCard = Modifier.padding(start = 8.dp, end = 8.dp, bottom = 16.dp),
+            uiState = uiSyncStatusState,
+            onDismiss = onDismiss,
+            onUpdateAppClick = {}
+        )
     }
 }

--- a/app/src/main/java/com/anytypeio/anytype/ui/date/DateObjectFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/date/DateObjectFragment.kt
@@ -38,6 +38,7 @@ import com.anytypeio.anytype.feature_date.ui.DateMainScreen
 import com.anytypeio.anytype.feature_date.viewmodel.DateObjectCommand
 import com.anytypeio.anytype.feature_date.viewmodel.DateObjectVmParams
 import com.anytypeio.anytype.ui.base.navigation
+import com.anytypeio.anytype.ui.home.WidgetOverlayFragment
 import com.anytypeio.anytype.ui.objects.creation.ObjectTypeSelectionFragment
 import com.anytypeio.anytype.ui.objects.types.pickers.ObjectTypeSelectionListener
 import com.anytypeio.anytype.ui.profile.ParticipantFragment
@@ -203,6 +204,17 @@ class DateObjectFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
                         toast("Failed to open URL")
                     }
                 }
+
+                DateObjectCommand.OpenWidgets -> {
+                    runCatching {
+                        WidgetOverlayFragment.show(
+                            parentFragmentManager,
+                            space
+                        )
+                    }.onFailure { e ->
+                        Timber.e(e, "Error opening widget overlay from date object")
+                    }
+                }
             }
         }
     }
@@ -237,7 +249,6 @@ class DateObjectFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
                     uiHeaderState = vm.uiHeaderState.collectAsStateWithLifecycle().value,
                     uiFieldsState = vm.uiFieldsState.collectAsStateWithLifecycle().value,
                     uiObjectsListState = vm.uiObjectsListState.collectAsStateWithLifecycle().value,
-                    uiNavigationWidget = vm.uiNavigationWidget.collectAsStateWithLifecycle().value,
                     uiFieldsSheetState = vm.uiFieldsSheetState.collectAsStateWithLifecycle().value,
                     uiContentState = vm.uiContentState.collectAsStateWithLifecycle().value,
                     canPaginate = vm.canPaginate.collectAsStateWithLifecycle().value,

--- a/app/src/main/java/com/anytypeio/anytype/ui/home/SpaceProfileHeader.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/home/SpaceProfileHeader.kt
@@ -16,16 +16,19 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.anytypeio.anytype.core_models.SystemColor
+import com.anytypeio.anytype.core_models.multiplayer.SpaceAccessType
 import com.anytypeio.anytype.core_models.ui.SpaceIconView
 import com.anytypeio.anytype.core_ui.R
 import com.anytypeio.anytype.core_ui.views.Caption1Regular
 import com.anytypeio.anytype.core_ui.views.HeadlineHeading
 import com.anytypeio.anytype.core_ui.widgets.objectIcon.SpaceIconView
 import com.anytypeio.anytype.ui.widgets.collection.DefaultTheme
+import com.anytypeio.anytype.localization.R as LocalizationR
 
 @Composable
 fun SpaceProfileHeader(
@@ -33,6 +36,7 @@ fun SpaceProfileHeader(
     spaceName: String,
     globalName: String?,
     identity: String?,
+    spaceAccessType: SpaceAccessType,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -66,17 +70,19 @@ fun SpaceProfileHeader(
                     )
                 }
             }
+            Spacer(modifier = Modifier.height(4.dp))
             val displayIdentity = globalName?.takeIf { it.isNotEmpty() } ?: identity
-            if (!displayIdentity.isNullOrEmpty()) {
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = displayIdentity,
-                    style = Caption1Regular,
-                    color = colorResource(id = R.color.text_secondary),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
+            val subtitle = displayIdentity ?: when (spaceAccessType) {
+                SpaceAccessType.PRIVATE -> stringResource(LocalizationR.string.space_header_private_channel)
+                else -> stringResource(LocalizationR.string.space_header_group_channel)
             }
+            Text(
+                text = subtitle,
+                style = Caption1Regular,
+                color = colorResource(id = R.color.text_secondary),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
         }
     }
 }
@@ -93,23 +99,42 @@ private fun SpaceProfileHeaderPreview() {
             ),
             spaceName = "Anytype",
             globalName = "anytype.any",
-            identity = "0x1234567890abcdef"
+            identity = "0x1234567890abcdef",
+            spaceAccessType = SpaceAccessType.PRIVATE
         )
     }
 }
 
-@Preview(name = "No Global Name", showBackground = true)
+@Preview(name = "Private Channel", showBackground = true)
 @Composable
-private fun SpaceProfileHeaderNoGlobalNamePreview() {
+private fun SpaceProfileHeaderPrivatePreview() {
     DefaultTheme {
         SpaceProfileHeader(
-            spaceIcon = SpaceIconView.ChatSpace.Placeholder(
-                color = SystemColor.PINK,
-                name = "John Doe"
+            spaceIcon = SpaceIconView.DataSpace.Placeholder(
+                color = SystemColor.TEAL,
+                name = "My Space"
             ),
-            spaceName = "John Doe",
+            spaceName = "My Space",
             globalName = null,
-            identity = "@johndoe"
+            identity = null,
+            spaceAccessType = SpaceAccessType.PRIVATE
+        )
+    }
+}
+
+@Preview(name = "Group Channel", showBackground = true)
+@Composable
+private fun SpaceProfileHeaderGroupPreview() {
+    DefaultTheme {
+        SpaceProfileHeader(
+            spaceIcon = SpaceIconView.DataSpace.Placeholder(
+                color = SystemColor.PINK,
+                name = "Team"
+            ),
+            spaceName = "Team Space",
+            globalName = null,
+            identity = null,
+            spaceAccessType = SpaceAccessType.SHARED
         )
     }
 }

--- a/app/src/main/java/com/anytypeio/anytype/ui/home/SpaceProfileHeader.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/home/SpaceProfileHeader.kt
@@ -1,0 +1,115 @@
+package com.anytypeio.anytype.ui.home
+
+import android.content.res.Configuration
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.anytypeio.anytype.core_models.SystemColor
+import com.anytypeio.anytype.core_models.ui.SpaceIconView
+import com.anytypeio.anytype.core_ui.R
+import com.anytypeio.anytype.core_ui.views.Caption1Regular
+import com.anytypeio.anytype.core_ui.views.HeadlineHeading
+import com.anytypeio.anytype.core_ui.widgets.objectIcon.SpaceIconView
+import com.anytypeio.anytype.ui.widgets.collection.DefaultTheme
+
+@Composable
+fun SpaceProfileHeader(
+    spaceIcon: SpaceIconView,
+    spaceName: String,
+    globalName: String?,
+    identity: String?,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = 24.dp, top = 24.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        SpaceIconView(
+            icon = spaceIcon,
+            mainSize = 64.dp
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Column {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = spaceName,
+                    style = HeadlineHeading,
+                    color = colorResource(id = R.color.text_primary),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (!globalName.isNullOrBlank()) {
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Image(
+                        modifier = Modifier.size(20.dp),
+                        painter = painterResource(id = R.drawable.ic_membership_badge_18),
+                        contentDescription = "membership badge"
+                    )
+                }
+            }
+            val displayIdentity = globalName?.takeIf { it.isNotEmpty() } ?: identity
+            if (!displayIdentity.isNullOrEmpty()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = displayIdentity,
+                    style = Caption1Regular,
+                    color = colorResource(id = R.color.text_secondary),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}
+
+@Preview(name = "Light Mode", showBackground = true)
+@Preview(name = "Dark Mode", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun SpaceProfileHeaderPreview() {
+    DefaultTheme {
+        SpaceProfileHeader(
+            spaceIcon = SpaceIconView.DataSpace.Placeholder(
+                color = SystemColor.SKY,
+                name = "Anytype"
+            ),
+            spaceName = "Anytype",
+            globalName = "anytype.any",
+            identity = "0x1234567890abcdef"
+        )
+    }
+}
+
+@Preview(name = "No Global Name", showBackground = true)
+@Composable
+private fun SpaceProfileHeaderNoGlobalNamePreview() {
+    DefaultTheme {
+        SpaceProfileHeader(
+            spaceIcon = SpaceIconView.ChatSpace.Placeholder(
+                color = SystemColor.PINK,
+                name = "John Doe"
+            ),
+            spaceName = "John Doe",
+            globalName = null,
+            identity = "@johndoe"
+        )
+    }
+}

--- a/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreen.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreen.kt
@@ -335,7 +335,8 @@ fun WidgetsScreen(
                         spaceIcon = spaceView.spaceIcon,
                         spaceName = spaceView.spaceName,
                         globalName = spaceView.memberGlobalName,
-                        identity = spaceView.memberIdentity
+                        identity = spaceView.memberIdentity,
+                        spaceAccessType = spaceView.spaceAccessType
                     )
                 }
             }

--- a/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreen.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreen.kt
@@ -120,6 +120,7 @@ fun WidgetsScreen(
     val hapticFeedback = rememberReorderHapticFeedback()
 
     val mode = viewModel.mode.collectAsState().value
+    val spaceView = viewModel.spaceViewState.collectAsState().value
     val pinnedWidgets = viewModel.pinnedViews.collectAsState().value
     val typeWidgets = viewModel.typeViews.collectAsState().value
     val unreadWidget = viewModel.unreadView.collectAsState().value
@@ -326,6 +327,18 @@ fun WidgetsScreen(
                 bottom = bottomContentPadding
             )
         ) {
+
+            // Space profile header
+            if (spaceView is HomeScreenViewModel.SpaceViewState.Success) {
+                item(key = "space_profile_header") {
+                    SpaceProfileHeader(
+                        spaceIcon = spaceView.spaceIcon,
+                        spaceName = spaceView.spaceName,
+                        globalName = spaceView.memberGlobalName,
+                        identity = spaceView.memberIdentity
+                    )
+                }
+            }
 
             // Chat widget pinned at the top for single-chat spaces (CHAT, ONE_TO_ONE)
             if (chatWidget is WidgetView.SpaceChat) {

--- a/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreen.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreen.kt
@@ -1,8 +1,6 @@
 package com.anytypeio.anytype.ui.home
 
-import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -18,7 +16,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -28,7 +25,6 @@ import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -42,8 +38,7 @@ import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.core_models.WidgetSectionType
 import com.anytypeio.anytype.core_ui.common.ReorderHapticFeedbackType
 import com.anytypeio.anytype.core_ui.common.rememberReorderHapticFeedback
-import com.anytypeio.anytype.core_ui.foundation.noRippleClickable
-import com.anytypeio.anytype.core_ui.foundation.noRippleCombinedClickable
+import com.anytypeio.anytype.core_ui.widgets.CircularFabButton
 import com.anytypeio.anytype.presentation.home.HomeScreenViewModel
 import com.anytypeio.anytype.presentation.home.InteractionMode
 import com.anytypeio.anytype.presentation.navigation.NavPanelState
@@ -66,49 +61,6 @@ import com.anytypeio.anytype.ui.widgets.types.ObjectTypesGroupWidgetCard
 import com.anytypeio.anytype.ui.widgets.types.SpaceChatWidgetCard
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
-
-
-@Composable
-fun CircularFabButton(
-    @DrawableRes iconRes: Int,
-    contentDescription: String,
-    modifier: Modifier = Modifier,
-    isEnabled: Boolean = true,
-    onClick: () -> Unit,
-    onLongClick: (() -> Unit)? = null,
-) {
-    Box(
-        modifier = modifier
-            .size(dimensionResource(R.dimen.nav_fab_button_size))
-            .shadow(
-                elevation = 20.dp,
-                shape = CircleShape,
-                clip = false
-            )
-            .background(
-                color = colorResource(id = R.color.navigation_panel),
-                shape = CircleShape
-            )
-            .alpha(if (isEnabled) 1f else 0.5f)
-            .then(
-                if (onLongClick != null) {
-                    Modifier.noRippleCombinedClickable(
-                        enabled = isEnabled,
-                        onLongClicked = onLongClick,
-                        onClick = onClick,
-                    )
-                } else {
-                    Modifier.noRippleClickable(onClick = onClick)
-                }
-            ),
-        contentAlignment = Alignment.Center
-    ) {
-        Image(
-            painter = painterResource(id = iconRes),
-            contentDescription = contentDescription
-        )
-    }
-}
 
 @Composable
 fun WidgetsScreen(

--- a/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreenToolbar.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreenToolbar.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.anytypeio.anytype.R
 import com.anytypeio.anytype.core_ui.common.DefaultPreviews
+import com.anytypeio.anytype.core_ui.widgets.CircularFabButton
 
 @Composable
 fun HomeScreenToolbar(

--- a/app/src/main/java/com/anytypeio/anytype/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/main/MainActivity.kt
@@ -802,6 +802,22 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), AppNavigation.Pr
                     Timber.e(it, "Error while navigation to notification object")
                 }
             }
+
+            is NotificationCommand.GoToChat -> {
+                runCatching {
+                    val controller = findNavController(R.id.fragment)
+                    controller.popBackStack(R.id.vaultScreen, false)
+                    controller.navigate(
+                        R.id.actionOpenChatFromVault,
+                        ChatFragment.args(
+                            space = command.space.id,
+                            ctx = command.chat
+                        )
+                    )
+                }.onFailure {
+                    Timber.e(it, "Error while navigation to notification chat")
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/anytypeio/anytype/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/main/MainActivity.kt
@@ -207,13 +207,15 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), AppNavigation.Pr
                                 runCatching {
                                     val controller = findNavController(R.id.fragment)
                                     controller.popBackStack(R.id.vaultScreen, false)
-                                    controller.navigate(
-                                        R.id.actionOpenSpaceFromVault,
-                                        WidgetsScreenFragment.args(
-                                            space = command.space,
-                                            deeplink = null
+                                    if (!command.openTargetDirectly) {
+                                        controller.navigate(
+                                            R.id.actionOpenSpaceFromVault,
+                                            WidgetsScreenFragment.args(
+                                                space = command.space,
+                                                deeplink = null
+                                            )
                                         )
-                                    )
+                                    }
                                     controller.navigate(
                                         R.id.chatScreen,
                                         ChatFragment.args(
@@ -234,13 +236,15 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), AppNavigation.Pr
                                         runCatching {
                                             val controller = findNavController(R.id.fragment)
                                             controller.popBackStack(R.id.vaultScreen, false)
-                                            controller.navigate(
-                                                R.id.actionOpenSpaceFromVault,
-                                                WidgetsScreenFragment.args(
-                                                    space = command.space,
-                                                    deeplink = null
+                                            if (!command.openTargetDirectly) {
+                                                controller.navigate(
+                                                    R.id.actionOpenSpaceFromVault,
+                                                    WidgetsScreenFragment.args(
+                                                        space = command.space,
+                                                        deeplink = null
+                                                    )
                                                 )
-                                            )
+                                            }
                                             proceedWithOpenObjectNavigation(command.navigation)
                                         }.onFailure {
                                             Timber.e(it, "Error while switching space when handling deep link to object")
@@ -343,15 +347,16 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), AppNavigation.Pr
                                 runCatching {
                                     val controller = findNavController(R.id.fragment)
                                     controller.popBackStack(R.id.vaultScreen, false)
-                                    
-                                    // Navigate to space home
-                                    controller.navigate(
-                                        R.id.actionOpenSpaceFromVault,
-                                        WidgetsScreenFragment.args(
-                                            space = command.space,
-                                            deeplink = null
+
+                                    if (!command.openTargetDirectly) {
+                                        controller.navigate(
+                                            R.id.actionOpenSpaceFromVault,
+                                            WidgetsScreenFragment.args(
+                                                space = command.space,
+                                                deeplink = null
+                                            )
                                         )
-                                    )
+                                    }
                                     // Then navigate to the object based on its layout
                                     proceedWithOpenObjectNavigation(command.navigation)
                                 }.onFailure {
@@ -786,6 +791,15 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), AppNavigation.Pr
                     )
                 }.onFailure {
                     Timber.e(it, "Error while navigation")
+                }
+            }
+
+            is NotificationCommand.GoToObject -> {
+                runCatching {
+                    findNavController(R.id.fragment).popBackStack(R.id.vaultScreen, false)
+                    proceedWithOpenObjectNavigation(command.navigation)
+                }.onFailure {
+                    Timber.e(it, "Error while navigation to notification object")
                 }
             }
         }

--- a/app/src/main/java/com/anytypeio/anytype/ui/vault/VaultFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/vault/VaultFragment.kt
@@ -366,13 +366,15 @@ class VaultFragment : BaseComposeFragment() {
     private fun proceed(destination: VaultNavigation) {
         when (destination) {
             is VaultNavigation.OpenObject -> runCatching {
-                findNavController().navigate(
-                    R.id.actionOpenSpaceFromVault,
-                    WidgetsScreenFragment.args(
-                        space = destination.space,
-                        deeplink = null
+                if (!destination.openTargetDirectly) {
+                    findNavController().navigate(
+                        R.id.actionOpenSpaceFromVault,
+                        WidgetsScreenFragment.args(
+                            space = destination.space,
+                            deeplink = null
+                        )
                     )
-                )
+                }
                 navigation().openDocument(
                     target = destination.ctx,
                     space = destination.space
@@ -382,13 +384,15 @@ class VaultFragment : BaseComposeFragment() {
             }
 
             is VaultNavigation.OpenSet -> runCatching {
-                findNavController().navigate(
-                    R.id.actionOpenSpaceFromVault,
-                    WidgetsScreenFragment.args(
-                        space = destination.space,
-                        deeplink = null
+                if (!destination.openTargetDirectly) {
+                    findNavController().navigate(
+                        R.id.actionOpenSpaceFromVault,
+                        WidgetsScreenFragment.args(
+                            space = destination.space,
+                            deeplink = null
+                        )
                     )
-                )
+                }
                 navigation().openObjectSet(
                     target = destination.ctx,
                     space = destination.space,
@@ -399,13 +403,15 @@ class VaultFragment : BaseComposeFragment() {
             }
 
             is VaultNavigation.OpenChat -> {
-                findNavController().navigate(
-                    R.id.actionOpenSpaceFromVault,
-                    WidgetsScreenFragment.args(
-                        space = destination.space,
-                        deeplink = null
+                if (!destination.openTargetDirectly) {
+                    findNavController().navigate(
+                        R.id.actionOpenSpaceFromVault,
+                        WidgetsScreenFragment.args(
+                            space = destination.space,
+                            deeplink = null
+                        )
                     )
-                )
+                }
                 navigation().openChat(
                     target = destination.ctx,
                     space = destination.space
@@ -414,13 +420,15 @@ class VaultFragment : BaseComposeFragment() {
 
             is VaultNavigation.OpenDateObject -> {
                 runCatching {
-                    findNavController().navigate(
-                        R.id.actionOpenSpaceFromVault,
-                        WidgetsScreenFragment.args(
-                            space = destination.space,
-                            deeplink = null
+                    if (!destination.openTargetDirectly) {
+                        findNavController().navigate(
+                            R.id.actionOpenSpaceFromVault,
+                            WidgetsScreenFragment.args(
+                                space = destination.space,
+                                deeplink = null
+                            )
                         )
-                    )
+                    }
                     navigation().openDateObject(
                         objectId = destination.ctx,
                         space = destination.space
@@ -432,13 +440,15 @@ class VaultFragment : BaseComposeFragment() {
 
             is VaultNavigation.OpenParticipant -> {
                 runCatching {
-                    findNavController().navigate(
-                        R.id.actionOpenSpaceFromVault,
-                        WidgetsScreenFragment.args(
-                            space = destination.space,
-                            deeplink = null
+                    if (!destination.openTargetDirectly) {
+                        findNavController().navigate(
+                            R.id.actionOpenSpaceFromVault,
+                            WidgetsScreenFragment.args(
+                                space = destination.space,
+                                deeplink = null
+                            )
                         )
-                    )
+                    }
                     navigation().openParticipantObject(
                         objectId = destination.ctx,
                         space = destination.space
@@ -450,13 +460,15 @@ class VaultFragment : BaseComposeFragment() {
 
             is VaultNavigation.OpenType -> {
                 runCatching {
-                    findNavController().navigate(
-                        R.id.actionOpenSpaceFromVault,
-                        WidgetsScreenFragment.args(
-                            space = destination.space,
-                            deeplink = null
+                    if (!destination.openTargetDirectly) {
+                        findNavController().navigate(
+                            R.id.actionOpenSpaceFromVault,
+                            WidgetsScreenFragment.args(
+                                space = destination.space,
+                                deeplink = null
+                            )
                         )
-                    )
+                    }
                     navigation().openObjectType(
                         objectId = destination.target,
                         space = destination.space

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/widgets/CircularFabButton.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/widgets/CircularFabButton.kt
@@ -1,0 +1,62 @@
+package com.anytypeio.anytype.core_ui.widgets
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.anytypeio.anytype.core_ui.R
+import com.anytypeio.anytype.core_ui.foundation.noRippleClickable
+import com.anytypeio.anytype.core_ui.foundation.noRippleCombinedClickable
+
+@Composable
+fun CircularFabButton(
+    @DrawableRes iconRes: Int,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+    isEnabled: Boolean = true,
+    onClick: () -> Unit,
+    onLongClick: (() -> Unit)? = null,
+) {
+    Box(
+        modifier = modifier
+            .size(dimensionResource(R.dimen.nav_fab_button_size))
+            .shadow(
+                elevation = 20.dp,
+                shape = CircleShape,
+                clip = false
+            )
+            .background(
+                color = colorResource(id = R.color.navigation_panel),
+                shape = CircleShape
+            )
+            .alpha(if (isEnabled) 1f else 0.5f)
+            .then(
+                if (onLongClick != null) {
+                    Modifier.noRippleCombinedClickable(
+                        enabled = isEnabled,
+                        onLongClicked = onLongClick,
+                        onClick = onClick,
+                    )
+                } else {
+                    Modifier.noRippleClickable(onClick = onClick)
+                }
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Image(
+            painter = painterResource(id = iconRes),
+            contentDescription = contentDescription
+        )
+    }
+}

--- a/domain/src/main/java/com/anytypeio/anytype/domain/spaces/ResolveSpaceHomepage.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/spaces/ResolveSpaceHomepage.kt
@@ -1,0 +1,65 @@
+package com.anytypeio.anytype.domain.spaces
+
+import com.anytypeio.anytype.core_models.DVFilter
+import com.anytypeio.anytype.core_models.DVFilterCondition
+import com.anytypeio.anytype.core_models.Relations
+import com.anytypeio.anytype.core_models.misc.OpenObjectNavigation
+import com.anytypeio.anytype.core_models.misc.navigation
+import com.anytypeio.anytype.core_models.primitives.SpaceId
+import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
+import com.anytypeio.anytype.domain.base.ResultInteractor
+import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
+import com.anytypeio.anytype.domain.search.SearchObjects
+import javax.inject.Inject
+
+class ResolveSpaceHomepage @Inject constructor(
+    dispatchers: AppCoroutineDispatchers,
+    private val spaceViews: SpaceViewSubscriptionContainer,
+    private val searchObjects: SearchObjects
+) : ResultInteractor<ResolveSpaceHomepage.Params, ResolveSpaceHomepage.Result>(dispatchers.io) {
+
+    override suspend fun doWork(params: Params): Result {
+        val homepage = spaceViews.get(params.space)?.homepage
+        if (homepage.isNullOrEmpty() || homepage in HOMEPAGE_SPECIAL_CONSTANTS) {
+            return Result.Widgets
+        }
+        val searchResult = searchObjects.invoke(
+            params = SearchObjects.Params(
+                space = params.space,
+                filters = listOf(
+                    DVFilter(
+                        relation = Relations.ID,
+                        value = homepage,
+                        condition = DVFilterCondition.EQUAL
+                    )
+                ),
+                keys = listOf(Relations.ID, Relations.LAYOUT, Relations.SPACE_ID),
+                limit = 1
+            )
+        )
+        val obj = searchResult.getOrNull()?.firstOrNull() ?: return Result.Widgets
+        return when (val nav = obj.navigation()) {
+            is OpenObjectNavigation.OpenParticipant,
+            is OpenObjectNavigation.UnexpectedLayoutError,
+            OpenObjectNavigation.NonValidObject -> Result.Widgets
+            is OpenObjectNavigation.OpenBookmarkUrl -> Result.Object(
+                OpenObjectNavigation.OpenEditor(
+                    target = homepage,
+                    space = obj.spaceId ?: params.space.id
+                )
+            )
+            else -> Result.Object(nav)
+        }
+    }
+
+    data class Params(val space: SpaceId)
+
+    sealed class Result {
+        data object Widgets : Result()
+        data class Object(val navigation: OpenObjectNavigation) : Result()
+    }
+
+    companion object {
+        val HOMEPAGE_SPECIAL_CONSTANTS = setOf("widgets", "graph", "lastOpened")
+    }
+}

--- a/feature-all-content/src/main/java/com/anytypeio/anytype/feature_allcontent/models/AllContentModels.kt
+++ b/feature-all-content/src/main/java/com/anytypeio/anytype/feature_allcontent/models/AllContentModels.kt
@@ -10,6 +10,7 @@ import com.anytypeio.anytype.core_models.ObjectWrapper
 import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.core_models.UrlBuilder
 import com.anytypeio.anytype.core_models.ext.DateParser
+import com.anytypeio.anytype.core_models.multiplayer.SpaceSyncAndP2PStatusState
 import com.anytypeio.anytype.core_models.primitives.SpaceId
 import com.anytypeio.anytype.core_models.ui.ObjectIcon
 import com.anytypeio.anytype.core_models.ui.objectIcon
@@ -48,6 +49,12 @@ sealed class AllContentMenuMode {
 sealed class UiTitleState {
     data object AllContent : UiTitleState()
     data object OnlyUnlinked : UiTitleState()
+}
+
+// SYNC STATUS BADGE
+sealed class UiSyncStatusBadgeState {
+    data object Hidden : UiSyncStatusBadgeState()
+    data class Visible(val status: SpaceSyncAndP2PStatusState) : UiSyncStatusBadgeState()
 }
 
 // TABS

--- a/feature-all-content/src/main/java/com/anytypeio/anytype/feature_allcontent/presentation/AllContentViewModel.kt
+++ b/feature-all-content/src/main/java/com/anytypeio/anytype/feature_allcontent/presentation/AllContentViewModel.kt
@@ -11,10 +11,12 @@ import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.core_models.UrlBuilder
 import com.anytypeio.anytype.core_models.misc.OpenObjectNavigation
 import com.anytypeio.anytype.core_models.misc.navigation
+import com.anytypeio.anytype.core_models.multiplayer.SpaceSyncAndP2PStatusState
 import com.anytypeio.anytype.core_models.primitives.SpaceId
 import com.anytypeio.anytype.domain.all_content.RestoreAllContentState
 import com.anytypeio.anytype.domain.all_content.UpdateAllContentState
 import com.anytypeio.anytype.domain.base.fold
+import com.anytypeio.anytype.domain.event.interactor.SpaceSyncAndP2PStatusProvider
 import com.anytypeio.anytype.domain.library.StorelessSubscriptionContainer
 import com.anytypeio.anytype.domain.misc.LocaleProvider
 import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
@@ -33,6 +35,7 @@ import com.anytypeio.anytype.feature_allcontent.models.UiContentState
 import com.anytypeio.anytype.feature_allcontent.models.UiItemsState
 import com.anytypeio.anytype.feature_allcontent.models.UiMenuState
 import com.anytypeio.anytype.feature_allcontent.models.UiSnackbarState
+import com.anytypeio.anytype.feature_allcontent.models.UiSyncStatusBadgeState
 import com.anytypeio.anytype.feature_allcontent.models.UiTabsState
 import com.anytypeio.anytype.feature_allcontent.models.UiTitleState
 import com.anytypeio.anytype.feature_allcontent.models.createSubscriptionParams
@@ -59,6 +62,9 @@ import com.anytypeio.anytype.presentation.navigation.NavPanelState
 import com.anytypeio.anytype.presentation.objects.MenuSortsItem
 import com.anytypeio.anytype.presentation.objects.ObjectsListSort
 import com.anytypeio.anytype.presentation.objects.getCreateObjectParams
+import com.anytypeio.anytype.presentation.sync.SyncStatusWidgetState
+import com.anytypeio.anytype.presentation.sync.toSyncStatusWidgetState
+import com.anytypeio.anytype.presentation.sync.updateStatus
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -107,7 +113,8 @@ class AllContentViewModel(
     private val removeObjectsFromWorkspace: RemoveObjectsFromWorkspace,
     private val userPermissionProvider: UserPermissionProvider,
     private val fieldParser: FieldParser,
-    private val spaceViews: SpaceViewSubscriptionContainer
+    private val spaceViews: SpaceViewSubscriptionContainer,
+    private val spaceSyncAndP2PStatusProvider: SpaceSyncAndP2PStatusProvider
 ) : ViewModel(), AnalyticSpaceHelperDelegate by analyticSpaceHelperDelegate {
 
     private val searchResultIds = MutableStateFlow<List<Id>>(emptyList())
@@ -119,6 +126,10 @@ class AllContentViewModel(
     val uiContentState = MutableStateFlow<UiContentState>(UiContentState.Idle())
     val uiBottomMenu = MutableStateFlow<AllContentBottomMenu>(AllContentBottomMenu())
     val uiSnackbarState = MutableStateFlow<UiSnackbarState>(UiSnackbarState.Hidden)
+    val uiSyncStatusBadgeState =
+        MutableStateFlow<UiSyncStatusBadgeState>(UiSyncStatusBadgeState.Hidden)
+    val uiSyncStatusWidgetState =
+        MutableStateFlow<SyncStatusWidgetState>(SyncStatusWidgetState.Hidden)
 
     val commands = MutableSharedFlow<Command>()
 
@@ -159,6 +170,20 @@ class AllContentViewModel(
         setupSearchStateFlow()
         setupMenuFlow()
         proceedWithObservingPermissions()
+        proceedWithObservingSyncStatus()
+    }
+
+    private fun proceedWithObservingSyncStatus() {
+        viewModelScope.launch {
+            spaceSyncAndP2PStatusProvider
+                .observe()
+                .catch { Timber.e(it, "Error while observing sync status") }
+                .collect { syncAndP2pState ->
+                    uiSyncStatusBadgeState.value = UiSyncStatusBadgeState.Visible(syncAndP2pState)
+                    uiSyncStatusWidgetState.value =
+                        uiSyncStatusWidgetState.value.updateStatus(syncAndP2pState)
+                }
+        }
     }
 
     private fun proceedWithObservingPermissions() {
@@ -727,6 +752,22 @@ class AllContentViewModel(
         }
     }
 
+    fun onTopBarTitleClicked() {
+        Timber.d("onTopBarTitleClicked")
+        viewModelScope.launch {
+            commands.emit(Command.OpenWidgets)
+        }
+    }
+
+    fun onSyncStatusBadgeClicked(status: SpaceSyncAndP2PStatusState) {
+        Timber.d("onSyncStatusBadgeClicked: $status")
+        uiSyncStatusWidgetState.value = status.toSyncStatusWidgetState()
+    }
+
+    fun onSyncStatusDismiss() {
+        uiSyncStatusWidgetState.value = SyncStatusWidgetState.Hidden
+    }
+
     fun onCreateObjectOfTypeClicked(objType: ObjectWrapper.Type) {
         proceedWithCreateDoc(objType)
     }
@@ -902,6 +943,7 @@ class AllContentViewModel(
         data object OpenGlobalSearch : Command()
         data object ExitToSpaceHome : Command()
         data object Back : Command()
+        data object OpenWidgets : Command()
     }
 
     companion object {

--- a/feature-all-content/src/main/java/com/anytypeio/anytype/feature_allcontent/presentation/AllContentViewModelFactory.kt
+++ b/feature-all-content/src/main/java/com/anytypeio/anytype/feature_allcontent/presentation/AllContentViewModelFactory.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.anytypeio.anytype.analytics.base.Analytics
 import com.anytypeio.anytype.domain.all_content.RestoreAllContentState
 import com.anytypeio.anytype.domain.all_content.UpdateAllContentState
+import com.anytypeio.anytype.domain.event.interactor.SpaceSyncAndP2PStatusProvider
 import com.anytypeio.anytype.domain.library.StorelessSubscriptionContainer
 import com.anytypeio.anytype.domain.misc.LocaleProvider
 import com.anytypeio.anytype.core_models.UrlBuilder
@@ -36,7 +37,8 @@ class AllContentViewModelFactory @Inject constructor(
     private val removeObjectsFromWorkspace: RemoveObjectsFromWorkspace,
     private val userPermissionProvider: UserPermissionProvider,
     private val fieldParser: FieldParser,
-    private val spaceViews: SpaceViewSubscriptionContainer
+    private val spaceViews: SpaceViewSubscriptionContainer,
+    private val spaceSyncAndP2PStatusProvider: SpaceSyncAndP2PStatusProvider
 ) : ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T =
@@ -56,6 +58,7 @@ class AllContentViewModelFactory @Inject constructor(
             removeObjectsFromWorkspace = removeObjectsFromWorkspace,
             userPermissionProvider = userPermissionProvider,
             fieldParser = fieldParser,
-            spaceViews = spaceViews
+            spaceViews = spaceViews,
+            spaceSyncAndP2PStatusProvider = spaceSyncAndP2PStatusProvider
         ) as T
 }

--- a/feature-all-content/src/main/java/com/anytypeio/anytype/feature_allcontent/ui/AllContentScreen.kt
+++ b/feature-all-content/src/main/java/com/anytypeio/anytype/feature_allcontent/ui/AllContentScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -51,7 +52,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -69,7 +69,6 @@ import com.anytypeio.anytype.core_ui.extensions.swapList
 import com.anytypeio.anytype.core_ui.foundation.DefaultSearchBar
 import com.anytypeio.anytype.core_ui.foundation.DismissBackground
 import com.anytypeio.anytype.core_ui.foundation.Divider
-import com.anytypeio.anytype.core_ui.foundation.components.BottomNavigationMenu
 import com.anytypeio.anytype.core_ui.views.BodyRegular
 import com.anytypeio.anytype.core_ui.views.ButtonSize
 import com.anytypeio.anytype.core_ui.views.Caption1Regular
@@ -78,8 +77,10 @@ import com.anytypeio.anytype.core_ui.views.Relations3
 import com.anytypeio.anytype.core_ui.views.UXBody
 import com.anytypeio.anytype.core_ui.views.animations.DotsLoadingIndicator
 import com.anytypeio.anytype.core_ui.views.animations.FadeAnimationSpecs
+import com.anytypeio.anytype.core_ui.widgets.CircularFabButton
 import com.anytypeio.anytype.core_ui.widgets.ListWidgetObjectIcon
 import com.anytypeio.anytype.core_utils.insets.EDGE_TO_EDGE_MIN_SDK
+import com.anytypeio.anytype.core_models.multiplayer.SpaceSyncAndP2PStatusState
 import com.anytypeio.anytype.feature_allcontent.R
 import com.anytypeio.anytype.feature_allcontent.models.AllContentMenuMode
 import com.anytypeio.anytype.feature_allcontent.models.AllContentTab
@@ -88,9 +89,9 @@ import com.anytypeio.anytype.feature_allcontent.models.UiContentState
 import com.anytypeio.anytype.feature_allcontent.models.UiItemsState
 import com.anytypeio.anytype.feature_allcontent.models.UiMenuState
 import com.anytypeio.anytype.feature_allcontent.models.UiSnackbarState
+import com.anytypeio.anytype.feature_allcontent.models.UiSyncStatusBadgeState
 import com.anytypeio.anytype.feature_allcontent.models.UiTabsState
 import com.anytypeio.anytype.feature_allcontent.models.UiTitleState
-import com.anytypeio.anytype.presentation.navigation.NavPanelState
 import com.anytypeio.anytype.presentation.objects.ObjectsListSort
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -103,8 +104,8 @@ fun AllContentWrapperScreen(
     uiTabsState: UiTabsState,
     uiMenuState: UiMenuState,
     uiSnackbarState: UiSnackbarState,
+    uiSyncStatusBadgeState: UiSyncStatusBadgeState,
     uiItemsState: UiItemsState,
-    uiBottomMenu: NavPanelState,
     onTabClick: (AllContentTab) -> Unit,
     onQueryChanged: (String) -> Unit,
     onModeClick: (AllContentMenuMode) -> Unit,
@@ -115,22 +116,21 @@ fun AllContentWrapperScreen(
     canPaginate: Boolean,
     onUpdateLimitSearch: () -> Unit,
     uiContentState: UiContentState,
-    onGlobalSearchClicked: () -> Unit,
     onAddDocClicked: () -> Unit,
     onCreateObjectLongClicked: () -> Unit,
     onBackClicked: () -> Unit,
-    onBackLongClicked: () -> Unit,
+    onTitleClick: () -> Unit,
+    onSyncStatusClick: (SpaceSyncAndP2PStatusState) -> Unit,
     moveToBin: (UiContentItem.Item) -> Unit,
     undoMoveToBin: (Id) -> Unit,
-    onDismissSnackbar: () -> Unit,
-    onShareButtonClicked: () -> Unit,
-    onHomeButtonClicked: () -> Unit
+    onDismissSnackbar: () -> Unit
 ) {
 
     AllContentMainScreen(
         uiTitleState = uiTitleState,
         uiTabsState = uiTabsState,
         uiSnackbarState = uiSnackbarState,
+        uiSyncStatusBadgeState = uiSyncStatusBadgeState,
         onTabClick = onTabClick,
         onQueryChanged = onQueryChanged,
         uiMenuState = uiMenuState,
@@ -140,18 +140,16 @@ fun AllContentWrapperScreen(
         onBinClick = onBinClick,
         uiItemsState = uiItemsState,
         uiContentState = uiContentState,
-        onGlobalSearchClicked = onGlobalSearchClicked,
         onAddDocClicked = onAddDocClicked,
         onCreateObjectLongClicked = onCreateObjectLongClicked,
         onBackClicked = onBackClicked,
+        onTitleClick = onTitleClick,
+        onSyncStatusClick = onSyncStatusClick,
         moveToBin = moveToBin,
-        uiBottomMenu = uiBottomMenu,
         undoMoveToBin = undoMoveToBin,
         onDismissSnackbar = onDismissSnackbar,
         canPaginate = canPaginate,
         onUpdateLimitSearch = onUpdateLimitSearch,
-        onShareButtonClicked = onShareButtonClicked,
-        onHomeButtonClicked = onHomeButtonClicked,
         onOpenAsObject = onOpenAsObject
     )
 }
@@ -164,7 +162,7 @@ fun AllContentMainScreen(
     uiTabsState: UiTabsState,
     uiMenuState: UiMenuState,
     uiSnackbarState: UiSnackbarState,
-    uiBottomMenu: NavPanelState,
+    uiSyncStatusBadgeState: UiSyncStatusBadgeState,
     onTabClick: (AllContentTab) -> Unit,
     onQueryChanged: (String) -> Unit,
     onModeClick: (AllContentMenuMode) -> Unit,
@@ -173,17 +171,16 @@ fun AllContentMainScreen(
     onOpenAsObject: (UiContentItem.Item) -> Unit,
     onBinClick: () -> Unit,
     uiContentState: UiContentState,
-    onGlobalSearchClicked: () -> Unit,
     onAddDocClicked: () -> Unit,
     onCreateObjectLongClicked: () -> Unit,
     onBackClicked: () -> Unit,
+    onTitleClick: () -> Unit,
+    onSyncStatusClick: (SpaceSyncAndP2PStatusState) -> Unit,
     moveToBin: (UiContentItem.Item) -> Unit,
     undoMoveToBin: (Id) -> Unit,
     onDismissSnackbar: () -> Unit,
     canPaginate: Boolean,
-    onUpdateLimitSearch: () -> Unit,
-    onShareButtonClicked: () -> Unit,
-    onHomeButtonClicked: () -> Unit
+    onUpdateLimitSearch: () -> Unit
 ) {
     var isSearchEmpty by remember { mutableStateOf(true) }
     val snackBarHostState = remember { SnackbarHostState() }
@@ -209,29 +206,6 @@ fun AllContentMainScreen(
         modifier = Modifier
             .fillMaxSize(),
         containerColor = colorResource(id = R.color.background_primary),
-        bottomBar = {
-            Box(
-                modifier = if (Build.VERSION.SDK_INT >= EDGE_TO_EDGE_MIN_SDK)
-                    Modifier
-                        .windowInsetsPadding(WindowInsets.navigationBars)
-                        .padding(bottom = 20.dp)
-                        .fillMaxWidth()
-                else
-                    Modifier
-                        .padding(bottom = 20.dp)
-                        .fillMaxWidth()
-            ) {
-                BottomMenu(
-                    modifier = Modifier.align(Alignment.BottomCenter),
-                    onGlobalSearchClicked = onGlobalSearchClicked,
-                    onAddDocClicked = onAddDocClicked,
-                    onCreateObjectLongClicked = onCreateObjectLongClicked,
-                    uiBottomMenu = uiBottomMenu,
-                    onShareButtonClicked = onShareButtonClicked,
-                    onHomeButtonClicked = onHomeButtonClicked
-                )
-            }
-        },
         topBar = {
             Column(
                 modifier = if (Build.VERSION.SDK_INT >= EDGE_TO_EDGE_MIN_SDK)
@@ -243,11 +217,14 @@ fun AllContentMainScreen(
             ) {
                 AllContentTopBarContainer(
                     titleState = uiTitleState,
+                    uiSyncStatusBadgeState = uiSyncStatusBadgeState,
                     uiMenuState = uiMenuState,
                     onSortClick = onSortClick,
                     onModeClick = onModeClick,
                     onBinClick = onBinClick,
-                    onBackClick = onBackClicked
+                    onBackClick = onBackClicked,
+                    onTitleClick = onTitleClick,
+                    onSyncStatusClick = onSyncStatusClick
                 )
                 AllContentTabs(tabsViewState = uiTabsState) { tab ->
                     onTabClick(tab)
@@ -279,72 +256,63 @@ fun AllContentMainScreen(
                         .padding(paddingValues)
                         .background(color = colorResource(id = R.color.background_primary))
 
-            Box(
-                modifier = contentModifier,
-                contentAlignment = Alignment.Center
-            ) {
-                when (uiItemsState) {
-                    UiItemsState.Empty -> {
-                        when (uiContentState) {
-                            is UiContentState.Error -> {
-                                ErrorState(uiContentState.message)
-                            }
+            Box(modifier = contentModifier) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    when (uiItemsState) {
+                        UiItemsState.Empty -> {
+                            when (uiContentState) {
+                                is UiContentState.Error -> {
+                                    ErrorState(uiContentState.message)
+                                }
 
-                            is UiContentState.Idle -> {
-                                // Do nothing.
-                            }
+                                is UiContentState.Idle -> {
+                                    // Do nothing.
+                                }
 
-                            UiContentState.InitLoading -> {
-                                LoadingState()
-                            }
+                                UiContentState.InitLoading -> {
+                                    LoadingState()
+                                }
 
-                            UiContentState.Paging -> {}
-                            UiContentState.Empty -> {
-                                EmptyState(isSearchEmpty = isSearchEmpty)
+                                UiContentState.Paging -> {}
+                                UiContentState.Empty -> {
+                                    EmptyState(isSearchEmpty = isSearchEmpty)
+                                }
                             }
                         }
-                    }
 
-                    is UiItemsState.Content -> {
-                        ContentItems(
-                            uiItemsState = uiItemsState,
-                            onItemClicked = onItemClicked,
-                            uiContentState = uiContentState,
-                            moveToBin = moveToBin,
-                            canPaginate = canPaginate,
-                            onUpdateLimitSearch = onUpdateLimitSearch,
-                            onOpenAsObject = onOpenAsObject
-                        )
+                        is UiItemsState.Content -> {
+                            ContentItems(
+                                uiItemsState = uiItemsState,
+                                onItemClicked = onItemClicked,
+                                uiContentState = uiContentState,
+                                moveToBin = moveToBin,
+                                canPaginate = canPaginate,
+                                onUpdateLimitSearch = onUpdateLimitSearch,
+                                onOpenAsObject = onOpenAsObject
+                            )
+                        }
                     }
                 }
+                CircularFabButton(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(
+                            end = dimensionResource(id = com.anytypeio.anytype.core_ui.R.dimen.nav_fab_margin),
+                            bottom = dimensionResource(id = com.anytypeio.anytype.core_ui.R.dimen.nav_fab_margin)
+                        ),
+                    iconRes = com.anytypeio.anytype.core_ui.R.drawable.ic_create_obj_32,
+                    contentDescription = stringResource(id = R.string.create),
+                    onClick = onAddDocClicked,
+                    onLongClick = onCreateObjectLongClicked
+                )
             }
         },
         snackbarHost = {
             SnackbarHost(hostState = snackBarHostState)
         }
-    )
-}
-
-@Composable
-fun BottomMenu(
-    uiBottomMenu: NavPanelState,
-    modifier: Modifier = Modifier,
-    onGlobalSearchClicked: () -> Unit,
-    onAddDocClicked: () -> Unit,
-    onCreateObjectLongClicked: () -> Unit,
-    onShareButtonClicked: () -> Unit,
-    onHomeButtonClicked: () -> Unit
-) {
-    val isImeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
-    if (isImeVisible) return
-    BottomNavigationMenu(
-        modifier = modifier,
-        onSearchClick = onGlobalSearchClicked,
-        onAddDocClick = onAddDocClicked,
-        onAddDocLongClick = onCreateObjectLongClicked,
-        onShareButtonClicked = onShareButtonClicked,
-        state = uiBottomMenu,
-        onHomeButtonClicked = onHomeButtonClicked
     )
 }
 
@@ -558,6 +526,7 @@ fun PreviewMainScreen() {
             ), selectedTab = AllContentTab.LISTS
         ),
         uiMenuState = UiMenuState.Hidden,
+        uiSyncStatusBadgeState = UiSyncStatusBadgeState.Hidden,
         onTabClick = {},
         onQueryChanged = {},
         onModeClick = {},
@@ -565,19 +534,17 @@ fun PreviewMainScreen() {
         onItemClicked = {},
         onBinClick = {},
         uiContentState = UiContentState.Error("Error message"),
-        onGlobalSearchClicked = {},
         onAddDocClicked = {},
         onCreateObjectLongClicked = {},
         onBackClicked = {},
+        onTitleClick = {},
+        onSyncStatusClick = {},
         moveToBin = {},
-        uiBottomMenu = NavPanelState.Init,
         uiSnackbarState = UiSnackbarState.Hidden,
         undoMoveToBin = {},
         onDismissSnackbar = {},
         canPaginate = true,
         onUpdateLimitSearch = {},
-        onShareButtonClicked = {},
-        onHomeButtonClicked = {},
         onOpenAsObject = {}
     )
 }

--- a/feature-all-content/src/main/java/com/anytypeio/anytype/feature_allcontent/ui/AllContentTopToolbar.kt
+++ b/feature-all-content/src/main/java/com/anytypeio/anytype/feature_allcontent/ui/AllContentTopToolbar.kt
@@ -2,9 +2,12 @@ package com.anytypeio.anytype.feature_allcontent.ui
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -15,6 +18,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -26,21 +30,29 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.anytypeio.anytype.core_models.DVSortType
+import com.anytypeio.anytype.core_models.multiplayer.P2PStatusUpdate
+import com.anytypeio.anytype.core_models.multiplayer.SpaceSyncAndP2PStatusState
+import com.anytypeio.anytype.core_models.multiplayer.SpaceSyncError
+import com.anytypeio.anytype.core_models.multiplayer.SpaceSyncNetwork
+import com.anytypeio.anytype.core_models.multiplayer.SpaceSyncStatus
+import com.anytypeio.anytype.core_models.multiplayer.SpaceSyncUpdate
 import com.anytypeio.anytype.core_ui.common.DefaultPreviews
-import com.anytypeio.anytype.core_ui.extensions.bouncingClickable
 import com.anytypeio.anytype.core_ui.foundation.noRippleThrottledClickable
-import com.anytypeio.anytype.core_ui.views.Title1
+import com.anytypeio.anytype.core_ui.syncstatus.StatusBadge
+import com.anytypeio.anytype.core_ui.views.PreviewTitle2Regular
 import com.anytypeio.anytype.core_ui.views.Title2
 import com.anytypeio.anytype.feature_allcontent.R
 import com.anytypeio.anytype.feature_allcontent.models.AllContentMenuMode
 import com.anytypeio.anytype.feature_allcontent.models.AllContentTab
 import com.anytypeio.anytype.feature_allcontent.models.UiMenuState
+import com.anytypeio.anytype.feature_allcontent.models.UiSyncStatusBadgeState
 import com.anytypeio.anytype.feature_allcontent.models.UiTabsState
 import com.anytypeio.anytype.feature_allcontent.models.UiTitleState
 import com.anytypeio.anytype.presentation.objects.MenuSortsItem
@@ -51,24 +63,36 @@ import com.anytypeio.anytype.presentation.objects.ObjectsListSort
 @Composable
 fun AllContentTopBarContainer(
     titleState: UiTitleState,
+    uiSyncStatusBadgeState: UiSyncStatusBadgeState,
     uiMenuState: UiMenuState,
+    onBackClick: () -> Unit,
+    onTitleClick: () -> Unit,
+    onSyncStatusClick: (SpaceSyncAndP2PStatusState) -> Unit,
     onModeClick: (AllContentMenuMode) -> Unit,
     onSortClick: (ObjectsListSort) -> Unit,
     onBinClick: () -> Unit,
-    onBackClick: () -> Unit
 ) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(48.dp)
+            .height(44.dp)
     ) {
+        // Back pill — circular button at start.
         Box(
             modifier = Modifier
-                .width(56.dp)
-                .fillMaxHeight()
-                .noRippleThrottledClickable {
-                    onBackClick()
-                },
+                .align(Alignment.CenterStart)
+                .padding(start = 16.dp)
+                .size(44.dp)
+                .shadow(
+                    elevation = 20.dp,
+                    shape = CircleShape,
+                    clip = false
+                )
+                .background(
+                    color = colorResource(id = com.anytypeio.anytype.core_ui.R.color.navigation_panel),
+                    shape = CircleShape
+                )
+                .noRippleThrottledClickable { onBackClick() },
             contentAlignment = Alignment.Center
         ) {
             Image(
@@ -78,20 +102,78 @@ fun AllContentTopBarContainer(
             )
         }
 
-        AllContentTitle(
+        // Center title pill — tapping opens the widgets overlay.
+        Row(
             modifier = Modifier
-                .wrapContentSize()
-                .align(Alignment.Center),
-            state = titleState
-        )
+                .align(Alignment.Center)
+                .fillMaxWidth()
+                .padding(start = 64.dp, end = 120.dp)
+                .fillMaxHeight()
+                .shadow(
+                    elevation = 20.dp,
+                    shape = RoundedCornerShape(22.dp),
+                    clip = false
+                )
+                .background(
+                    color = colorResource(id = com.anytypeio.anytype.core_ui.R.color.navigation_panel),
+                    shape = RoundedCornerShape(22.dp)
+                )
+                .noRippleThrottledClickable { onTitleClick() }
+                .padding(horizontal = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = when (titleState) {
+                    UiTitleState.AllContent -> stringResource(id = R.string.all_content_title_all_content)
+                    UiTitleState.OnlyUnlinked -> stringResource(id = R.string.all_content_title_only_unlinked)
+                },
+                style = PreviewTitle2Regular,
+                color = colorResource(id = R.color.text_primary),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
 
-        AllContentMenuButton(
-            modifier = Modifier.align(Alignment.CenterEnd),
-            onModeClick = onModeClick,
-            onSortClick = onSortClick,
-            onBinClick = onBinClick,
-            uiMenuState = uiMenuState,
-        )
+        // Trailing — optional sync badge pill + menu pill.
+        Row(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(end = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            if (uiSyncStatusBadgeState is UiSyncStatusBadgeState.Visible) {
+                Box(
+                    modifier = Modifier
+                        .size(44.dp)
+                        .shadow(
+                            elevation = 20.dp,
+                            shape = CircleShape,
+                            clip = false
+                        )
+                        .background(
+                            color = colorResource(id = com.anytypeio.anytype.core_ui.R.color.navigation_panel),
+                            shape = CircleShape
+                        )
+                        .noRippleThrottledClickable {
+                            onSyncStatusClick(uiSyncStatusBadgeState.status)
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    StatusBadge(
+                        status = uiSyncStatusBadgeState.status,
+                        modifier = Modifier.size(28.dp)
+                    )
+                }
+            }
+            AllContentMenuButton(
+                uiMenuState = uiMenuState,
+                onModeClick = onModeClick,
+                onSortClick = onSortClick,
+                onBinClick = onBinClick
+            )
+        }
     }
 }
 
@@ -99,7 +181,19 @@ fun AllContentTopBarContainer(
 @Composable
 private fun AllContentTopBarContainerPreview() {
     AllContentTopBarContainer(
-        titleState = UiTitleState.OnlyUnlinked,
+        titleState = UiTitleState.AllContent,
+        uiSyncStatusBadgeState = UiSyncStatusBadgeState.Visible(
+            status = SpaceSyncAndP2PStatusState.Success(
+                spaceSyncUpdate = SpaceSyncUpdate.Update(
+                    id = "1",
+                    status = SpaceSyncStatus.SYNCING,
+                    network = SpaceSyncNetwork.ANYTYPE,
+                    error = SpaceSyncError.NULL,
+                    syncingObjectsCounter = 2
+                ),
+                p2PStatusUpdate = P2PStatusUpdate.Initial
+            )
+        ),
         uiMenuState = UiMenuState.Visible(
             mode = listOf(
                 AllContentMenuMode.AllContent(isSelected = true),
@@ -126,45 +220,35 @@ private fun AllContentTopBarContainerPreview() {
                 ),
             )
         ),
+        onBackClick = {},
+        onTitleClick = {},
+        onSyncStatusClick = {},
         onModeClick = {},
         onSortClick = {},
-        onBinClick = {},
-        onBackClick = {}
+        onBinClick = {}
     )
 }
-//endregion
 
-//region AllContentTitle
+@DefaultPreviews
 @Composable
-fun AllContentTitle(modifier: Modifier, state: UiTitleState) {
-    when (state) {
-        UiTitleState.AllContent -> {
-            Text(
-                modifier = modifier
-                    .wrapContentSize(),
-                text = stringResource(id = R.string.all_content_title_all_content),
-                style = Title1,
-                color = colorResource(id = R.color.text_primary)
-            )
-        }
-
-        UiTitleState.OnlyUnlinked -> {
-            Text(
-                modifier = modifier
-                    .wrapContentSize(),
-                text = stringResource(id = R.string.all_content_title_only_unlinked),
-                style = Title1,
-                color = colorResource(id = R.color.text_primary)
-            )
-        }
-    }
+private fun AllContentTopBarContainerHiddenSyncPreview() {
+    AllContentTopBarContainer(
+        titleState = UiTitleState.OnlyUnlinked,
+        uiSyncStatusBadgeState = UiSyncStatusBadgeState.Hidden,
+        uiMenuState = UiMenuState.Hidden,
+        onBackClick = {},
+        onTitleClick = {},
+        onSyncStatusClick = {},
+        onModeClick = {},
+        onSortClick = {},
+        onBinClick = {}
+    )
 }
 //endregion
 
 //region AllContentMenuButton
 @Composable
 fun AllContentMenuButton(
-    modifier: Modifier,
     uiMenuState: UiMenuState,
     onModeClick: (AllContentMenuMode) -> Unit,
     onSortClick: (ObjectsListSort) -> Unit,
@@ -173,34 +257,46 @@ fun AllContentMenuButton(
 
     var isMenuExpanded by remember { mutableStateOf(false) }
 
-    Image(
-        modifier = modifier
-            .padding(end = 12.dp)
-            .size(32.dp)
-            .bouncingClickable { isMenuExpanded = true },
-        painter = painterResource(id = R.drawable.ic_space_list_dots),
-        contentDescription = "Menu icon",
-        contentScale = ContentScale.Inside
-    )
-    if (uiMenuState is UiMenuState.Visible) {
-        DropdownMenu(
-            modifier = Modifier.width(252.dp),
-            expanded = isMenuExpanded,
-            onDismissRequest = { isMenuExpanded = false },
-            shape = RoundedCornerShape(size = 16.dp),
-            containerColor = colorResource(id = R.color.background_primary),
-            shadowElevation = 5.dp,
-            border = BorderStroke(
-                width = 0.5.dp,
-                color = colorResource(id = R.color.background_secondary)
+    Box(
+        modifier = Modifier
+            .size(44.dp)
+            .shadow(
+                elevation = 20.dp,
+                shape = CircleShape,
+                clip = false
             )
-        ) {
-            AllContentMenu(
-                uiMenuState = uiMenuState,
-                onModeClick = onModeClick,
-                onSortClick = onSortClick,
-                onBinClick = onBinClick
+            .background(
+                color = colorResource(id = com.anytypeio.anytype.core_ui.R.color.navigation_panel),
+                shape = CircleShape
             )
+            .noRippleThrottledClickable { isMenuExpanded = true },
+        contentAlignment = Alignment.Center
+    ) {
+        Image(
+            modifier = Modifier.size(24.dp),
+            painter = painterResource(id = R.drawable.ic_space_list_dots),
+            contentDescription = stringResource(id = R.string.more)
+        )
+        if (uiMenuState is UiMenuState.Visible) {
+            DropdownMenu(
+                modifier = Modifier.width(252.dp),
+                expanded = isMenuExpanded,
+                onDismissRequest = { isMenuExpanded = false },
+                shape = RoundedCornerShape(size = 16.dp),
+                containerColor = colorResource(id = R.color.background_primary),
+                shadowElevation = 5.dp,
+                border = BorderStroke(
+                    width = 0.5.dp,
+                    color = colorResource(id = R.color.background_secondary)
+                )
+            ) {
+                AllContentMenu(
+                    uiMenuState = uiMenuState,
+                    onModeClick = onModeClick,
+                    onSortClick = onSortClick,
+                    onBinClick = onBinClick
+                )
+            }
         }
     }
 }

--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/Toolbars.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/Toolbars.kt
@@ -7,9 +7,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
@@ -30,12 +30,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import androidx.compose.ui.unit.Dp
@@ -43,43 +41,21 @@ import androidx.compose.ui.unit.dp
 import com.anytypeio.anytype.core_models.ui.SpaceIconView
 import com.anytypeio.anytype.core_ui.common.DefaultPreviews
 import com.anytypeio.anytype.core_ui.foundation.noRippleClickable
+import com.anytypeio.anytype.core_ui.foundation.noRippleThrottledClickable
 import com.anytypeio.anytype.core_ui.views.Caption1Medium
-import com.anytypeio.anytype.core_ui.views.Title1
+import com.anytypeio.anytype.core_ui.views.PreviewTitle2Regular
 import com.anytypeio.anytype.core_ui.widgets.ListWidgetObjectIcon
 import com.anytypeio.anytype.core_ui.widgets.objectIcon.SpaceIconView
 import com.anytypeio.anytype.feature_chats.R
 import com.anytypeio.anytype.feature_chats.presentation.ChatViewModel
 
 
-private val ChatToolbarButtonSize = 40.dp
-private val ChatToolbarButtonOuterPadding = 12.dp
-private val ChatToolbarTitlePillSideBuffer = 20.dp
-private val ChatToolbarTitlePillHorizontalPadding: Dp =
-    ChatToolbarButtonSize + ChatToolbarButtonOuterPadding + ChatToolbarTitlePillSideBuffer
-
-@Composable
-private fun ChatToolbarCircularContainer(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    content: @Composable BoxScope.() -> Unit,
-) {
-    Box(
-        modifier = modifier
-            .size(ChatToolbarButtonSize)
-            .shadow(
-                elevation = 4.dp,
-                shape = CircleShape,
-                clip = false,
-                ambientColor = Color.Black.copy(alpha = 0.12f),
-                spotColor = Color.Black.copy(alpha = 0.12f),
-            )
-            .clip(CircleShape)
-            .background(colorResource(R.color.shape_primary))
-            .noRippleClickable(onClick = onClick),
-        contentAlignment = Alignment.Center,
-        content = content,
-    )
-}
+private val ChatToolbarHeight = 44.dp
+private val ChatToolbarPillSize = 44.dp
+private val ChatToolbarHorizontalPadding = 16.dp
+private val ChatToolbarPillGap = 4.dp
+private val ChatToolbarTitleSidePadding: Dp =
+    ChatToolbarHorizontalPadding + ChatToolbarPillSize + ChatToolbarPillGap
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -100,117 +76,136 @@ fun ChatTopToolbar(
 ) {
     var showDropdownMenu by remember { mutableStateOf(false) }
 
+    val showMenuButton = when (header) {
+        is ChatViewModel.HeaderView.ChatObject -> header.showDropDownMenu
+        is ChatViewModel.HeaderView.Default -> header.showDropDownMenu
+        ChatViewModel.HeaderView.Init -> false
+    }
+    val titleEndPadding: Dp =
+        if (showMenuButton) ChatToolbarTitleSidePadding else ChatToolbarHorizontalPadding
+
+    val isMuted = when (header) {
+        is ChatViewModel.HeaderView.Default -> header.isMuted
+        is ChatViewModel.HeaderView.ChatObject -> header.isMuted
+        else -> false
+    }
+    val titleText = when (header) {
+        is ChatViewModel.HeaderView.Default -> header.title.ifEmpty {
+            stringResource(R.string.untitled)
+        }
+        is ChatViewModel.HeaderView.ChatObject -> header.title.ifEmpty {
+            stringResource(R.string.untitled)
+        }
+        is ChatViewModel.HeaderView.Init -> ""
+    }
+
     Box(
-        modifier = modifier.height(52.dp)
+        modifier = modifier.height(ChatToolbarHeight)
     ) {
-        ChatToolbarCircularContainer(
+        Box(
             modifier = Modifier
                 .align(Alignment.CenterStart)
-                .padding(start = ChatToolbarButtonOuterPadding),
-            onClick = onBackButtonClicked
+                .padding(start = ChatToolbarHorizontalPadding)
+                .size(ChatToolbarPillSize)
+                .shadow(
+                    elevation = 20.dp,
+                    shape = CircleShape,
+                    clip = false
+                )
+                .background(
+                    color = colorResource(id = R.color.navigation_panel),
+                    shape = CircleShape
+                )
+                .noRippleThrottledClickable { onBackButtonClicked() },
+            contentAlignment = Alignment.Center
         ) {
             Image(
                 painter = painterResource(R.drawable.ic_default_top_back),
                 contentDescription = stringResource(R.string.content_desc_back_button)
             )
         }
-        
-        when(header) {
-            is ChatViewModel.HeaderView.ChatObject -> {
-                ChatToolbarCircularContainer(
-                    modifier = Modifier
-                        .align(Alignment.CenterEnd)
-                        .padding(end = ChatToolbarButtonOuterPadding),
-                    onClick = { showDropdownMenu = !showDropdownMenu }
-                ) {
-                    ListWidgetObjectIcon(
-                        modifier = Modifier,
-                        iconSize = 28.dp,
-                        icon = header.icon
-                    )
-                }
-            }
-            is ChatViewModel.HeaderView.Default -> {
-                val onRightContainerClick: () -> Unit = {
-                    if (header.showDropDownMenu) {
-                        showDropdownMenu = !showDropdownMenu
-                    } else {
-                        onSpaceIconClicked()
-                    }
-                }
-                ChatToolbarCircularContainer(
-                    modifier = Modifier
-                        .align(Alignment.CenterEnd)
-                        .padding(end = ChatToolbarButtonOuterPadding),
-                    onClick = onRightContainerClick
-                ) {
-                    SpaceIconView(
-                        modifier = Modifier,
-                        mainSize = 28.dp,
-                        icon = header.icon,
-                        onSpaceIconClick = onRightContainerClick
-                    )
-                }
-            }
-            ChatViewModel.HeaderView.Init -> {
-                // Do nothing
-            }
-        }
 
-        val isMuted = when (header) {
-            is ChatViewModel.HeaderView.Default -> header.isMuted
-            is ChatViewModel.HeaderView.ChatObject -> header.isMuted
-            else -> false
-        }
-        val titleText = when (header) {
-            is ChatViewModel.HeaderView.Default -> header.title.ifEmpty {
-                stringResource(R.string.untitled)
-            }
-            is ChatViewModel.HeaderView.ChatObject -> header.title.ifEmpty {
-                stringResource(R.string.untitled)
-            }
-            is ChatViewModel.HeaderView.Init -> ""
-        }
-
-        Box(
+        Row(
             modifier = Modifier
                 .align(Alignment.Center)
-                .padding(horizontal = ChatToolbarTitlePillHorizontalPadding)
-                .height(ChatToolbarButtonSize)
+                .fillMaxWidth()
+                .padding(start = ChatToolbarTitleSidePadding, end = titleEndPadding)
+                .fillMaxHeight()
                 .shadow(
-                    elevation = 4.dp,
-                    shape = RoundedCornerShape(20.dp),
-                    clip = false,
-                    ambientColor = Color.Black.copy(alpha = 0.12f),
-                    spotColor = Color.Black.copy(alpha = 0.12f),
+                    elevation = 20.dp,
+                    shape = RoundedCornerShape(22.dp),
+                    clip = false
                 )
-                .clip(RoundedCornerShape(20.dp))
-                .background(colorResource(R.color.shape_primary))
-                .noRippleClickable { onTitleClick() }
-                .padding(horizontal = 16.dp),
-            contentAlignment = Alignment.Center
+                .background(
+                    color = colorResource(id = R.color.navigation_panel),
+                    shape = RoundedCornerShape(22.dp)
+                )
+                .noRippleThrottledClickable { onTitleClick() }
+                .padding(horizontal = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = titleText,
-                    color = colorResource(R.color.text_primary),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    textAlign = TextAlign.Center,
-                    style = Title1,
-                    modifier = if (isMuted) Modifier.weight(1f, fill = false) else Modifier
-                )
-                if (isMuted) {
-                    Spacer(modifier = Modifier.width(6.dp))
-                    Image(
-                        modifier = Modifier.size(18.dp),
-                        painter = painterResource(id = R.drawable.ci_notifications_off),
-                        contentDescription = stringResource(id = R.string.content_desc_muted),
-                        colorFilter = ColorFilter.tint(colorResource(R.color.text_primary))
+            when (header) {
+                is ChatViewModel.HeaderView.ChatObject -> {
+                    ListWidgetObjectIcon(
+                        modifier = Modifier,
+                        iconSize = 24.dp,
+                        icon = header.icon
                     )
+                    Spacer(modifier = Modifier.width(8.dp))
                 }
+                is ChatViewModel.HeaderView.Default -> {
+                    SpaceIconView(
+                        modifier = Modifier,
+                        mainSize = 24.dp,
+                        icon = header.icon,
+                        onSpaceIconClick = { onTitleClick() }
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                ChatViewModel.HeaderView.Init -> Unit
+            }
+            Text(
+                text = titleText,
+                color = colorResource(R.color.text_primary),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = PreviewTitle2Regular,
+                modifier = Modifier.weight(1f, fill = false)
+            )
+            if (isMuted) {
+                Spacer(modifier = Modifier.width(6.dp))
+                Image(
+                    modifier = Modifier.size(18.dp),
+                    painter = painterResource(id = R.drawable.ci_notifications_off),
+                    contentDescription = stringResource(id = R.string.content_desc_muted),
+                    colorFilter = ColorFilter.tint(colorResource(R.color.text_primary))
+                )
+            }
+        }
+
+        if (showMenuButton) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .padding(end = ChatToolbarHorizontalPadding)
+                    .size(ChatToolbarPillSize)
+                    .shadow(
+                        elevation = 20.dp,
+                        shape = CircleShape,
+                        clip = false
+                    )
+                    .background(
+                        color = colorResource(id = R.color.navigation_panel),
+                        shape = CircleShape
+                    )
+                    .noRippleThrottledClickable { showDropdownMenu = true },
+                contentAlignment = Alignment.Center
+            ) {
+                Image(
+                    modifier = Modifier.size(24.dp),
+                    painter = painterResource(id = R.drawable.ic_space_list_dots),
+                    contentDescription = stringResource(R.string.more)
+                )
             }
         }
 
@@ -218,7 +213,7 @@ fun ChatTopToolbar(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 52.dp)
+                    .padding(top = ChatToolbarHeight)
                     .align(Alignment.TopEnd)
             ) {
                 ChatMenu(
@@ -261,7 +256,7 @@ fun ChatTopToolbar(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 52.dp)
+                    .padding(top = ChatToolbarHeight)
                     .align(Alignment.TopEnd)
             ) {
                 SpaceChatMenu(
@@ -330,6 +325,30 @@ fun ChatTopToolbarMutedPreview() {
             title = "My Chat Space",
             icon = SpaceIconView.ChatSpace.Placeholder(name = "MCS"),
             isMuted = true
+        ),
+        onSpaceIconClicked = {},
+        onBackButtonClicked = {},
+        onInviteMembersClicked = {},
+        onEditInfo = {},
+        onPin = {},
+        onCopyLink = {},
+        onMoveToBin = {},
+        onProperties = {},
+        onNotificationSettingChanged = {},
+        onSearchClick = {}
+    )
+}
+
+@DefaultPreviews
+@Composable
+fun ChatTopToolbarNoMenuPreview() {
+    ChatTopToolbar(
+        modifier = Modifier.fillMaxWidth(),
+        header = ChatViewModel.HeaderView.Default(
+            title = "Read-only Space",
+            icon = SpaceIconView.ChatSpace.Placeholder(name = "RO"),
+            isMuted = false,
+            showDropDownMenu = false
         ),
         onSpaceIconClicked = {},
         onBackButtonClicked = {},

--- a/feature-date/src/main/java/com/anytypeio/anytype/feature_date/ui/MainScreen.kt
+++ b/feature-date/src/main/java/com/anytypeio/anytype/feature_date/ui/MainScreen.kt
@@ -30,11 +30,11 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.anytypeio.anytype.core_models.Id
-import com.anytypeio.anytype.core_ui.foundation.components.BottomNavigationMenu
 import com.anytypeio.anytype.core_ui.lists.objects.PaginatedObjectList
 import com.anytypeio.anytype.core_ui.lists.objects.UiContentState
 import com.anytypeio.anytype.core_ui.lists.objects.UiObjectsListState
 import com.anytypeio.anytype.core_ui.syncstatus.SpaceSyncStatusScreen
+import com.anytypeio.anytype.core_ui.widgets.CircularFabButton
 import com.anytypeio.anytype.core_utils.insets.EDGE_TO_EDGE_MIN_SDK
 import com.anytypeio.anytype.feature_date.R
 import com.anytypeio.anytype.feature_date.ui.models.DateEvent
@@ -45,8 +45,8 @@ import com.anytypeio.anytype.feature_date.viewmodel.UiFieldsState
 import com.anytypeio.anytype.feature_date.viewmodel.UiHeaderState
 import com.anytypeio.anytype.feature_date.viewmodel.UiSnackbarState
 import com.anytypeio.anytype.feature_date.viewmodel.UiSyncStatusBadgeState
-import com.anytypeio.anytype.presentation.navigation.NavPanelState
 import com.anytypeio.anytype.presentation.sync.SyncStatusWidgetState
+import androidx.compose.ui.res.dimensionResource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -58,7 +58,6 @@ fun DateMainScreen(
     uiHeaderState: UiHeaderState,
     uiFieldsState: UiFieldsState,
     uiObjectsListState: UiObjectsListState,
-    uiNavigationWidget: NavPanelState,
     uiFieldsSheetState: UiFieldsSheetState,
     uiSyncStatusState: SyncStatusWidgetState,
     uiCalendarState: UiCalendarState,
@@ -106,7 +105,8 @@ fun DateMainScreen(
                 TopToolbarScreen(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(48.dp),
+                        .height(44.dp),
+                    uiHeaderState = uiHeaderState,
                     uiCalendarIconState = uiCalendarIconState,
                     uiSyncStatusBadgeState = uiSyncStatusBadgeState,
                     onDateEvent = onDateEvent
@@ -159,32 +159,26 @@ fun DateMainScreen(
                     uiState = uiContentState,
                     canPaginate = canPaginate,
                     onLoadMore = {
-                        DateEvent.ObjectsList.OnLoadMore
+                        onDateEvent(DateEvent.ObjectsList.OnLoadMore)
                     },
                     onMoveToBin = { item ->
-                        DateEvent.ObjectsList.OnObjectMoveToBin(item)
+                        onDateEvent(DateEvent.ObjectsList.OnObjectMoveToBin(item))
                     },
                     onObjectClicked = { item ->
-                        DateEvent.ObjectsList.OnObjectClicked(item)
+                        onDateEvent(DateEvent.ObjectsList.OnObjectClicked(item))
                     }
                 )
-                BottomNavigationMenu(
+                CircularFabButton(
                     modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = 16.dp),
-                    onSearchClick = {
-                        onDateEvent(DateEvent.NavigationWidget.OnGlobalSearchClick)
-                    },
-                    onAddDocClick = {
-                        onDateEvent(DateEvent.NavigationWidget.OnAddDocClick)
-                    },
-                    onAddDocLongClick = {
-                        onDateEvent(DateEvent.NavigationWidget.OnAddDocLongClick)
-                    },
-                    state = uiNavigationWidget,
-                    onHomeButtonClicked = {
-                        onDateEvent(DateEvent.NavigationWidget.OnHomeClick)
-                    }
+                        .align(Alignment.BottomEnd)
+                        .padding(
+                            end = dimensionResource(id = com.anytypeio.anytype.core_ui.R.dimen.nav_fab_margin),
+                            bottom = dimensionResource(id = com.anytypeio.anytype.core_ui.R.dimen.nav_fab_margin)
+                        ),
+                    iconRes = R.drawable.ic_create_obj_32,
+                    contentDescription = stringResource(id = R.string.create),
+                    onClick = { onDateEvent(DateEvent.NavigationWidget.OnAddDocClick) },
+                    onLongClick = { onDateEvent(DateEvent.NavigationWidget.OnAddDocLongClick) }
                 )
             }
         },

--- a/feature-date/src/main/java/com/anytypeio/anytype/feature_date/ui/TopToolbarScreen.kt
+++ b/feature-date/src/main/java/com/anytypeio/anytype/feature_date/ui/TopToolbarScreen.kt
@@ -1,16 +1,30 @@
 package com.anytypeio.anytype.feature_date.ui
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.anytypeio.anytype.core_models.DayOfWeekCustom
+import com.anytypeio.anytype.core_models.RelativeDate
 import com.anytypeio.anytype.core_models.multiplayer.P2PStatusUpdate
 import com.anytypeio.anytype.core_models.multiplayer.SpaceSyncAndP2PStatusState
 import com.anytypeio.anytype.core_models.multiplayer.SpaceSyncError
@@ -21,14 +35,17 @@ import com.anytypeio.anytype.core_models.primitives.TimestampInSeconds
 import com.anytypeio.anytype.core_ui.common.DefaultPreviews
 import com.anytypeio.anytype.core_ui.foundation.noRippleThrottledClickable
 import com.anytypeio.anytype.core_ui.syncstatus.StatusBadge
+import com.anytypeio.anytype.core_ui.views.PreviewTitle2Regular
 import com.anytypeio.anytype.feature_date.R
 import com.anytypeio.anytype.feature_date.ui.models.DateEvent
 import com.anytypeio.anytype.feature_date.viewmodel.UiCalendarIconState
+import com.anytypeio.anytype.feature_date.viewmodel.UiHeaderState
 import com.anytypeio.anytype.feature_date.viewmodel.UiSyncStatusBadgeState
 
 @Composable
 fun TopToolbarScreen(
     modifier: Modifier,
+    uiHeaderState: UiHeaderState,
     uiCalendarIconState: UiCalendarIconState,
     uiSyncStatusBadgeState: UiSyncStatusBadgeState,
     onDateEvent: (DateEvent) -> Unit
@@ -36,44 +53,135 @@ fun TopToolbarScreen(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(48.dp)
+            .height(44.dp)
     ) {
-        if (uiSyncStatusBadgeState is UiSyncStatusBadgeState.Visible) {
-            Box(
-                modifier = Modifier
-                    .size(48.dp)
-                    .noRippleThrottledClickable {
-                        onDateEvent(
-                            DateEvent.TopToolbar.OnSyncStatusClick(
-                                status = uiSyncStatusBadgeState.status
-                            )
-                        )
-                    },
-            ) {
-                StatusBadge(
-                    status = uiSyncStatusBadgeState.status,
-                    modifier = Modifier
-                        .size(28.dp)
-                        .align(Alignment.Center)
+        // Back pill — circular button at start.
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .padding(start = 16.dp)
+                .size(44.dp)
+                .shadow(
+                    elevation = 20.dp,
+                    shape = CircleShape,
+                    clip = false
+                )
+                .background(
+                    color = colorResource(id = com.anytypeio.anytype.core_ui.R.color.navigation_panel),
+                    shape = CircleShape
+                )
+                .noRippleThrottledClickable {
+                    onDateEvent(DateEvent.TopToolbar.OnBackClick)
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            Image(
+                modifier = Modifier.wrapContentSize(),
+                painter = painterResource(R.drawable.ic_default_top_back),
+                contentDescription = stringResource(R.string.content_desc_back_button)
+            )
+        }
+
+        // Center title pill — tapping opens the widgets overlay.
+        Row(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .fillMaxWidth()
+                .padding(start = 64.dp, end = 120.dp)
+                .fillMaxHeight()
+                .shadow(
+                    elevation = 20.dp,
+                    shape = RoundedCornerShape(22.dp),
+                    clip = false
+                )
+                .background(
+                    color = colorResource(id = com.anytypeio.anytype.core_ui.R.color.navigation_panel),
+                    shape = RoundedCornerShape(22.dp)
+                )
+                .noRippleThrottledClickable {
+                    onDateEvent(DateEvent.TopToolbar.OnTitleClick)
+                }
+                .padding(horizontal = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            val titleText = (uiHeaderState as? UiHeaderState.Content)?.title.orEmpty()
+            if (titleText.isNotEmpty()) {
+                Text(
+                    text = titleText,
+                    style = PreviewTitle2Regular,
+                    color = colorResource(id = com.anytypeio.anytype.core_ui.R.color.text_primary),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
             }
         }
-        if (uiCalendarIconState is UiCalendarIconState.Visible) {
-            Image(
-                modifier = Modifier
-                    .size(48.dp)
-                    .align(Alignment.CenterEnd)
-                    .noRippleThrottledClickable {
-                        onDateEvent(
-                            DateEvent.TopToolbar.OnCalendarClick(
-                                timestampInSeconds = uiCalendarIconState.timestampInSeconds
-                            )
+
+        // Trailing — optional sync badge pill + calendar pill (rightmost slot).
+        Row(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(end = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            if (uiSyncStatusBadgeState is UiSyncStatusBadgeState.Visible) {
+                Box(
+                    modifier = Modifier
+                        .size(44.dp)
+                        .shadow(
+                            elevation = 20.dp,
+                            shape = CircleShape,
+                            clip = false
                         )
-                    },
-                contentDescription = null,
-                painter = painterResource(id = R.drawable.ic_calendar_24),
-                contentScale = ContentScale.None
-            )
+                        .background(
+                            color = colorResource(id = com.anytypeio.anytype.core_ui.R.color.navigation_panel),
+                            shape = CircleShape
+                        )
+                        .noRippleThrottledClickable {
+                            onDateEvent(
+                                DateEvent.TopToolbar.OnSyncStatusClick(
+                                    status = uiSyncStatusBadgeState.status
+                                )
+                            )
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    StatusBadge(
+                        status = uiSyncStatusBadgeState.status,
+                        modifier = Modifier.size(28.dp)
+                    )
+                }
+            }
+            if (uiCalendarIconState is UiCalendarIconState.Visible) {
+                Box(
+                    modifier = Modifier
+                        .size(44.dp)
+                        .shadow(
+                            elevation = 20.dp,
+                            shape = CircleShape,
+                            clip = false
+                        )
+                        .background(
+                            color = colorResource(id = com.anytypeio.anytype.core_ui.R.color.navigation_panel),
+                            shape = CircleShape
+                        )
+                        .noRippleThrottledClickable {
+                            onDateEvent(
+                                DateEvent.TopToolbar.OnCalendarClick(
+                                    timestampInSeconds = uiCalendarIconState.timestampInSeconds
+                                )
+                            )
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Image(
+                        modifier = Modifier.size(24.dp),
+                        painter = painterResource(id = R.drawable.ic_calendar_24),
+                        contentDescription = null
+                    )
+                }
+            }
         }
     }
 }
@@ -90,6 +198,13 @@ fun TopToolbarPreview() {
     )
     TopToolbarScreen(
         modifier = Modifier.fillMaxWidth(),
+        uiHeaderState = UiHeaderState.Content(
+            title = "Tue, 12 Oct",
+            relativeDate = RelativeDate.Today(
+                initialTimeInMillis = 1634016000000,
+                dayOfWeek = DayOfWeekCustom.MONDAY
+            )
+        ),
         uiCalendarIconState = UiCalendarIconState.Visible(
             timestampInSeconds = TimestampInSeconds(3232L)
         ),
@@ -99,6 +214,18 @@ fun TopToolbarPreview() {
                 p2PStatusUpdate = P2PStatusUpdate.Initial
             )
         ),
+        onDateEvent = {}
+    )
+}
+
+@Composable
+@DefaultPreviews
+fun TopToolbarHiddenSyncPreview() {
+    TopToolbarScreen(
+        modifier = Modifier.fillMaxWidth(),
+        uiHeaderState = UiHeaderState.Loading,
+        uiCalendarIconState = UiCalendarIconState.Hidden,
+        uiSyncStatusBadgeState = UiSyncStatusBadgeState.Hidden,
         onDateEvent = {}
     )
 }

--- a/feature-date/src/main/java/com/anytypeio/anytype/feature_date/ui/models/DateEvent.kt
+++ b/feature-date/src/main/java/com/anytypeio/anytype/feature_date/ui/models/DateEvent.kt
@@ -11,6 +11,8 @@ sealed class DateEvent {
     sealed class TopToolbar : DateEvent() {
         data class OnSyncStatusClick(val status: SpaceSyncAndP2PStatusState) : TopToolbar()
         data class OnCalendarClick(val timestampInSeconds: TimestampInSeconds) : TopToolbar()
+        data object OnBackClick : TopToolbar()
+        data object OnTitleClick : TopToolbar()
     }
 
     sealed class Header : DateEvent() {

--- a/feature-date/src/main/java/com/anytypeio/anytype/feature_date/viewmodel/DateObjectCommand.kt
+++ b/feature-date/src/main/java/com/anytypeio/anytype/feature_date/viewmodel/DateObjectCommand.kt
@@ -20,4 +20,5 @@ sealed class DateObjectCommand {
     data object OpenGlobalSearch : DateObjectCommand()
     data object ExitToVault : DateObjectCommand()
     data object Back : DateObjectCommand()
+    data object OpenWidgets : DateObjectCommand()
 }

--- a/feature-date/src/main/java/com/anytypeio/anytype/feature_date/viewmodel/DateObjectViewModel.kt
+++ b/feature-date/src/main/java/com/anytypeio/anytype/feature_date/viewmodel/DateObjectViewModel.kt
@@ -786,6 +786,18 @@ class DateObjectViewModel(
                 uiSyncStatusWidgetState.value =
                     event.status.toSyncStatusWidgetState()
             }
+
+            DateEvent.TopToolbar.OnBackClick -> {
+                viewModelScope.launch {
+                    effects.emit(DateObjectCommand.Back)
+                }
+            }
+
+            DateEvent.TopToolbar.OnTitleClick -> {
+                viewModelScope.launch {
+                    effects.emit(DateObjectCommand.OpenWidgets)
+                }
+            }
         }
     }
 

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/Models.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/Models.kt
@@ -111,12 +111,37 @@ sealed class VaultCommand {
 }
 
 sealed class VaultNavigation {
-    data class OpenChat(val ctx: Id, val space: Id) : VaultNavigation()
-    data class OpenObject(val ctx: Id, val space: Id) : VaultNavigation()
-    data class OpenSet(val ctx: Id, val space: Id, val view: Id?) : VaultNavigation()
-    data class OpenDateObject(val ctx: Id, val space: Id) : VaultNavigation()
-    data class OpenParticipant(val ctx: Id, val space: Id) : VaultNavigation()
-    data class OpenType(val target: Id, val space: Id) : VaultNavigation()
+    data class OpenChat(
+        val ctx: Id,
+        val space: Id,
+        val openTargetDirectly: Boolean = false
+    ) : VaultNavigation()
+    data class OpenObject(
+        val ctx: Id,
+        val space: Id,
+        val openTargetDirectly: Boolean = false
+    ) : VaultNavigation()
+    data class OpenSet(
+        val ctx: Id,
+        val space: Id,
+        val view: Id?,
+        val openTargetDirectly: Boolean = false
+    ) : VaultNavigation()
+    data class OpenDateObject(
+        val ctx: Id,
+        val space: Id,
+        val openTargetDirectly: Boolean = false
+    ) : VaultNavigation()
+    data class OpenParticipant(
+        val ctx: Id,
+        val space: Id,
+        val openTargetDirectly: Boolean = false
+    ) : VaultNavigation()
+    data class OpenType(
+        val target: Id,
+        val space: Id,
+        val openTargetDirectly: Boolean = false
+    ) : VaultNavigation()
     data class OpenUrl(val url: String) : VaultNavigation()
     data class ShowError(val message: String) : VaultNavigation()
 }

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModel.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModel.kt
@@ -8,8 +8,6 @@ import com.anytypeio.anytype.analytics.base.EventsPropertiesKey
 import com.anytypeio.anytype.analytics.base.sendEvent
 import com.anytypeio.anytype.analytics.props.Props
 import com.anytypeio.anytype.core_models.Config
-import com.anytypeio.anytype.core_models.DVFilter
-import com.anytypeio.anytype.core_models.DVFilterCondition
 import com.anytypeio.anytype.core_models.NetworkMode
 import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.core_models.ObjectWrapper
@@ -58,9 +56,9 @@ import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
 import com.anytypeio.anytype.domain.primitives.FieldParser
 import com.anytypeio.anytype.domain.resources.StringResourceProvider
 import com.anytypeio.anytype.domain.search.ProfileSubscriptionManager
-import com.anytypeio.anytype.domain.search.SearchObjects
 import com.anytypeio.anytype.domain.spaces.CreateSpace
 import com.anytypeio.anytype.domain.spaces.DeleteSpace
+import com.anytypeio.anytype.domain.spaces.ResolveSpaceHomepage
 import com.anytypeio.anytype.domain.spaces.SaveCurrentSpace
 import com.anytypeio.anytype.domain.vault.SetCreateSpaceBadgeSeen
 import com.anytypeio.anytype.domain.vault.SetSpaceOrder
@@ -140,7 +138,7 @@ class VaultViewModel(
     private val osWidgetDataViewSync: OsWidgetDataViewSync,
     private val networkModeProvider: NetworkModeProvider,
     private val getMembershipFeatures: GetMembershipFeatures,
-    private val searchObjects: SearchObjects,
+    private val resolveSpaceHomepage: ResolveSpaceHomepage,
     private val userSettingsRepository: UserSettingsRepository
 ) : ViewModel(),
     DeepLinkToObjectDelegate by deepLinkToObjectDelegate {
@@ -1179,69 +1177,40 @@ class VaultViewModel(
                 VaultCommand.EnterSpaceLevelChat(space = targetSpace, chat = chat)
             }
             else -> {
-                val homepage = spaceView?.homepage
-                resolveHomepageNavigation(homepage, targetSpace)
+                resolveHomepageNavigation(targetSpace)
             }
         }
     }
 
     private suspend fun resolveHomepageNavigation(
-        homepage: String?,
         targetSpace: SpaceId
     ): VaultCommand? {
-        if (homepage.isNullOrEmpty() || homepage in HOMEPAGE_SPECIAL_CONSTANTS) {
-            return VaultCommand.EnterSpaceHomeScreen(space = targetSpace)
-        }
-        // Homepage is an object ID — resolve and navigate
-        val results = searchObjects.invoke(
-            params = SearchObjects.Params(
-                space = targetSpace,
-                filters = listOf(
-                    DVFilter(
-                        relation = Relations.ID,
-                        value = homepage,
-                        condition = DVFilterCondition.EQUAL
-                    )
-                ),
-                keys = listOf(Relations.ID, Relations.LAYOUT, Relations.SPACE_ID),
-                limit = 1
-            )
-        )
-        val obj = results.getOrNull()?.firstOrNull()
-        if (obj == null) {
-            Timber.w("Homepage object $homepage not found, falling back to widgets")
-            return VaultCommand.EnterSpaceHomeScreen(space = targetSpace)
-        }
-        // Navigate to the homepage object via VaultNavigation
-        // (VaultFragment first opens the widgets screen, then the object on top)
-        when (val nav = obj.navigation()) {
-            is OpenObjectNavigation.OpenParticipant -> {
-                return VaultCommand.EnterSpaceHomeScreen(space = targetSpace)
-            }
-            is OpenObjectNavigation.OpenBookmarkUrl -> {
-                // Open bookmark as editor object, not as external URL
-                proceedWithNavigation(
-                    OpenObjectNavigation.OpenEditor(
-                        target = homepage,
-                        space = obj.spaceId ?: targetSpace.id
-                    )
-                )
-                return null
-            }
-            else -> {
-                proceedWithNavigation(nav)
-                return null
+        val result = resolveSpaceHomepage.async(
+            ResolveSpaceHomepage.Params(space = targetSpace)
+        ).getOrNull() ?: ResolveSpaceHomepage.Result.Widgets
+        return when (result) {
+            ResolveSpaceHomepage.Result.Widgets ->
+                VaultCommand.EnterSpaceHomeScreen(space = targetSpace)
+            is ResolveSpaceHomepage.Result.Object -> {
+                // Homepage is an explicit object — open it directly, bypassing
+                // the widgets back-stack entry (DROID-4388).
+                proceedWithNavigation(result.navigation, openTargetDirectly = true)
+                null
             }
         }
     }
 
-    private fun proceedWithNavigation(navigation: OpenObjectNavigation) {
+    private fun proceedWithNavigation(
+        navigation: OpenObjectNavigation,
+        openTargetDirectly: Boolean = false
+    ) {
         val nav = when (navigation) {
             is OpenObjectNavigation.OpenDataView -> {
                 VaultNavigation.OpenSet(
                     ctx = navigation.target,
                     space = navigation.space,
-                    view = null
+                    view = null,
+                    openTargetDirectly = openTargetDirectly
                 )
             }
 
@@ -1249,7 +1218,8 @@ class VaultViewModel(
 
                 VaultNavigation.OpenObject(
                     ctx = navigation.target,
-                    space = navigation.space
+                    space = navigation.space,
+                    openTargetDirectly = openTargetDirectly
                 )
 
             }
@@ -1257,7 +1227,8 @@ class VaultViewModel(
             is OpenObjectNavigation.OpenChat -> {
                 VaultNavigation.OpenChat(
                     ctx = navigation.target,
-                    space = navigation.space
+                    space = navigation.space,
+                    openTargetDirectly = openTargetDirectly
                 )
 
             }
@@ -1273,7 +1244,8 @@ class VaultViewModel(
             is OpenObjectNavigation.OpenDateObject -> {
                 VaultNavigation.OpenDateObject(
                     ctx = navigation.target,
-                    space = navigation.space
+                    space = navigation.space,
+                    openTargetDirectly = openTargetDirectly
                 )
 
             }
@@ -1281,7 +1253,8 @@ class VaultViewModel(
             is OpenObjectNavigation.OpenParticipant -> {
                 VaultNavigation.OpenParticipant(
                     ctx = navigation.target,
-                    space = navigation.space
+                    space = navigation.space,
+                    openTargetDirectly = openTargetDirectly
                 )
 
             }
@@ -1289,7 +1262,8 @@ class VaultViewModel(
             is OpenObjectNavigation.OpenType -> {
                 VaultNavigation.OpenType(
                     target = navigation.target,
-                    space = navigation.space
+                    space = navigation.space,
+                    openTargetDirectly = openTargetDirectly
                 )
             }
 
@@ -1676,6 +1650,5 @@ class VaultViewModel(
 
     companion object {
         private const val OS_WIDGET_SYNC_DEBOUNCE_MS = 2000L
-        private val HOMEPAGE_SPECIAL_CONSTANTS = setOf("widgets", "graph", "lastOpened")
     }
 }

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModelFactory.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModelFactory.kt
@@ -24,9 +24,9 @@ import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
 import com.anytypeio.anytype.domain.primitives.FieldParser
 import com.anytypeio.anytype.domain.resources.StringResourceProvider
 import com.anytypeio.anytype.domain.search.ProfileSubscriptionManager
-import com.anytypeio.anytype.domain.search.SearchObjects
 import com.anytypeio.anytype.domain.spaces.CreateSpace
 import com.anytypeio.anytype.domain.spaces.DeleteSpace
+import com.anytypeio.anytype.domain.spaces.ResolveSpaceHomepage
 import com.anytypeio.anytype.domain.spaces.SaveCurrentSpace
 import com.anytypeio.anytype.domain.vault.SetCreateSpaceBadgeSeen
 import com.anytypeio.anytype.domain.vault.SetSpaceOrder
@@ -77,7 +77,7 @@ class VaultViewModelFactory @Inject constructor(
     private val osWidgetDataViewSync: OsWidgetDataViewSync,
     private val networkModeProvider: NetworkModeProvider,
     private val getMembershipFeatures: GetMembershipFeatures,
-    private val searchObjects: SearchObjects,
+    private val resolveSpaceHomepage: ResolveSpaceHomepage,
     private val userSettingsRepository: UserSettingsRepository
 ) : ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
@@ -119,7 +119,7 @@ class VaultViewModelFactory @Inject constructor(
         osWidgetDataViewSync = osWidgetDataViewSync,
         networkModeProvider = networkModeProvider,
         getMembershipFeatures = getMembershipFeatures,
-        searchObjects = searchObjects,
+        resolveSpaceHomepage = resolveSpaceHomepage,
         userSettingsRepository = userSettingsRepository
     ) as T
 }

--- a/feature-vault/src/test/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModelFabric.kt
+++ b/feature-vault/src/test/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModelFabric.kt
@@ -23,9 +23,9 @@ import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
 import com.anytypeio.anytype.domain.primitives.FieldParser
 import com.anytypeio.anytype.domain.resources.StringResourceProvider
 import com.anytypeio.anytype.domain.search.ProfileSubscriptionManager
-import com.anytypeio.anytype.domain.search.SearchObjects
 import com.anytypeio.anytype.domain.spaces.CreateSpace
 import com.anytypeio.anytype.domain.spaces.DeleteSpace
+import com.anytypeio.anytype.domain.spaces.ResolveSpaceHomepage
 import com.anytypeio.anytype.domain.spaces.SaveCurrentSpace
 import com.anytypeio.anytype.domain.vault.SetCreateSpaceBadgeSeen
 import com.anytypeio.anytype.domain.vault.SetSpaceOrder
@@ -91,7 +91,7 @@ object VaultViewModelFabric {
         osWidgetDataViewSync: OsWidgetDataViewSync = mock(),
         networkModeProvider: NetworkModeProvider = mock(),
         getMembershipFeatures: GetMembershipFeatures = mock(),
-        searchObjects: SearchObjects = mock(),
+        resolveSpaceHomepage: ResolveSpaceHomepage = mock(),
         userSettingsRepository: UserSettingsRepository = mock {
             on { observeCompactModeEnabled() }.thenReturn(flowOf(false))
         }
@@ -131,7 +131,7 @@ object VaultViewModelFabric {
         osWidgetDataViewSync = osWidgetDataViewSync,
         networkModeProvider = networkModeProvider,
         getMembershipFeatures = getMembershipFeatures,
-        searchObjects = searchObjects,
+        resolveSpaceHomepage = resolveSpaceHomepage,
         userSettingsRepository = userSettingsRepository
     )
 }

--- a/localization/src/main/res/values/strings.xml
+++ b/localization/src/main/res/values/strings.xml
@@ -2397,6 +2397,8 @@ Please provide specific details of your needs here.</string>
     </string>
     <string name="private_local_yours_forever">encrypted, local, yours forever</string>
     <string name="private_channel">Direct channel</string>
+    <string name="space_header_private_channel">Private channel</string>
+    <string name="space_header_group_channel">Group channel</string>
     <string name="wallpaper_item_space_icon_color">Default Color</string>
 
     <string name="publish_to_web">Publish to Web</string>

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomeScreenViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomeScreenViewModel.kt
@@ -652,13 +652,23 @@ class HomeScreenViewModel(
                     } else {
                         name
                     }
+                    val otherMember = if (
+                        spaceView.isOneToOneSpace
+                        && members is ActiveSpaceMemberSubscriptionContainer.Store.Data
+                    ) {
+                        members.members.find { it.identity == spaceView.oneToOneIdentity }
+                    } else {
+                        null
+                    }
                     _spaceViewState.value = SpaceViewState.Success(
                         spaceName = spaceName,
                         spaceIcon = spaceIcon,
                         membersCount = spaceMemberCount,
                         spaceChatId = spaceView.getSingleValue<String>(Relations.CHAT_ID),
                         isOneToOneSpace = spaceView.isOneToOneSpace,
-                        spaceAccessType = spaceView.spaceAccessType ?: SpaceAccessType.PRIVATE
+                        spaceAccessType = spaceView.spaceAccessType ?: SpaceAccessType.PRIVATE,
+                        memberGlobalName = otherMember?.globalName,
+                        memberIdentity = otherMember?.identity
                     )
                 }
         }
@@ -3650,6 +3660,8 @@ class HomeScreenViewModel(
             val spaceChatId: Id? = null,
             val spaceAccessType: SpaceAccessType,
             val isOneToOneSpace: Boolean,
+            val memberGlobalName: String? = null,
+            val memberIdentity: String? = null,
         ) : SpaceViewState() {
             val canCreateAdditionalChats: Boolean
                 get() = !isOneToOneSpace

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/home/SpaceHomepageResolver.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/home/SpaceHomepageResolver.kt
@@ -1,0 +1,13 @@
+package com.anytypeio.anytype.presentation.home
+
+import com.anytypeio.anytype.core_models.ObjectWrapper
+import com.anytypeio.anytype.domain.spaces.ResolveSpaceHomepage
+
+object SpaceHomepageResolver {
+
+    fun isExplicitObjectHomepage(homepage: String?): Boolean =
+        !homepage.isNullOrEmpty() && homepage !in ResolveSpaceHomepage.HOMEPAGE_SPECIAL_CONSTANTS
+
+    fun shouldSkipWidgetInjection(spaceView: ObjectWrapper.SpaceView?): Boolean =
+        isExplicitObjectHomepage(spaceView?.homepage)
+}

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/main/MainViewModel.kt
@@ -52,11 +52,13 @@ import com.anytypeio.anytype.domain.multiplayer.ParticipantSubscriptionContainer
 import com.anytypeio.anytype.domain.multiplayer.SpaceInviteResolver
 import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
 import com.anytypeio.anytype.domain.notifications.SystemNotificationService
+import com.anytypeio.anytype.domain.spaces.ResolveSpaceHomepage
 import com.anytypeio.anytype.domain.subscriptions.GlobalSubscriptionManager
 import com.anytypeio.anytype.domain.vault.SetSpacesIntroductionShown
 import com.anytypeio.anytype.domain.wallpaper.ObserveSpaceWallpaper
 import com.anytypeio.anytype.domain.workspace.DeepLinkToObjectDelegate
 import com.anytypeio.anytype.domain.workspace.SpaceManager
+import com.anytypeio.anytype.presentation.home.SpaceHomepageResolver
 import com.anytypeio.anytype.presentation.main.MainViewModel.Command.ShowDeletedAccountScreen
 import com.anytypeio.anytype.presentation.membership.provider.MembershipProvider
 import com.anytypeio.anytype.presentation.notifications.NotificationAction
@@ -111,6 +113,7 @@ class MainViewModel(
     private val chatsDetailsSubscriptionContainer: ChatsDetailsSubscriptionContainer,
     private val participantSubscriptionContainer: ParticipantSubscriptionContainer,
     private val userSettingsRepository: UserSettingsRepository,
+    private val resolveSpaceHomepage: ResolveSpaceHomepage,
     private val debugRunProfiler: DebugRunProfiler
 ) : ViewModel(),
     NotificationActionDelegate by notificationActionDelegate,
@@ -678,6 +681,28 @@ class MainViewModel(
                 "OS widget navigation: space=$targetSpace, " +
                     "oneToOne=$shouldNavigateDirectlyToChat, chatId=$chatId"
             )
+
+            // When the space has an explicit-object homepage configured, resolve it
+            // and open it directly (skipping the widgets back-stack entry).
+            if (!shouldNavigateDirectlyToChat &&
+                SpaceHomepageResolver.shouldSkipWidgetInjection(spaceView)
+            ) {
+                val homepageResult = resolveSpaceHomepage.async(
+                    ResolveSpaceHomepage.Params(space = SpaceId(targetSpace))
+                ).getOrNull()
+                if (homepageResult is ResolveSpaceHomepage.Result.Object) {
+                    commands.emit(
+                        Command.Deeplink.DeepLinkToObjectFromWidget(
+                            space = targetSpace,
+                            obj = spaceView?.homepage.orEmpty(),
+                            navigation = homepageResult.navigation,
+                            openTargetDirectly = true
+                        )
+                    )
+                    return
+                }
+            }
+
             commands.emit(
                 Command.Deeplink.DeepLinkToSpace(
                     space = targetSpace,
@@ -726,7 +751,8 @@ class MainViewModel(
                     Command.Deeplink.DeepLinkToObjectFromWidget(
                         space = targetSpace,
                         obj = objectId,
-                        navigation = navigation
+                        navigation = navigation,
+                        openTargetDirectly = hasExplicitObjectHomepage(SpaceId(targetSpace))
                     )
                 )
             }
@@ -754,8 +780,6 @@ class MainViewModel(
             .set(targetSpace)
             .onSuccess { config ->
                 val home = config.home
-                val spaceView = spaceViews
-                    .get(deeplink.space)
                 val sideEffect = Command.Deeplink.DeepLinkToObject.SideEffect.SwitchSpace(home = home)
                 viewModelScope.sendEvent(
                     analytics = analytics,
@@ -771,11 +795,23 @@ class MainViewModel(
                         navigation = result.obj.navigation(),
                         sideEffect = sideEffect,
                         space = deeplink.space.id,
-                        obj = deeplink.obj
+                        obj = deeplink.obj,
+                        openTargetDirectly = hasExplicitObjectHomepage(deeplink.space)
                     ),
                 )
             }
     }
+
+    /**
+     * Returns `true` when the given space has an explicit-object homepage configured
+     * (see DROID-4388). When `true`, deep-link/push back-stack handlers skip the
+     * widgets-screen injection so the back stack ends at [Vault, Target].
+     *
+     * Falls back to `false` when the SpaceView is not yet loaded — conservative
+     * default preserves the legacy [Vault, Widgets, Target] shape.
+     */
+    private fun hasExplicitObjectHomepage(space: SpaceId): Boolean =
+        SpaceHomepageResolver.shouldSkipWidgetInjection(spaceViews.get(space))
 
     fun onOpenChatTriggeredByPush(chatId: String, spaceId: String) {
         Timber.d("onOpenChatTriggeredByPush: $chatId, $spaceId")
@@ -788,7 +824,8 @@ class MainViewModel(
                             Command.LaunchChat(
                                 space = spaceId,
                                 chat = chatId,
-                                triggeredByPush = true
+                                triggeredByPush = true,
+                                openTargetDirectly = hasExplicitObjectHomepage(SpaceId(spaceId))
                             )
                         )
                     }.onFailure {
@@ -803,7 +840,8 @@ class MainViewModel(
                     Command.LaunchChat(
                         space = spaceId,
                         chat = chatId,
-                        triggeredByPush = true
+                        triggeredByPush = true,
+                        openTargetDirectly = hasExplicitObjectHomepage(SpaceId(spaceId))
                     )
                 )
             }
@@ -960,7 +998,8 @@ class MainViewModel(
         data class LaunchChat(
             val space: Id,
             val chat: Id,
-            val triggeredByPush: Boolean = false
+            val triggeredByPush: Boolean = false,
+            val openTargetDirectly: Boolean = false
         ) : Command()
 
         data class Navigate(val destination: OpenObjectNavigation) : Command()
@@ -971,7 +1010,8 @@ class MainViewModel(
                 val obj: Id,
                 val space: Id,
                 val navigation: OpenObjectNavigation,
-                val sideEffect: SideEffect? = null
+                val sideEffect: SideEffect? = null,
+                val openTargetDirectly: Boolean = false
             ) : Deeplink() {
                 sealed class SideEffect {
                     data class SwitchSpace(val home: Id) : SideEffect()
@@ -1010,7 +1050,8 @@ class MainViewModel(
             data class DeepLinkToObjectFromWidget(
                 val space: Id,
                 val obj: Id,
-                val navigation: OpenObjectNavigation
+                val navigation: OpenObjectNavigation,
+                val openTargetDirectly: Boolean = false
             ) : Deeplink()
 
             /**

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/main/MainViewModel.kt
@@ -691,14 +691,30 @@ class MainViewModel(
                     ResolveSpaceHomepage.Params(space = SpaceId(targetSpace))
                 ).getOrNull()
                 if (homepageResult is ResolveSpaceHomepage.Result.Object) {
-                    commands.emit(
-                        Command.Deeplink.DeepLinkToObjectFromWidget(
-                            space = targetSpace,
-                            obj = spaceView?.homepage.orEmpty(),
-                            navigation = homepageResult.navigation,
-                            openTargetDirectly = true
-                        )
-                    )
+                    // Chat homepages must go through the chat-screen nav graph
+                    // rather than `proceedWithOpenObjectNavigation`, which rejects
+                    // `OpenChat` with a toast.
+                    when (val nav = homepageResult.navigation) {
+                        is OpenObjectNavigation.OpenChat -> {
+                            commands.emit(
+                                Command.Deeplink.DeepLinkToSpace(
+                                    space = targetSpace,
+                                    shouldNavigateDirectlyToChat = true,
+                                    chatId = nav.target
+                                )
+                            )
+                        }
+                        else -> {
+                            commands.emit(
+                                Command.Deeplink.DeepLinkToObjectFromWidget(
+                                    space = targetSpace,
+                                    obj = spaceView?.homepage.orEmpty(),
+                                    navigation = nav,
+                                    openTargetDirectly = true
+                                )
+                            )
+                        }
+                    }
                     return
                 }
             }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/main/MainViewModelFactory.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/main/MainViewModelFactory.kt
@@ -23,6 +23,7 @@ import com.anytypeio.anytype.domain.multiplayer.ParticipantSubscriptionContainer
 import com.anytypeio.anytype.domain.multiplayer.SpaceInviteResolver
 import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
 import com.anytypeio.anytype.domain.notifications.SystemNotificationService
+import com.anytypeio.anytype.domain.spaces.ResolveSpaceHomepage
 import com.anytypeio.anytype.domain.subscriptions.GlobalSubscriptionManager
 import com.anytypeio.anytype.domain.vault.SetSpacesIntroductionShown
 import com.anytypeio.anytype.domain.wallpaper.ObserveSpaceWallpaper
@@ -64,6 +65,7 @@ class MainViewModelFactory @Inject constructor(
     private val chatsDetailsSubscriptionContainer: ChatsDetailsSubscriptionContainer,
     private val participantSubscriptionContainer: ParticipantSubscriptionContainer,
     private val userSettingsRepository: UserSettingsRepository,
+    private val resolveSpaceHomepage: ResolveSpaceHomepage,
     private val debugRunProfiler: DebugRunProfiler
     ) : ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
@@ -99,6 +101,7 @@ class MainViewModelFactory @Inject constructor(
         chatsDetailsSubscriptionContainer = chatsDetailsSubscriptionContainer,
         participantSubscriptionContainer = participantSubscriptionContainer,
         userSettingsRepository = userSettingsRepository,
+        resolveSpaceHomepage = resolveSpaceHomepage,
         debugRunProfiler = debugRunProfiler
     ) as T
 }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/notifications/NotificationActionDelegate.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/notifications/NotificationActionDelegate.kt
@@ -144,13 +144,15 @@ interface NotificationActionDelegate {
             val homepageResult = resolveSpaceHomepage.async(
                 ResolveSpaceHomepage.Params(space = space)
             ).getOrNull()
-            return if (homepageResult is ResolveSpaceHomepage.Result.Object) {
-                NotificationCommand.GoToObject(
-                    space = space,
-                    navigation = homepageResult.navigation
-                )
-            } else {
-                NotificationCommand.GoToSpace(space = space)
+            if (homepageResult !is ResolveSpaceHomepage.Result.Object) {
+                return NotificationCommand.GoToSpace(space = space)
+            }
+            // Chat homepages need the chat-screen nav graph, not the generic
+            // object-navigation path (which rejects OpenChat with a toast).
+            return when (val nav = homepageResult.navigation) {
+                is com.anytypeio.anytype.core_models.misc.OpenObjectNavigation.OpenChat ->
+                    NotificationCommand.GoToChat(space = space, chat = nav.target)
+                else -> NotificationCommand.GoToObject(space = space, navigation = nav)
             }
         }
     }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/notifications/NotificationActionDelegate.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/notifications/NotificationActionDelegate.kt
@@ -4,6 +4,7 @@ import com.anytypeio.anytype.domain.base.fold
 import com.anytypeio.anytype.domain.multiplayer.GetSpaceMemberByIdentity
 import com.anytypeio.anytype.domain.notifications.ReplyNotifications
 import com.anytypeio.anytype.domain.notifications.SystemNotificationService
+import com.anytypeio.anytype.domain.spaces.ResolveSpaceHomepage
 import com.anytypeio.anytype.domain.spaces.SaveCurrentSpace
 import com.anytypeio.anytype.domain.workspace.SpaceManager
 import javax.inject.Inject
@@ -22,7 +23,8 @@ interface NotificationActionDelegate {
         private val replyNotifications: ReplyNotifications,
         private val systemNotificationService: SystemNotificationService,
         private val spaceManager: SpaceManager,
-        private val saveCurrentSpace: SaveCurrentSpace
+        private val saveCurrentSpace: SaveCurrentSpace,
+        private val resolveSpaceHomepage: ResolveSpaceHomepage
     ) : NotificationActionDelegate {
 
         override val dispatcher: MutableSharedFlow<NotificationCommand> = MutableSharedFlow()
@@ -123,11 +125,33 @@ interface NotificationActionDelegate {
                             Timber.e(it, "Error while saving current space")
                         }
                     )
-                dispatcher.emit(NotificationCommand.GoToSpace(space = action.space,))
+                dispatcher.emit(resolveGoToSpaceCommand(action.space))
             } else {
                 // TODO show error msg
             }
             systemNotificationService.cancel(action.notification)
+        }
+
+        /**
+         * When a user taps a notification to enter a space, honor the space's
+         * homepage setting: if an explicit object is configured, open that
+         * object directly; otherwise fall back to the widgets home screen
+         * (DROID-4388).
+         */
+        private suspend fun resolveGoToSpaceCommand(
+            space: com.anytypeio.anytype.core_models.primitives.SpaceId
+        ): NotificationCommand {
+            val homepageResult = resolveSpaceHomepage.async(
+                ResolveSpaceHomepage.Params(space = space)
+            ).getOrNull()
+            return if (homepageResult is ResolveSpaceHomepage.Result.Object) {
+                NotificationCommand.GoToObject(
+                    space = space,
+                    navigation = homepageResult.navigation
+                )
+            } else {
+                NotificationCommand.GoToSpace(space = space)
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/notifications/NotificationsViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/notifications/NotificationsViewModel.kt
@@ -305,6 +305,7 @@ sealed class NotificationCommand {
         val space: SpaceId,
         val navigation: com.anytypeio.anytype.core_models.misc.OpenObjectNavigation
     ) : NotificationCommand()
+    data class GoToChat(val space: SpaceId, val chat: Id) : NotificationCommand()
     data class ViewSpaceJoinRequest(val space: SpaceId, val member: Id) : NotificationCommand()
     data class ViewSpaceLeaveRequest(val space: SpaceId) : NotificationCommand()
 }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/notifications/NotificationsViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/notifications/NotificationsViewModel.kt
@@ -301,6 +301,10 @@ sealed class NotificationAction {
 
 sealed class NotificationCommand {
     data class GoToSpace(val space: SpaceId) : NotificationCommand()
+    data class GoToObject(
+        val space: SpaceId,
+        val navigation: com.anytypeio.anytype.core_models.misc.OpenObjectNavigation
+    ) : NotificationCommand()
     data class ViewSpaceJoinRequest(val space: SpaceId, val member: Id) : NotificationCommand()
     data class ViewSpaceLeaveRequest(val space: SpaceId) : NotificationCommand()
 }


### PR DESCRIPTION
## Summary

- When a space has an explicit-object homepage configured (`setHomepage` / DROID-4388), the back stack no longer injects the widgets screen between Vault and the target. Navigation now matches the natural `[Vault, Target]` shape.
- Centralizes homepage resolution in a new `ResolveSpaceHomepage` domain use case; `VaultViewModel` and the OS-widget / notification entry points share this logic instead of duplicating it.
- `VaultNavigation.Open*` and three `MainViewModel.Command` variants carry a new `openTargetDirectly` flag, computed by the VM and consumed by `VaultFragment` / `MainActivity`.

## What changed

**New files**
- `domain/.../spaces/ResolveSpaceHomepage.kt` — use case returning `Result.Widgets` or `Result.Object(OpenObjectNavigation)`.
- `presentation/.../home/SpaceHomepageResolver.kt` — synchronous helper for the "should skip widget injection" boolean check.

**VM-side flag propagation**
- `feature-vault` `VaultNavigation.Open*` variants gain `openTargetDirectly: Boolean = false`. `VaultViewModel.resolveHomepageNavigation` now delegates to `ResolveSpaceHomepage` and sets the flag when the homepage is a real object. `SearchObjects` + duplicated `HOMEPAGE_SPECIAL_CONSTANTS` removed.
- `MainViewModel.Command.LaunchChat`, `DeepLinkToObject`, and `DeepLinkToObjectFromWidget` gain the same flag. `MainViewModel` computes it at the three target-carrying emit sites.
- `proceedWithOsWidgetSpaceSwitch` (no target) and `NotificationActionDelegate.proceedWithGoToSpaceAction` (no target) now resolve the homepage via `ResolveSpaceHomepage` and re-emit as the target-aware command (`DeepLinkToObjectFromWidget` / new `NotificationCommand.GoToObject`) when applicable.

**UI-side**
- `VaultFragment.proceed(VaultNavigation)` — each of six `Open*` branches guards the `WidgetsScreenFragment.args` navigate with `if (!destination.openTargetDirectly)`.
- `MainActivity` — same guard at four command-handling sites; new `NotificationCommand.GoToObject` handler routes through `proceedWithOpenObjectNavigation`.

**DI**
- `VaultViewModelFactory` swaps `SearchObjects` for `ResolveSpaceHomepage`.
- `MainViewModelFactory` / `MainEntryDI` inject `ResolveSpaceHomepage`.
- `NotificationActionDelegate.Default` auto-wires the new dependency via `@Inject`.

## Test plan

- [x] `./gradlew :app:assembleDebug` passes (Dagger wiring resolves).
- [x] `./gradlew :feature-vault:testDebugUnitTest` passes.
- [x] `./gradlew :presentation:testDebugUnitTest` — no new regressions (identical 122/1125 failure count vs. branch baseline before this change; all pre-existing).
- [ ] Manual device verification of back-stack across the matrix `{homepage = null, "widgets", <page id>, <chat id>} × {Vault tap, deep-link to object, deep-link to space, push to chat, OS widget → object}`.
- [ ] Edge cases: homepage == deep-linked target itself (no double-nesting); stale / deleted homepage id (falls back to widgets); `SpaceView` not yet loaded (falls back to widgets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)