### PR TITLE
DROID-4201 Redesign | Unify Create FAB behavior across screens

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/di/feature/CreateObjectFeatureDI.kt
+++ b/app/src/main/java/com/anytypeio/anytype/di/feature/CreateObjectFeatureDI.kt
@@ -3,6 +3,10 @@ package com.anytypeio.anytype.di.feature
 import androidx.lifecycle.ViewModelProvider
 import com.anytypeio.anytype.core_utils.di.scope.PerScreen
 import com.anytypeio.anytype.di.common.ComponentDependencies
+import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
+import com.anytypeio.anytype.domain.block.repo.BlockRepository
+import com.anytypeio.anytype.domain.device.FileSharer
+import com.anytypeio.anytype.domain.media.UploadFile
 import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
 import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
 import com.anytypeio.anytype.feature_create_object.presentation.CreateObjectViewModelFactory
@@ -11,6 +15,7 @@ import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
+import dagger.Provides
 
 @Component(
     dependencies = [CreateObjectFeatureDependencies::class],
@@ -34,6 +39,15 @@ interface CreateObjectFeatureComponent {
 
 @Module
 object CreateObjectFeatureModule {
+
+    @JvmStatic
+    @Provides
+    @PerScreen
+    fun provideUploadFile(
+        repo: BlockRepository,
+        dispatchers: AppCoroutineDispatchers
+    ): UploadFile = UploadFile(repo = repo, dispatchers = dispatchers)
+
     @Module
     interface Declarations {
         @PerScreen
@@ -47,4 +61,7 @@ object CreateObjectFeatureModule {
 interface CreateObjectFeatureDependencies : ComponentDependencies {
     fun storeOfObjectTypes(): StoreOfObjectTypes
     fun spaceViewSubscriptionContainer(): SpaceViewSubscriptionContainer
+    fun blockRepo(): BlockRepository
+    fun dispatchers(): AppCoroutineDispatchers
+    fun fileSharer(): FileSharer
 }

--- a/app/src/main/java/com/anytypeio/anytype/ui/allcontent/AllContentFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/allcontent/AllContentFragment.kt
@@ -16,6 +16,9 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -29,7 +32,6 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.fragment.findNavController
 import com.anytypeio.anytype.R
 import com.anytypeio.anytype.core_models.Id
-import com.anytypeio.anytype.core_models.ObjectWrapper
 import com.anytypeio.anytype.core_models.primitives.SpaceId
 import com.anytypeio.anytype.core_utils.ext.argString
 import com.anytypeio.anytype.core_utils.ext.subscribe
@@ -43,27 +45,34 @@ import com.anytypeio.anytype.feature_allcontent.presentation.AllContentViewModel
 import com.anytypeio.anytype.feature_allcontent.presentation.AllContentViewModelFactory
 import com.anytypeio.anytype.feature_allcontent.ui.AllContentNavigation.ALL_CONTENT_MAIN
 import com.anytypeio.anytype.feature_allcontent.ui.AllContentWrapperScreen
+import com.anytypeio.anytype.feature_create_object.presentation.CreateObjectViewModelFactory
+import com.anytypeio.anytype.feature_create_object.presentation.NewCreateObjectViewModel
+import com.anytypeio.anytype.feature_create_object.ui.CreateObjectSheetHost
 import com.anytypeio.anytype.presentation.sync.SyncStatusWidgetState
 import com.anytypeio.anytype.presentation.widgets.collection.Subscription
 import com.anytypeio.anytype.ui.base.navigation
 import com.anytypeio.anytype.ui.home.WidgetOverlayFragment
 import com.anytypeio.anytype.ui.multiplayer.ShareSpaceFragment
-import com.anytypeio.anytype.ui.objects.creation.ObjectTypeSelectionFragment
-import com.anytypeio.anytype.ui.objects.types.pickers.ObjectTypeSelectionListener
 import com.anytypeio.anytype.ui.profile.ParticipantFragment
 import com.anytypeio.anytype.ui.search.GlobalSearchFragment
 import com.anytypeio.anytype.ui.settings.typography
 import javax.inject.Inject
 import timber.log.Timber
 
-class AllContentFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
+class AllContentFragment : BaseComposeFragment() {
 
     @Inject
     lateinit var factory: AllContentViewModelFactory
 
     private val vm by viewModels<AllContentViewModel> { factory }
 
+    private lateinit var createObjectFactory: CreateObjectViewModelFactory
+
+    private val createObjectVm by viewModels<NewCreateObjectViewModel> { createObjectFactory }
+
     private val space get() = argString(ARG_SPACE)
+
+    private fun createObjectComponentKey(): String = "all-content-create-object:$space"
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -254,6 +263,7 @@ class AllContentFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
             startDestination = ALL_CONTENT_MAIN
         ) {
             composable(route = ALL_CONTENT_MAIN) {
+                var createObjectSheetVisible by remember { mutableStateOf(false) }
                 AllContentWrapperScreen(
                     uiItemsState = vm.uiItemsState.collectAsStateWithLifecycle().value,
                     onTabClick = vm::onTabClicked,
@@ -272,11 +282,7 @@ class AllContentFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
                     canPaginate = vm.canPaginate.collectAsStateWithLifecycle().value,
                     onUpdateLimitSearch = vm::updateLimit,
                     uiContentState = vm.uiContentState.collectAsStateWithLifecycle().value,
-                    onAddDocClicked = vm::onAddDockClicked,
-                    onCreateObjectLongClicked = {
-                        val dialog = ObjectTypeSelectionFragment.new(space = space)
-                        dialog.show(childFragmentManager, null)
-                    },
+                    onAddDocClicked = { createObjectSheetVisible = true },
                     onBackClicked = vm::onBackClicked,
                     onTitleClick = vm::onTopBarTitleClicked,
                     onSyncStatusClick = vm::onSyncStatusBadgeClicked,
@@ -290,12 +296,16 @@ class AllContentFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
                     uiSyncStatusState = syncStatusWidgetState,
                     onDismiss = vm::onSyncStatusDismiss
                 )
+                CreateObjectSheetHost(
+                    vm = createObjectVm,
+                    visible = createObjectSheetVisible,
+                    onDismiss = { createObjectSheetVisible = false },
+                    onCreateObjectOfType = { objType ->
+                        vm.onCreateObjectOfTypeClicked(objType = objType)
+                    }
+                )
             }
         }
-    }
-
-    override fun onSelectObjectType(objType: ObjectWrapper.Type) {
-        vm.onCreateObjectOfTypeClicked(objType = objType)
     }
 
     override fun onStart() {
@@ -311,10 +321,20 @@ class AllContentFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
     override fun injectDependencies() {
         val vmParams = AllContentViewModel.VmParams(spaceId = SpaceId(space))
         componentManager().allContentComponent.get(vmParams).inject(this)
+        val createObjectVmParams = NewCreateObjectViewModel.VmParams(
+            spaceId = SpaceId(space),
+            showAttachObject = false,
+            showMediaSection = true
+        )
+        createObjectFactory = componentManager()
+            .createObjectFeatureComponent
+            .get(key = createObjectComponentKey(), param = createObjectVmParams)
+            .viewModelFactory()
     }
 
     override fun releaseDependencies() {
         componentManager().allContentComponent.release()
+        componentManager().createObjectFeatureComponent.release(createObjectComponentKey())
     }
 
     override fun onApplyWindowRootInsets(view: View) {

--- a/app/src/main/java/com/anytypeio/anytype/ui/date/DateObjectFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/date/DateObjectFragment.kt
@@ -6,9 +6,16 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
@@ -22,7 +29,6 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
 import com.anytypeio.anytype.R
 import com.anytypeio.anytype.core_models.Id
-import com.anytypeio.anytype.core_models.ObjectWrapper
 import com.anytypeio.anytype.core_models.primitives.SpaceId
 import com.anytypeio.anytype.core_ui.views.BaseAlertDialog
 import com.anytypeio.anytype.core_utils.ext.argString
@@ -31,6 +37,9 @@ import com.anytypeio.anytype.core_utils.ext.toast
 import com.anytypeio.anytype.core_utils.insets.EDGE_TO_EDGE_MIN_SDK
 import com.anytypeio.anytype.core_utils.ui.BaseComposeFragment
 import com.anytypeio.anytype.di.common.componentManager
+import com.anytypeio.anytype.feature_create_object.presentation.CreateObjectViewModelFactory
+import com.anytypeio.anytype.feature_create_object.presentation.NewCreateObjectViewModel
+import com.anytypeio.anytype.feature_create_object.ui.CreateObjectSheetHost
 import com.anytypeio.anytype.feature_date.viewmodel.UiErrorState
 import com.anytypeio.anytype.feature_date.viewmodel.DateObjectViewModel
 import com.anytypeio.anytype.feature_date.viewmodel.DateObjectVMFactory
@@ -39,8 +48,6 @@ import com.anytypeio.anytype.feature_date.viewmodel.DateObjectCommand
 import com.anytypeio.anytype.feature_date.viewmodel.DateObjectVmParams
 import com.anytypeio.anytype.ui.base.navigation
 import com.anytypeio.anytype.ui.home.WidgetOverlayFragment
-import com.anytypeio.anytype.ui.objects.creation.ObjectTypeSelectionFragment
-import com.anytypeio.anytype.ui.objects.types.pickers.ObjectTypeSelectionListener
 import com.anytypeio.anytype.ui.profile.ParticipantFragment
 import com.anytypeio.anytype.ui.search.GlobalSearchFragment
 import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
@@ -48,15 +55,22 @@ import com.google.accompanist.navigation.material.rememberBottomSheetNavigator
 import javax.inject.Inject
 import timber.log.Timber
 
-class DateObjectFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
+class DateObjectFragment : BaseComposeFragment() {
     @Inject
     lateinit var factory: DateObjectVMFactory
 
     private val vm by viewModels<DateObjectViewModel> { factory }
+
+    private lateinit var createObjectFactory: CreateObjectViewModelFactory
+
+    private val createObjectVm by viewModels<NewCreateObjectViewModel> { createObjectFactory }
+
     private lateinit var navComposeController: NavHostController
 
     private val space get() = argString(ARG_SPACE)
     private val objectId get() = argString(ARG_OBJECT_ID)
+
+    private fun createObjectComponentKey(): String = "date-object-create-object:$space:$objectId"
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -175,10 +189,6 @@ class DateObjectFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
                 is DateObjectCommand.SendToast.Error -> {
                     toast(effect.message)
                 }
-                DateObjectCommand.TypeSelectionScreen -> {
-                    val dialog = ObjectTypeSelectionFragment.new(space = space)
-                    dialog.show(childFragmentManager, null)
-                }
                 is DateObjectCommand.NavigateToParticipant -> {
                     runCatching {
                         findNavController().navigate(
@@ -219,10 +229,6 @@ class DateObjectFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
         }
     }
 
-    override fun onSelectObjectType(objType: ObjectWrapper.Type) {
-        vm.onCreateObjectOfTypeClicked(objType = objType)
-    }
-
     override fun onStart() {
         super.onStart()
         vm.onStart()
@@ -243,20 +249,37 @@ class DateObjectFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
             startDestination = DATE_MAIN
         ) {
             composable(route = DATE_MAIN) {
-                DateMainScreen(
-                    uiCalendarIconState = vm.uiCalendarIconState.collectAsStateWithLifecycle().value,
-                    uiSyncStatusBadgeState = vm.uiSyncStatusBadgeState.collectAsStateWithLifecycle().value,
-                    uiHeaderState = vm.uiHeaderState.collectAsStateWithLifecycle().value,
-                    uiFieldsState = vm.uiFieldsState.collectAsStateWithLifecycle().value,
-                    uiObjectsListState = vm.uiObjectsListState.collectAsStateWithLifecycle().value,
-                    uiFieldsSheetState = vm.uiFieldsSheetState.collectAsStateWithLifecycle().value,
-                    uiContentState = vm.uiContentState.collectAsStateWithLifecycle().value,
-                    canPaginate = vm.canPaginate.collectAsStateWithLifecycle().value,
-                    uiCalendarState = vm.uiCalendarState.collectAsStateWithLifecycle().value,
-                    uiSyncStatusState = vm.uiSyncStatusWidgetState.collectAsStateWithLifecycle().value,
-                    uiSnackbarState = vm.uiSnackbarState.collectAsStateWithLifecycle().value,
-                    onDateEvent = vm::onDateEvent
-                )
+                var createObjectSheetVisible by remember { mutableStateOf(false) }
+                Box(modifier = Modifier.fillMaxSize()) {
+                    DateMainScreen(
+                        uiCalendarIconState = vm.uiCalendarIconState.collectAsStateWithLifecycle().value,
+                        uiSyncStatusBadgeState = vm.uiSyncStatusBadgeState.collectAsStateWithLifecycle().value,
+                        uiHeaderState = vm.uiHeaderState.collectAsStateWithLifecycle().value,
+                        uiFieldsState = vm.uiFieldsState.collectAsStateWithLifecycle().value,
+                        uiObjectsListState = vm.uiObjectsListState.collectAsStateWithLifecycle().value,
+                        uiFieldsSheetState = vm.uiFieldsSheetState.collectAsStateWithLifecycle().value,
+                        uiContentState = vm.uiContentState.collectAsStateWithLifecycle().value,
+                        canPaginate = vm.canPaginate.collectAsStateWithLifecycle().value,
+                        uiCalendarState = vm.uiCalendarState.collectAsStateWithLifecycle().value,
+                        uiSyncStatusState = vm.uiSyncStatusWidgetState.collectAsStateWithLifecycle().value,
+                        uiSnackbarState = vm.uiSnackbarState.collectAsStateWithLifecycle().value,
+                        onDateEvent = { event ->
+                            if (event is com.anytypeio.anytype.feature_date.ui.models.DateEvent.NavigationWidget.OnAddDocClick) {
+                                createObjectSheetVisible = true
+                            } else {
+                                vm.onDateEvent(event)
+                            }
+                        }
+                    )
+                    CreateObjectSheetHost(
+                        vm = createObjectVm,
+                        visible = createObjectSheetVisible,
+                        onDismiss = { createObjectSheetVisible = false },
+                        onCreateObjectOfType = { objType ->
+                            vm.onCreateObjectOfTypeClicked(objType = objType)
+                        }
+                    )
+                }
             }
         }
     }
@@ -297,10 +320,20 @@ class DateObjectFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
             objectId = objectId
         )
         componentManager().dateObjectComponent.get(params).inject(this)
+        val createObjectVmParams = NewCreateObjectViewModel.VmParams(
+            spaceId = SpaceId(space),
+            showAttachObject = false,
+            showMediaSection = true
+        )
+        createObjectFactory = componentManager()
+            .createObjectFeatureComponent
+            .get(key = createObjectComponentKey(), param = createObjectVmParams)
+            .viewModelFactory()
     }
 
     override fun releaseDependencies() {
         componentManager().dateObjectComponent.release()
+        componentManager().createObjectFeatureComponent.release(createObjectComponentKey())
     }
 
     override fun onApplyWindowRootInsets(view: View) {

--- a/app/src/main/java/com/anytypeio/anytype/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/editor/EditorFragment.kt
@@ -1005,6 +1005,7 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
 
         binding.recycler.removeOnScrollListener(fabScrollListener)
         pickerDelegate.clearPickit()
+        isSheetHostInstalled = false
         super.onDestroyView()
     }
 

--- a/app/src/main/java/com/anytypeio/anytype/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/editor/EditorFragment.kt
@@ -128,6 +128,9 @@ import com.anytypeio.anytype.core_utils.ext.visible
 import com.anytypeio.anytype.core_utils.intents.ActivityCustomTabsHelper
 import com.anytypeio.anytype.core_utils.ui.showActionableSnackBar
 import com.anytypeio.anytype.databinding.FragmentEditorBinding
+import com.anytypeio.anytype.feature_create_object.presentation.CreateObjectViewModelFactory
+import com.anytypeio.anytype.feature_create_object.presentation.NewCreateObjectViewModel
+import com.anytypeio.anytype.feature_create_object.ui.CreateObjectSheetHost
 import com.anytypeio.anytype.device.launchMediaPicker
 import com.anytypeio.anytype.di.common.componentManager
 import com.anytypeio.anytype.di.feature.DefaultComponentParam
@@ -210,6 +213,12 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
     ObjectTypeUpdateListener {
 
     private val keyboardDelayJobs = mutableListOf<Job>()
+
+    private lateinit var createObjectFactory: CreateObjectViewModelFactory
+
+    private val createObjectVm by viewModels<NewCreateObjectViewModel> { createObjectFactory }
+
+    private fun createObjectComponentKey(): String = "editor-create-object:$ctx"
 
     protected val ctx get() = arg<Id>(CTX_KEY)
     protected val space get() = arg<Id>(SPACE_ID_KEY)
@@ -634,15 +643,7 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
         // wiring.
         binding.fabCreate
             .clicks()
-            .onEach { vm.onAddNewDocumentClicked() }
-            .launchIn(lifecycleScope)
-
-        binding.fabCreate
-            .longClicks(withHaptic = true)
-            .onEach {
-                val dialog = ObjectTypeSelectionFragment.new(space = space)
-                dialog.show(childFragmentManager, "editor-create-object-of-type-dialog")
-            }
+            .onEach { showCreateObjectSheet() }
             .launchIn(lifecycleScope)
 
         binding.recycler.addOnScrollListener(fabScrollListener)
@@ -2411,6 +2412,37 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
         inflater, container, false
     )
 
+    // Owned outside the ComposeView's setContent lambda so the first click
+    // isn't lost: `setContent` schedules composition asynchronously, so if
+    // we created the state inside the composable we'd still see null when
+    // toggling visibility on the same tick.
+    private val createObjectSheetVisible = androidx.compose.runtime.mutableStateOf(false)
+    private var isSheetHostInstalled = false
+
+    private fun installCreateObjectSheetHost() {
+        if (isSheetHostInstalled) return
+        val composeView = binding.createObjectSheetHost
+        composeView.setViewCompositionStrategy(
+            androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+        )
+        composeView.setContent {
+            CreateObjectSheetHost(
+                vm = createObjectVm,
+                visible = createObjectSheetVisible.value,
+                onDismiss = { createObjectSheetVisible.value = false },
+                onCreateObjectOfType = { objType ->
+                    vm.onAddNewDocumentClicked(objType = objType)
+                }
+            )
+        }
+        isSheetHostInstalled = true
+    }
+
+    private fun showCreateObjectSheet() {
+        installCreateObjectSheetHost()
+        createObjectSheetVisible.value = true
+    }
+
     override fun injectDependencies() {
         componentManager().editorComponent
             .get(
@@ -2421,10 +2453,20 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
                 )
             )
             .inject(this)
+        val createObjectVmParams = NewCreateObjectViewModel.VmParams(
+            spaceId = SpaceId(space),
+            showAttachObject = false,
+            showMediaSection = true
+        )
+        createObjectFactory = componentManager()
+            .createObjectFeatureComponent
+            .get(key = createObjectComponentKey(), param = createObjectVmParams)
+            .viewModelFactory()
     }
 
     override fun releaseDependencies() {
         componentManager().editorComponent.release(ctx)
+        componentManager().createObjectFeatureComponent.release(createObjectComponentKey())
     }
 
     //region Media Picker

--- a/app/src/main/java/com/anytypeio/anytype/ui/sets/ObjectSetFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/sets/ObjectSetFragment.kt
@@ -1541,6 +1541,7 @@ open class ObjectSetFragment :
 
     override fun onDestroyView() {
         viewerGridAdapter.clear()
+        isSheetHostInstalled = false
         super.onDestroyView()
     }
 

--- a/app/src/main/java/com/anytypeio/anytype/ui/sets/ObjectSetFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/sets/ObjectSetFragment.kt
@@ -100,6 +100,9 @@ import com.anytypeio.anytype.core_utils.ext.toast
 import com.anytypeio.anytype.core_utils.ext.visible
 import com.anytypeio.anytype.core_utils.intents.ActivityCustomTabsHelper
 import com.anytypeio.anytype.databinding.FragmentObjectSetBinding
+import com.anytypeio.anytype.feature_create_object.presentation.CreateObjectViewModelFactory
+import com.anytypeio.anytype.feature_create_object.presentation.NewCreateObjectViewModel
+import com.anytypeio.anytype.feature_create_object.ui.CreateObjectSheetHost
 import com.anytypeio.anytype.di.common.componentManager
 import com.anytypeio.anytype.di.feature.DefaultComponentParam
 import com.anytypeio.anytype.presentation.editor.cover.CoverColor
@@ -157,6 +160,17 @@ open class ObjectSetFragment :
     OnDataViewSelectSourceAction,
     ObjectTypeSelectionListener,
     CollectionObjectTypeSelectionListener {
+
+    private lateinit var createObjectFactory: CreateObjectViewModelFactory
+
+    private val createObjectVm by viewModels<NewCreateObjectViewModel> { createObjectFactory }
+
+    private fun createObjectComponentKey(): String = "object-set-create-object:$ctx"
+
+    // Owned outside the ComposeView's setContent so the first tap isn't lost
+    // while composition is still pending.
+    private val createObjectSheetVisible = androidx.compose.runtime.mutableStateOf(false)
+    private var isSheetHostInstalled = false
 
     // Controls
 
@@ -339,16 +353,8 @@ open class ObjectSetFragment :
             // Create (right) — mirrors the editor. Buttons stay fixed at
             // all times; visibility comes from VM state, not scroll.
             subscribe(binding.fabCreate.clicks().throttleFirst()) {
-                vm.onAddNewDocumentClicked()
+                showCreateObjectSheet()
             }
-
-            binding.fabCreate
-                .longClicks(withHaptic = true)
-                .onEach {
-                    val dialog = ObjectTypeSelectionFragment.new(space = space)
-                    dialog.show(childFragmentManager, "set-create-object-of-type-dialog")
-                }
-                .launchIn(lifecycleScope)
 
             subscribe(binding.discussionButton.clicks().throttleFirst()) {
                 vm.onDiscussionButtonClicked()
@@ -1662,6 +1668,30 @@ open class ObjectSetFragment :
         }
     }
 
+    private fun installCreateObjectSheetHost() {
+        if (isSheetHostInstalled) return
+        val composeView = binding.createObjectSheetHost
+        composeView.setViewCompositionStrategy(
+            androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+        )
+        composeView.setContent {
+            CreateObjectSheetHost(
+                vm = createObjectVm,
+                visible = createObjectSheetVisible.value,
+                onDismiss = { createObjectSheetVisible.value = false },
+                onCreateObjectOfType = { objType ->
+                    vm.onAddNewDocumentClicked(objType = objType)
+                }
+            )
+        }
+        isSheetHostInstalled = true
+    }
+
+    private fun showCreateObjectSheet() {
+        installCreateObjectSheetHost()
+        createObjectSheetVisible.value = true
+    }
+
     override fun injectDependencies() {
         componentManager().objectSetComponent
             .get(
@@ -1672,10 +1702,20 @@ open class ObjectSetFragment :
                 )
             )
             .inject(this)
+        val createObjectVmParams = NewCreateObjectViewModel.VmParams(
+            spaceId = SpaceId(space),
+            showAttachObject = false,
+            showMediaSection = true
+        )
+        createObjectFactory = componentManager()
+            .createObjectFeatureComponent
+            .get(key = createObjectComponentKey(), param = createObjectVmParams)
+            .viewModelFactory()
     }
 
     override fun releaseDependencies() {
         componentManager().objectSetComponent.release(ctx)
+        componentManager().createObjectFeatureComponent.release(createObjectComponentKey())
     }
 
     private fun showObjectHeaderContextMenu(

--- a/app/src/main/java/com/anytypeio/anytype/ui/widgets/collection/CollectionFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/widgets/collection/CollectionFragment.kt
@@ -6,7 +6,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.os.bundleOf
@@ -15,7 +22,6 @@ import androidx.navigation.fragment.findNavController
 import com.anytypeio.anytype.BuildConfig
 import com.anytypeio.anytype.R
 import com.anytypeio.anytype.core_models.Id
-import com.anytypeio.anytype.core_models.ObjectWrapper
 import com.anytypeio.anytype.core_models.primitives.SpaceId
 import com.anytypeio.anytype.core_utils.ext.arg
 import com.anytypeio.anytype.core_utils.ext.argString
@@ -30,21 +36,28 @@ import com.anytypeio.anytype.presentation.widgets.collection.Subscription
 import com.anytypeio.anytype.presentation.widgets.collection.SubscriptionMapper
 import com.anytypeio.anytype.ui.base.navigation
 import com.anytypeio.anytype.ui.dashboard.DeleteAlertFragment
+import com.anytypeio.anytype.feature_create_object.presentation.CreateObjectViewModelFactory
+import com.anytypeio.anytype.feature_create_object.presentation.NewCreateObjectViewModel
+import com.anytypeio.anytype.feature_create_object.ui.CreateObjectSheetHost
 import com.anytypeio.anytype.ui.home.WidgetsScreenFragment
 import com.anytypeio.anytype.ui.multiplayer.ShareSpaceFragment
-import com.anytypeio.anytype.ui.objects.creation.ObjectTypeSelectionFragment
-import com.anytypeio.anytype.ui.objects.types.pickers.ObjectTypeSelectionListener
 import javax.inject.Inject
 import timber.log.Timber
 
-class CollectionFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
+class CollectionFragment : BaseComposeFragment() {
 
     @Inject
     lateinit var factory: CollectionViewModel.Factory
 
+    private lateinit var createObjectFactory: CreateObjectViewModelFactory
+
+    private val createObjectVm by viewModels<NewCreateObjectViewModel> { createObjectFactory }
+
     private val navigation get() = navigation()
 
     private val space get() = arg<Id>(SPACE_ID_KEY)
+
+    private fun createObjectComponentKey(): String = "collection-create-object:$space"
 
     private val subscription: Subscription by lazy {
         SubscriptionMapper().map(
@@ -66,16 +79,24 @@ class CollectionFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 DefaultTheme {
-                    CollectionScreen(
-                        vm = vm,
-                        onCreateObjectLongClicked = {
-                            val dialog = ObjectTypeSelectionFragment.new(space = space)
-                            dialog.show(childFragmentManager, "fullscreen-widget-create-object-type-dialog")
-                        },
-                        onSearchClicked = {
-                            vm.onSearchClicked(space)
-                        }
-                    )
+                    var createObjectSheetVisible by remember { mutableStateOf(false) }
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        CollectionScreen(
+                            vm = vm,
+                            onAddDocClicked = { createObjectSheetVisible = true },
+                            onSearchClicked = {
+                                vm.onSearchClicked(space)
+                            }
+                        )
+                        CreateObjectSheetHost(
+                            vm = createObjectVm,
+                            visible = createObjectSheetVisible,
+                            onDismiss = { createObjectSheetVisible = false },
+                            onCreateObjectOfType = { objType ->
+                                vm.onAddClicked(objType = objType)
+                            }
+                        )
+                    }
                 }
             }
         }
@@ -204,10 +225,6 @@ class CollectionFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
         )
     }
 
-    override fun onSelectObjectType(objType: ObjectWrapper.Type) {
-        vm.onAddClicked(objType = objType)
-    }
-
     override fun onStop() {
         vm.onStop()
         super.onStop()
@@ -216,10 +233,20 @@ class CollectionFragment : BaseComposeFragment(), ObjectTypeSelectionListener {
     override fun injectDependencies() {
         val vmParams = CollectionViewModel.VmParams(spaceId = SpaceId(space))
         componentManager().collectionComponent.get(params = vmParams).inject(this)
+        val createObjectVmParams = NewCreateObjectViewModel.VmParams(
+            spaceId = SpaceId(space),
+            showAttachObject = false,
+            showMediaSection = true
+        )
+        createObjectFactory = componentManager()
+            .createObjectFeatureComponent
+            .get(key = createObjectComponentKey(), param = createObjectVmParams)
+            .viewModelFactory()
     }
 
     override fun releaseDependencies() {
         componentManager().collectionComponent.release()
+        componentManager().createObjectFeatureComponent.release(createObjectComponentKey())
     }
 
     override fun onApplyWindowRootInsets(view: View) {

--- a/app/src/main/java/com/anytypeio/anytype/ui/widgets/collection/CollectionFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/widgets/collection/CollectionFragment.kt
@@ -6,14 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.os.bundleOf
@@ -36,9 +29,6 @@ import com.anytypeio.anytype.presentation.widgets.collection.Subscription
 import com.anytypeio.anytype.presentation.widgets.collection.SubscriptionMapper
 import com.anytypeio.anytype.ui.base.navigation
 import com.anytypeio.anytype.ui.dashboard.DeleteAlertFragment
-import com.anytypeio.anytype.feature_create_object.presentation.CreateObjectViewModelFactory
-import com.anytypeio.anytype.feature_create_object.presentation.NewCreateObjectViewModel
-import com.anytypeio.anytype.feature_create_object.ui.CreateObjectSheetHost
 import com.anytypeio.anytype.ui.home.WidgetsScreenFragment
 import com.anytypeio.anytype.ui.multiplayer.ShareSpaceFragment
 import javax.inject.Inject
@@ -49,15 +39,9 @@ class CollectionFragment : BaseComposeFragment() {
     @Inject
     lateinit var factory: CollectionViewModel.Factory
 
-    private lateinit var createObjectFactory: CreateObjectViewModelFactory
-
-    private val createObjectVm by viewModels<NewCreateObjectViewModel> { createObjectFactory }
-
     private val navigation get() = navigation()
 
     private val space get() = arg<Id>(SPACE_ID_KEY)
-
-    private fun createObjectComponentKey(): String = "collection-create-object:$space"
 
     private val subscription: Subscription by lazy {
         SubscriptionMapper().map(
@@ -79,24 +63,7 @@ class CollectionFragment : BaseComposeFragment() {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 DefaultTheme {
-                    var createObjectSheetVisible by remember { mutableStateOf(false) }
-                    Box(modifier = Modifier.fillMaxSize()) {
-                        CollectionScreen(
-                            vm = vm,
-                            onAddDocClicked = { createObjectSheetVisible = true },
-                            onSearchClicked = {
-                                vm.onSearchClicked(space)
-                            }
-                        )
-                        CreateObjectSheetHost(
-                            vm = createObjectVm,
-                            visible = createObjectSheetVisible,
-                            onDismiss = { createObjectSheetVisible = false },
-                            onCreateObjectOfType = { objType ->
-                                vm.onAddClicked(objType = objType)
-                            }
-                        )
-                    }
+                    CollectionScreen(vm = vm)
                 }
             }
         }
@@ -233,20 +200,10 @@ class CollectionFragment : BaseComposeFragment() {
     override fun injectDependencies() {
         val vmParams = CollectionViewModel.VmParams(spaceId = SpaceId(space))
         componentManager().collectionComponent.get(params = vmParams).inject(this)
-        val createObjectVmParams = NewCreateObjectViewModel.VmParams(
-            spaceId = SpaceId(space),
-            showAttachObject = false,
-            showMediaSection = true
-        )
-        createObjectFactory = componentManager()
-            .createObjectFeatureComponent
-            .get(key = createObjectComponentKey(), param = createObjectVmParams)
-            .viewModelFactory()
     }
 
     override fun releaseDependencies() {
         componentManager().collectionComponent.release()
-        componentManager().createObjectFeatureComponent.release(createObjectComponentKey())
     }
 
     override fun onApplyWindowRootInsets(view: View) {

--- a/app/src/main/java/com/anytypeio/anytype/ui/widgets/collection/CollectionScreen.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/widgets/collection/CollectionScreen.kt
@@ -122,7 +122,7 @@ import sh.calvin.reorderable.rememberReorderableLazyListState
 fun ScreenContent(
     vm: CollectionViewModel,
     uiState: CollectionUiState,
-    onCreateObjectLongClicked: () -> Unit,
+    onAddDocClicked: () -> Unit,
     onSearchClicked: () -> Unit,
 ) {
     Box(
@@ -150,8 +150,7 @@ fun ScreenContent(
                     .padding(bottom = 20.dp)) {
                 BottomNavigationMenu(
                     onSearchClick = onSearchClicked,
-                    onAddDocClick = { vm.onAddClicked(null) },
-                    onAddDocLongClick = onCreateObjectLongClicked,
+                    onAddDocClick = onAddDocClicked,
                     onShareButtonClicked = vm::onShareButtonClicked,
                     state = vm.navPanelState.collectAsStateWithLifecycle().value,
                     onHomeButtonClicked = vm::onHomeButtonClicked
@@ -622,7 +621,7 @@ fun CollectionItem(
 @Composable
 fun CollectionScreen(
     vm: CollectionViewModel,
-    onCreateObjectLongClicked: () -> Unit,
+    onAddDocClicked: () -> Unit,
     onSearchClicked: () -> Unit
 ) {
 
@@ -645,7 +644,7 @@ fun CollectionScreen(
                 ScreenContent(
                     vm = vm,
                     uiState = state,
-                    onCreateObjectLongClicked = onCreateObjectLongClicked,
+                    onAddDocClicked = onAddDocClicked,
                     onSearchClicked = onSearchClicked
                 )
                 LaunchedEffect(state) {

--- a/app/src/main/java/com/anytypeio/anytype/ui/widgets/collection/CollectionScreen.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/widgets/collection/CollectionScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.BottomSheetScaffold
@@ -60,9 +61,11 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.BottomCenter
 import androidx.compose.ui.Alignment.Companion.CenterEnd
+import androidx.compose.ui.Alignment.Companion.CenterStart
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
@@ -85,7 +88,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.anytypeio.anytype.BuildConfig
 import com.anytypeio.anytype.R
 import com.anytypeio.anytype.core_ui.common.keyboardAsState
-import com.anytypeio.anytype.core_ui.foundation.components.BottomNavigationMenu
 import com.anytypeio.anytype.core_ui.foundation.noRippleClickable
 import com.anytypeio.anytype.core_ui.foundation.noRippleThrottledClickable
 import com.anytypeio.anytype.core_ui.views.Caption1Regular
@@ -122,8 +124,6 @@ import sh.calvin.reorderable.rememberReorderableLazyListState
 fun ScreenContent(
     vm: CollectionViewModel,
     uiState: CollectionUiState,
-    onAddDocClicked: () -> Unit,
-    onSearchClicked: () -> Unit,
 ) {
     Box(
         Modifier.background(color = colorResource(R.color.background_primary))
@@ -143,18 +143,6 @@ fun ScreenContent(
                 TopBar(vm, uiState)
                 SearchBar(vm, uiState)
                 ListView(vm, uiState, stringResource(id = R.string.search_no_results_try))
-            }
-            Box(
-                Modifier
-                    .align(BottomCenter)
-                    .padding(bottom = 20.dp)) {
-                BottomNavigationMenu(
-                    onSearchClick = onSearchClicked,
-                    onAddDocClick = onAddDocClicked,
-                    onShareButtonClicked = vm::onShareButtonClicked,
-                    state = vm.navPanelState.collectAsStateWithLifecycle().value,
-                    onHomeButtonClicked = vm::onHomeButtonClicked
-                )
             }
         }
         if (uiState.operationInProgress) {
@@ -177,6 +165,29 @@ fun TopBar(
             .fillMaxWidth()
             .height(48.dp)
     ) {
+        Box(
+            modifier = Modifier
+                .align(CenterStart)
+                .padding(start = 16.dp)
+                .size(44.dp)
+                .shadow(
+                    elevation = 20.dp,
+                    shape = CircleShape,
+                    clip = false
+                )
+                .background(
+                    color = colorResource(id = com.anytypeio.anytype.core_ui.R.color.navigation_panel),
+                    shape = CircleShape
+                )
+                .noRippleThrottledClickable { vm.onPrevClicked() },
+            contentAlignment = Alignment.Center
+        ) {
+            Image(
+                modifier = Modifier.wrapContentSize(),
+                painter = painterResource(R.drawable.ic_default_top_back),
+                contentDescription = stringResource(R.string.content_desc_back_button)
+            )
+        }
         Text(
             modifier = Modifier
                 .align(Alignment.Center),
@@ -620,9 +631,7 @@ fun CollectionItem(
 @ExperimentalMaterialApi
 @Composable
 fun CollectionScreen(
-    vm: CollectionViewModel,
-    onAddDocClicked: () -> Unit,
-    onSearchClicked: () -> Unit
+    vm: CollectionViewModel
 ) {
 
     val uiState by vm.uiState.collectAsStateWithLifecycle()
@@ -643,9 +652,7 @@ fun CollectionScreen(
             ) {
                 ScreenContent(
                     vm = vm,
-                    uiState = state,
-                    onAddDocClicked = onAddDocClicked,
-                    onSearchClicked = onSearchClicked
+                    uiState = state
                 )
                 LaunchedEffect(state) {
 

--- a/app/src/main/res/layout/fragment_editor.xml
+++ b/app/src/main/res/layout/fragment_editor.xml
@@ -401,4 +401,9 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/createObjectSheetHost"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_object_set.xml
+++ b/app/src/main/res/layout/fragment_object_set.xml
@@ -247,4 +247,13 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/createObjectSheetHost"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
 </androidx.constraintlayout.motion.widget.MotionLayout>

--- a/feature-all-content/src/main/java/com/anytypeio/anytype/feature_allcontent/ui/AllContentScreen.kt
+++ b/feature-all-content/src/main/java/com/anytypeio/anytype/feature_allcontent/ui/AllContentScreen.kt
@@ -117,7 +117,6 @@ fun AllContentWrapperScreen(
     onUpdateLimitSearch: () -> Unit,
     uiContentState: UiContentState,
     onAddDocClicked: () -> Unit,
-    onCreateObjectLongClicked: () -> Unit,
     onBackClicked: () -> Unit,
     onTitleClick: () -> Unit,
     onSyncStatusClick: (SpaceSyncAndP2PStatusState) -> Unit,
@@ -141,7 +140,6 @@ fun AllContentWrapperScreen(
         uiItemsState = uiItemsState,
         uiContentState = uiContentState,
         onAddDocClicked = onAddDocClicked,
-        onCreateObjectLongClicked = onCreateObjectLongClicked,
         onBackClicked = onBackClicked,
         onTitleClick = onTitleClick,
         onSyncStatusClick = onSyncStatusClick,
@@ -172,7 +170,6 @@ fun AllContentMainScreen(
     onBinClick: () -> Unit,
     uiContentState: UiContentState,
     onAddDocClicked: () -> Unit,
-    onCreateObjectLongClicked: () -> Unit,
     onBackClicked: () -> Unit,
     onTitleClick: () -> Unit,
     onSyncStatusClick: (SpaceSyncAndP2PStatusState) -> Unit,
@@ -305,8 +302,7 @@ fun AllContentMainScreen(
                         ),
                     iconRes = com.anytypeio.anytype.core_ui.R.drawable.ic_create_obj_32,
                     contentDescription = stringResource(id = R.string.create),
-                    onClick = onAddDocClicked,
-                    onLongClick = onCreateObjectLongClicked
+                    onClick = onAddDocClicked
                 )
             }
         },
@@ -535,7 +531,6 @@ fun PreviewMainScreen() {
         onBinClick = {},
         uiContentState = UiContentState.Error("Error message"),
         onAddDocClicked = {},
-        onCreateObjectLongClicked = {},
         onBackClicked = {},
         onTitleClick = {},
         onSyncStatusClick = {},

--- a/feature-create-object/build.gradle
+++ b/feature-create-object/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     // Lifecycle
     implementation libs.lifecycleViewModel
     implementation libs.lifecycleRuntime
+    implementation libs.lifecycleCompose
 
     // Compose
     implementation libs.compose
@@ -39,6 +40,7 @@ dependencies {
     implementation libs.composeToolingPreview
     implementation libs.composeMaterial3
     implementation libs.composeMaterial
+    implementation libs.activityCompose
 
     debugImplementation libs.composeTooling
 

--- a/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/CreateObjectViewModelFactory.kt
+++ b/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/CreateObjectViewModelFactory.kt
@@ -2,6 +2,8 @@ package com.anytypeio.anytype.feature_create_object.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.anytypeio.anytype.domain.device.FileSharer
+import com.anytypeio.anytype.domain.media.UploadFile
 import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
 import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
 import javax.inject.Inject
@@ -11,11 +13,15 @@ import javax.inject.Inject
  *
  * @param storeOfObjectTypes Store for fetching object types
  * @param spaceViewContainer Container for observing space properties (needed for sort order)
+ * @param uploadFile Use case for uploading a local file to the space
+ * @param fileSharer Resolves content URIs into local paths the middleware can read
  * @param vmParams Parameters including the current space ID
  */
 class CreateObjectViewModelFactory @Inject constructor(
     private val storeOfObjectTypes: StoreOfObjectTypes,
     private val spaceViewContainer: SpaceViewSubscriptionContainer,
+    private val uploadFile: UploadFile,
+    private val fileSharer: FileSharer,
     private val vmParams: NewCreateObjectViewModel.VmParams
 ) : ViewModelProvider.Factory {
 
@@ -24,6 +30,8 @@ class CreateObjectViewModelFactory @Inject constructor(
         return NewCreateObjectViewModel(
             storeOfObjectTypes = storeOfObjectTypes,
             spaceViewContainer = spaceViewContainer,
+            uploadFile = uploadFile,
+            fileSharer = fileSharer,
             vmParams = vmParams
         ) as T
     }

--- a/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModel.kt
+++ b/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModel.kt
@@ -19,6 +19,7 @@ import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
 import com.anytypeio.anytype.presentation.notifications.UploadSuccessSnackbar
 import com.anytypeio.anytype.presentation.objects.sortByTypePriority
 import javax.inject.Inject
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -65,6 +66,8 @@ class NewCreateObjectViewModel @Inject constructor(
     )
     val uploadSnackbar: SharedFlow<UploadSuccessSnackbar> = _uploadSnackbar.asSharedFlow()
 
+    private var observeJob: Job? = null
+
     init {
         observeObjectTypes()
     }
@@ -74,7 +77,8 @@ class NewCreateObjectViewModel @Inject constructor(
      * The sort order respects user's custom widget ordering via orderId field.
      */
     private fun observeObjectTypes() {
-        viewModelScope.launch {
+        observeJob?.cancel()
+        observeJob = viewModelScope.launch {
             try {
                 _state.update { it.copy(isLoading = true) }
 

--- a/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModel.kt
+++ b/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModel.kt
@@ -2,18 +2,28 @@ package com.anytypeio.anytype.feature_create_object.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.anytypeio.anytype.core_models.Block
 import com.anytypeio.anytype.core_models.ObjectType
 import com.anytypeio.anytype.core_models.ObjectTypeIds
+import com.anytypeio.anytype.core_models.ObjectWrapper
 import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.core_models.SupportedLayouts
 import com.anytypeio.anytype.core_models.primitives.SpaceId
+import com.anytypeio.anytype.core_models.primitives.TypeKey
 import com.anytypeio.anytype.core_models.ui.objectIcon
+import com.anytypeio.anytype.domain.base.fold
+import com.anytypeio.anytype.domain.device.FileSharer
+import com.anytypeio.anytype.domain.media.UploadFile
 import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
 import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
+import com.anytypeio.anytype.presentation.notifications.UploadSuccessSnackbar
 import com.anytypeio.anytype.presentation.objects.sortByTypePriority
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
@@ -26,13 +36,18 @@ import timber.log.Timber
  * Types are sorted according to user's custom widget order (orderId), with fallback to
  * space-specific default order, then alphabetical.
  *
- * @param storeOfObjectTypes Store containing all available object types
- * @param spaceViewContainer Container for observing space view properties
- * @param vmParams Parameters including the current space ID
+ * Also owns upload plumbing for the popup's media rows (Photos / Camera / Files):
+ * when the host surface exposes `showMediaSection`, selected URIs are uploaded as
+ * standalone file/image/video objects in the current space via [uploadFiles], and
+ * success events are emitted on [uploadSnackbar] for the host fragment to display.
+ * Centralising upload here means each host screen only needs the shared VM and does
+ * not have to add `UploadFile` / `FileSharer` to its own VM.
  */
 class NewCreateObjectViewModel @Inject constructor(
     private val storeOfObjectTypes: StoreOfObjectTypes,
     private val spaceViewContainer: SpaceViewSubscriptionContainer,
+    private val uploadFile: UploadFile,
+    private val fileSharer: FileSharer,
     private val vmParams: VmParams
 ) : ViewModel() {
 
@@ -43,6 +58,12 @@ class NewCreateObjectViewModel @Inject constructor(
         )
     )
     val state: StateFlow<NewCreateObjectState> = _state.asStateFlow()
+
+    private val _uploadSnackbar = MutableSharedFlow<UploadSuccessSnackbar>(
+        replay = 0,
+        extraBufferCapacity = 8
+    )
+    val uploadSnackbar: SharedFlow<UploadSuccessSnackbar> = _uploadSnackbar.asSharedFlow()
 
     init {
         observeObjectTypes()
@@ -182,6 +203,73 @@ class NewCreateObjectViewModel @Inject constructor(
     }
 
     /**
+     * Resolves an object type by its unique key. Used by host fragments to
+     * convert a `CreateObjectAction.CreateObjectOfType` (which carries only
+     * the key) back into the full [ObjectWrapper.Type] their screen VM's
+     * create method expects. Returns null if the type is unknown, e.g. when
+     * it has not finished syncing into [storeOfObjectTypes] yet.
+     */
+    suspend fun resolveType(typeKey: TypeKey): ObjectWrapper.Type? {
+        return storeOfObjectTypes.getByKey(typeKey.key)
+    }
+
+    /**
+     * Uploads a list of URIs as standalone file/image/video objects in the
+     * current space. Triggered from the popup's media rows. Emits to
+     * [uploadSnackbar] on success so the host fragment can show the usual
+     * upload-complete snackbar.
+     */
+    fun uploadFiles(targets: List<CreateObjectUploadTarget>) {
+        if (vmParams.spaceId.id.isEmpty() || targets.isEmpty()) return
+        viewModelScope.launch {
+            val successes = mutableListOf<Block.Content.File.Type>()
+            targets.forEach { target ->
+                val path = runCatching { fileSharer.getPath(target.uri) }
+                    .getOrNull()
+                    ?.takeIf { it.isNotEmpty() }
+                if (path == null) {
+                    Timber.w("Upload: could not resolve path for ${target.uri}")
+                    target.sourceFilePath?.let { src ->
+                        runCatching { java.io.File(src).delete() }
+                    }
+                    return@forEach
+                }
+                uploadFile.async(
+                    UploadFile.Params(
+                        space = vmParams.spaceId,
+                        path = path,
+                        type = target.type,
+                        createdInContext = null
+                    )
+                ).fold(
+                    onSuccess = { uploaded ->
+                        Timber.d("Upload success id=${uploaded.id}")
+                        successes += target.type
+                    },
+                    onFailure = { e -> Timber.e(e, "Upload failed for $path") }
+                )
+                runCatching { java.io.File(path).delete() }
+                target.sourceFilePath?.let { src ->
+                    runCatching { java.io.File(src).delete() }
+                }
+            }
+            if (successes.isNotEmpty()) {
+                _uploadSnackbar.emit(successes.toSnackbarVariant())
+            }
+        }
+    }
+
+    private fun List<Block.Content.File.Type>.toSnackbarVariant(): UploadSuccessSnackbar {
+        val distinct = distinct()
+        if (distinct.size > 1) return UploadSuccessSnackbar.Mixed
+        return when (distinct.single()) {
+            Block.Content.File.Type.IMAGE -> UploadSuccessSnackbar.Image
+            Block.Content.File.Type.VIDEO -> UploadSuccessSnackbar.Video
+            else -> UploadSuccessSnackbar.File
+        }
+    }
+
+    /**
      * Parameters for the ViewModel.
      *
      * @param spaceId The current space ID, used to determine space type for sorting.
@@ -196,3 +284,21 @@ class NewCreateObjectViewModel @Inject constructor(
         val showMediaSection: Boolean = false
     )
 }
+
+/**
+ * Describes a local URI that should be uploaded to the current space when the
+ * user picks it from the create-object popup's media rows.
+ *
+ * @property uri The content URI (from `PickVisualMedia`, `OpenMultipleDocuments`,
+ *   or the `FileProvider` URI used for camera capture).
+ * @property type File kind hint; middleware uses it when creating the resulting
+ *   object.
+ * @property sourceFilePath Optional local file path to delete once upload
+ *   completes. Used by the camera capture path to clean up the FileProvider-
+ *   backed temp file in the app cache.
+ */
+data class CreateObjectUploadTarget(
+    val uri: String,
+    val type: Block.Content.File.Type,
+    val sourceFilePath: String? = null
+)

--- a/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/ui/CreateObjectSheetHost.kt
+++ b/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/ui/CreateObjectSheetHost.kt
@@ -186,10 +186,7 @@ internal fun launchCameraForCreateObjectUpload(
 ) {
     val tempDir = File(context.cacheDir, CREATE_OBJECT_UPLOAD_TEMP_FOLDER)
     if (!tempDir.exists()) tempDir.mkdirs()
-    val photoFile = File.createTempFile("IMG_", ".jpg", tempDir).apply {
-        createNewFile()
-        deleteOnExit()
-    }
+    val photoFile = File.createTempFile("IMG_", ".jpg", tempDir)
     val uri = FileProvider.getUriForFile(
         context,
         "${context.packageName}.provider",

--- a/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/ui/CreateObjectSheetHost.kt
+++ b/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/ui/CreateObjectSheetHost.kt
@@ -1,0 +1,202 @@
+package com.anytypeio.anytype.feature_create_object.ui
+
+import android.Manifest
+import android.content.Context
+import android.net.Uri
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.FileProvider
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.anytypeio.anytype.core_models.Block
+import com.anytypeio.anytype.core_models.ObjectWrapper
+import com.anytypeio.anytype.core_models.primitives.TypeKey
+import com.anytypeio.anytype.core_utils.ext.isVideo
+import com.anytypeio.anytype.feature_create_object.presentation.CreateObjectAction
+import com.anytypeio.anytype.feature_create_object.presentation.CreateObjectUploadTarget
+import com.anytypeio.anytype.feature_create_object.presentation.NewCreateObjectViewModel
+import java.io.File
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * Reusable host for the global Create-object popup.
+ *
+ * This composable wires up everything a screen needs to surface the full
+ * [CreateObjectPopup]: the visibility/state plumbing, the four
+ * `ActivityResult` launchers for Photos / Camera / Files uploads, the
+ * permission launcher for camera capture, and the action dispatch that
+ * routes media picks into [vm]'s upload and type picks into
+ * [onCreateObjectOfType]. Hosts that don't need uploads can simply pass a
+ * [NewCreateObjectViewModel] whose `VmParams.showMediaSection` is false —
+ * the media rows will stay hidden and the launchers remain inert.
+ */
+@Composable
+fun CreateObjectSheetHost(
+    vm: NewCreateObjectViewModel,
+    visible: Boolean,
+    onDismiss: () -> Unit,
+    onCreateObjectOfType: (ObjectWrapper.Type) -> Unit,
+    onAttachExistingObject: () -> Unit = {}
+) {
+    val state = vm.state.collectAsStateWithLifecycle().value
+
+    LaunchedEffect(visible) {
+        if (visible) vm.onOpen()
+    }
+
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    val uploadMediaLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickMultipleVisualMedia()
+    ) { uris ->
+        if (uris.isEmpty()) return@rememberLauncherForActivityResult
+        vm.uploadFiles(
+            uris.map { uri ->
+                val type = if (isVideo(uri, context)) {
+                    Block.Content.File.Type.VIDEO
+                } else {
+                    Block.Content.File.Type.IMAGE
+                }
+                CreateObjectUploadTarget(uri.toString(), type)
+            }
+        )
+        onDismiss()
+    }
+
+    val uploadFileLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenMultipleDocuments()
+    ) { uris ->
+        if (uris.isEmpty()) return@rememberLauncherForActivityResult
+        vm.uploadFiles(
+            uris.map { uri ->
+                CreateObjectUploadTarget(
+                    uri = uri.toString(),
+                    type = Block.Content.File.Type.NONE
+                )
+            }
+        )
+        onDismiss()
+    }
+
+    var capturedPhotoUri by rememberSaveable { mutableStateOf<String?>(null) }
+    var capturedPhotoPath by rememberSaveable { mutableStateOf<String?>(null) }
+
+    val takePhotoLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.TakePicture()
+    ) { isSuccess ->
+        val uri = capturedPhotoUri
+        val sourcePath = capturedPhotoPath
+        if (isSuccess && uri != null) {
+            vm.uploadFiles(
+                listOf(
+                    CreateObjectUploadTarget(
+                        uri = uri,
+                        type = Block.Content.File.Type.IMAGE,
+                        sourceFilePath = sourcePath
+                    )
+                )
+            )
+            onDismiss()
+        } else if (sourcePath != null) {
+            // Capture cancelled/failed — still clean up the empty temp file.
+            runCatching { File(sourcePath).delete() }
+        }
+        capturedPhotoUri = null
+        capturedPhotoPath = null
+    }
+
+    val takePhotoPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            launchCameraForCreateObjectUpload(
+                context = context,
+                launcher = takePhotoLauncher,
+                onPhotoReady = { uri, file ->
+                    capturedPhotoUri = uri.toString()
+                    capturedPhotoPath = file.absolutePath
+                }
+            )
+        } else {
+            Timber.w("Camera permission denied for create-object upload")
+        }
+    }
+
+    CreateObjectPopup(
+        expanded = visible,
+        onDismissRequest = onDismiss,
+        state = state,
+        onAction = { action ->
+            when (action) {
+                CreateObjectAction.SelectPhotos -> {
+                    uploadMediaLauncher.launch(
+                        PickVisualMediaRequest(
+                            ActivityResultContracts.PickVisualMedia.ImageAndVideo
+                        )
+                    )
+                }
+                CreateObjectAction.TakePhoto -> {
+                    takePhotoPermissionLauncher.launch(Manifest.permission.CAMERA)
+                }
+                CreateObjectAction.SelectFiles -> {
+                    uploadFileLauncher.launch(arrayOf("*/*"))
+                }
+                CreateObjectAction.AttachExistingObject -> {
+                    onAttachExistingObject()
+                }
+                is CreateObjectAction.CreateObjectOfType -> {
+                    scope.launch {
+                        val type = vm.resolveType(TypeKey(action.typeKey))
+                        if (type != null) {
+                            onCreateObjectOfType(type)
+                        } else {
+                            Timber.w("Create-object: type ${action.typeKey} not in store")
+                        }
+                        onDismiss()
+                    }
+                }
+                is CreateObjectAction.UpdateSearch,
+                is CreateObjectAction.Retry -> {
+                    vm.onAction(action)
+                }
+            }
+        }
+    )
+}
+
+/**
+ * Writes a temp JPEG into the app cache, gives the launcher the FileProvider URI,
+ * and reports the URI back via [onPhotoReady] so callers can upload on capture.
+ */
+internal fun launchCameraForCreateObjectUpload(
+    context: Context,
+    launcher: ManagedActivityResultLauncher<Uri, Boolean>,
+    onPhotoReady: (uri: Uri, file: File) -> Unit
+) {
+    val tempDir = File(context.cacheDir, CREATE_OBJECT_UPLOAD_TEMP_FOLDER)
+    if (!tempDir.exists()) tempDir.mkdirs()
+    val photoFile = File.createTempFile("IMG_", ".jpg", tempDir).apply {
+        createNewFile()
+        deleteOnExit()
+    }
+    val uri = FileProvider.getUriForFile(
+        context,
+        "${context.packageName}.provider",
+        photoFile
+    )
+    onPhotoReady(uri, photoFile)
+    launcher.launch(uri)
+}
+
+private const val CREATE_OBJECT_UPLOAD_TEMP_FOLDER = "create_object_upload_temp_folder"

--- a/feature-create-object/src/test/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModelTest.kt
+++ b/feature-create-object/src/test/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModelTest.kt
@@ -554,6 +554,8 @@ class NewCreateObjectViewModelTest {
         return NewCreateObjectViewModel(
             storeOfObjectTypes = storeOfObjectTypes,
             spaceViewContainer = spaceViewContainer,
+            uploadFile = org.mockito.kotlin.mock(),
+            fileSharer = org.mockito.kotlin.mock(),
             vmParams = vmParams
         )
     }

--- a/feature-date/src/main/java/com/anytypeio/anytype/feature_date/ui/MainScreen.kt
+++ b/feature-date/src/main/java/com/anytypeio/anytype/feature_date/ui/MainScreen.kt
@@ -177,8 +177,7 @@ fun DateMainScreen(
                         ),
                     iconRes = R.drawable.ic_create_obj_32,
                     contentDescription = stringResource(id = R.string.create),
-                    onClick = { onDateEvent(DateEvent.NavigationWidget.OnAddDocClick) },
-                    onLongClick = { onDateEvent(DateEvent.NavigationWidget.OnAddDocLongClick) }
+                    onClick = { onDateEvent(DateEvent.NavigationWidget.OnAddDocClick) }
                 )
             }
         },

--- a/feature-date/src/main/java/com/anytypeio/anytype/feature_date/ui/models/DateEvent.kt
+++ b/feature-date/src/main/java/com/anytypeio/anytype/feature_date/ui/models/DateEvent.kt
@@ -37,7 +37,6 @@ sealed class DateEvent {
     sealed class NavigationWidget : DateEvent() {
         data object OnGlobalSearchClick : NavigationWidget()
         data object OnAddDocClick : NavigationWidget()
-        data object OnAddDocLongClick : NavigationWidget()
         data object OnBackClick : NavigationWidget()
         data object OnBackLongClick : NavigationWidget()
         data object OnHomeClick : NavigationWidget()

--- a/feature-date/src/main/java/com/anytypeio/anytype/feature_date/viewmodel/DateObjectCommand.kt
+++ b/feature-date/src/main/java/com/anytypeio/anytype/feature_date/viewmodel/DateObjectCommand.kt
@@ -11,7 +11,6 @@ sealed class DateObjectCommand {
     data class NavigateToDateObject(val objectId: Id, val space: SpaceId) : DateObjectCommand()
     data class NavigateToParticipant(val objectId: Id, val space: SpaceId) : DateObjectCommand()
     data class OpenUrl(val url: String) : DateObjectCommand()
-    data object TypeSelectionScreen : DateObjectCommand()
     data object ExitToHomeOrChat : DateObjectCommand()
     sealed class SendToast : DateObjectCommand() {
         data class Error(val message: String) : SendToast()

--- a/feature-date/src/main/java/com/anytypeio/anytype/feature_date/viewmodel/DateObjectViewModel.kt
+++ b/feature-date/src/main/java/com/anytypeio/anytype/feature_date/viewmodel/DateObjectViewModel.kt
@@ -906,13 +906,8 @@ class DateObjectViewModel(
     private fun onNavigationWidgetEvent(event: DateEvent.NavigationWidget) {
         when (event) {
             DateEvent.NavigationWidget.OnAddDocClick -> {
-                proceedWithCreateDoc()
-            }
-
-            DateEvent.NavigationWidget.OnAddDocLongClick -> {
-                viewModelScope.launch {
-                    effects.emit(DateObjectCommand.TypeSelectionScreen)
-                }
+                // Intercepted by DateObjectFragment to open the shared
+                // CreateObjectPopup; VM no longer handles the click directly.
             }
 
             DateEvent.NavigationWidget.OnBackClick -> {


### PR DESCRIPTION
## Summary
- Short-click on the Create FAB now opens the shared `CreateObjectPopup` on **Editor**, **Object Set**, **All Content**, **Collection Widget (fullscreen)**, and **Date Object** — matching Home/Widgets. Long-click handlers + `ObjectTypeSelectionFragment` dialogs are removed from these flows.
- New reusable `CreateObjectSheetHost` composable wraps the popup with media (Photos / Camera / Files) + permission launchers, so host fragments only need to flip a boolean and route type-create back to their screen VM.
- Upload capability moves into `NewCreateObjectViewModel` itself (`uploadFiles`, `uploadSnackbar`, `resolveType`), avoiding per-VM DI churn across 5 presentation modules.

## Test plan
- [x] **Home (regression)**: tap Create FAB → popup opens as before.
- [x] **Editor**: open any document → tap Create FAB → popup opens; long-press FAB → no-op (no dialog, no haptic).
- [x] **Object Set / Collection**: open a set → tap Create FAB → popup opens; long-press → no-op. Data-view header "+" buttons unchanged.
- [ ] **All Content**: tap Create FAB → popup opens; long-press → no-op.
- [ ] **Collection Widget (Bin/Favorites fullscreen)**: tap bottom-nav Create → popup opens; long-press → no-op.
- [ ] **Date Object**: tap Create FAB → popup opens; long-press → no-op.
- [ ] In each popup: select a type → object is created in that screen's space. Pick Photos/Camera/Files → upload succeeds, snackbar shows (Home) / upload completes silently (other screens — snackbar wiring deferred).
- [ ] **First-tap fix**: tap FAB exactly once in Editor — popup opens on the first tap (verifies the `mutableStateOf` lifecycle fix for the `setContent` race).

## Known follow-ups
- `WidgetsScreenFragment` / `WidgetOverlayFragment` still use inline popup + launcher code (~140 LOC of duplication); migrating them to `CreateObjectSheetHost` is a safe cleanup PR.
- `CircularFabButton.onLongClick` and `BottomNavigationMenu.onAddDocLongClick` params are now unused at all call sites but remain as optional (`= {}`) defaults. They can be removed outright in a follow-up.
- Upload-success snackbar is currently only shown on Home; wiring it to the other fragments via `NewCreateObjectViewModel.uploadSnackbar` is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)