### PR TITLE
DROID-4264 Vault | Hotfix | Prevent commands replay on rotation/recreation

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/ui/vault/VaultFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/vault/VaultFragment.kt
@@ -194,6 +194,9 @@ class VaultFragment : BaseComposeFragment() {
             vm.commands.collect { command -> proceed(command) }
         }
         LaunchedEffect(Unit) {
+            vm.inviteCommands.collect { command -> proceed(command) }
+        }
+        LaunchedEffect(Unit) {
             vm.navigations.collect { command -> proceed(command) }
         }
     }

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModel.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModel.kt
@@ -74,9 +74,11 @@ import com.anytypeio.anytype.domain.workspace.DeepLinkToObjectDelegate
 import com.anytypeio.anytype.domain.workspace.SpaceManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -143,7 +145,10 @@ class VaultViewModel(
 ) : ViewModel(),
     DeepLinkToObjectDelegate by deepLinkToObjectDelegate {
 
-    val commands = MutableSharedFlow<VaultCommand>(replay = 1)
+    val commands = MutableSharedFlow<VaultCommand>(replay = 0)
+
+    private val _inviteCommands = Channel<VaultCommand>(capacity = Channel.BUFFERED)
+    val inviteCommands = _inviteCommands.receiveAsFlow()
     val navigations = MutableSharedFlow<VaultNavigation>(replay = 0)
     val showCreateChannelMenu = MutableStateFlow(false)
     val notificationError = MutableStateFlow<String?>(null)
@@ -967,7 +972,7 @@ class VaultViewModel(
                     }
 
                     is DeepLinkResolver.Action.Invite -> {
-                        commands.emit(VaultCommand.NavigateToRequestJoinSpace(link = qrCode))
+                        _inviteCommands.send(VaultCommand.NavigateToRequestJoinSpace(link = qrCode))
                     }
 
                     else -> {
@@ -976,7 +981,7 @@ class VaultViewModel(
                         val fileKey = spaceInviteResolver.parseFileKey(qrCode)
                         val contentId = spaceInviteResolver.parseContentId(qrCode)
                         if (fileKey != null && contentId != null) {
-                            commands.emit(VaultCommand.NavigateToRequestJoinSpace(link = qrCode))
+                            _inviteCommands.send(VaultCommand.NavigateToRequestJoinSpace(link = qrCode))
                         } else {
                             Timber.e("Failed to parse QR code: invalid format")
                             vaultErrors.value = VaultErrors.QrCodeIsNotValid


### PR DESCRIPTION
## Summary

- Hotfix for #3208 (`1cf5fd447`): reverts `VaultViewModel.commands` SharedFlow back to `replay = 0` to prevent spurious re-delivery of one-shot UI events (open settings, launch QR scan, show delete/leave dialogs) after device rotation or process recreation
- Introduces a separate buffered `Channel` (`inviteCommands`) specifically for `NavigateToRequestJoinSpace` commands, preserving the original QR race-condition fix without affecting other commands
- Adds a collector for `inviteCommands` in `VaultFragment`

## Test plan

- [ ] Scan QR invite code from vault screen → should navigate to join space screen (original fix preserved)
- [ ] Open settings from vault, rotate device → settings should NOT re-open
- [ ] Trigger any vault command (delete space, leave space, scan QR), navigate away and return → previous command should NOT replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)