### PR TITLE
DROID-4264 Vault | Fix | QR code join space not working from vault screen

### DIFF
--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModel.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModel.kt
@@ -143,7 +143,7 @@ class VaultViewModel(
 ) : ViewModel(),
     DeepLinkToObjectDelegate by deepLinkToObjectDelegate {
 
-    val commands = MutableSharedFlow<VaultCommand>(replay = 0)
+    val commands = MutableSharedFlow<VaultCommand>(replay = 1)
     val navigations = MutableSharedFlow<VaultNavigation>(replay = 0)
     val showCreateChannelMenu = MutableStateFlow(false)
     val notificationError = MutableStateFlow<String?>(null)


### PR DESCRIPTION
## Summary
- Fix QR code scan → join space flow not working when initiated from the vault screen
- When `QrScannerActivity` returns, `MainActivity` gets recreated, causing `VaultViewModel` to be re-initialized with a fresh `commands` SharedFlow (`replay = 0`). The QR callback emits `NavigateToRequestJoinSpace` before the Compose collector subscribes, so the command is silently lost.
- Changed `commands` SharedFlow from `replay = 0` to `replay = 1` so the most recent command is buffered and delivered when the collector subscribes.

## Test plan
- [ ] Scan a space invite QR code from the vault screen → should navigate to the join space request screen
- [ ] Verify other vault commands (notifications, gallery install, deep links) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)