### PR TITLE
DROID-4400 Fix scroll position lost when returning from media viewer

### DIFF
--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/ChatScreen.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/ChatScreen.kt
@@ -472,6 +472,12 @@ fun ChatScreen(
 
     val scope = rememberCoroutineScope()
 
+    // Persists the ID of the first visible message across Fragment recreation (e.g. when
+    // returning from MediaActivity triggers Activity/Fragment destruction).  When the
+    // ViewModel is recreated and messages reload, we scroll back to this message instead
+    // of jumping to the bottom.
+    var savedFirstVisibleMessageId by rememberSaveable { mutableStateOf<String?>(null) }
+
     var text by rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(TextFieldValue())
     }
@@ -632,8 +638,44 @@ fun ChatScreen(
             }
     }
 
+    // Track the topmost visible message ID so we can save it for scroll restoration.
+    // In reverseLayout, lastOrNull() is the item at the top of the screen (highest index).
+    LaunchedEffect(lazyListState) {
+        snapshotFlow {
+            val topVisible = lazyListState.layoutInfo.visibleItemsInfo.lastOrNull()
+            topVisible?.let { messages.getOrNull(it.index) }
+        }
+            .filterNotNull()
+            .mapNotNull { item -> (item as? ChatView.Message)?.id }
+            .distinctUntilChanged()
+            .collect { id ->
+                savedFirstVisibleMessageId = id
+            }
+    }
+
+    // Whether we have already consumed the saved scroll position after recreation.
+    // Once consumed, normal auto-scroll-to-bottom behaviour resumes.
+    var scrollRestored by remember { mutableStateOf(false) }
+
     // Scrolling to bottom when list size changes and we are at the bottom of the list
     LaunchedEffect(messages.size) {
+        if (messages.isEmpty()) return@LaunchedEffect
+        // After Fragment recreation (e.g. returning from MediaActivity with "Don't Keep
+        // Activities" or under OS memory pressure), restore the scroll position to the
+        // previously visible message instead of jumping to bottom.
+        if (!scrollRestored) {
+            scrollRestored = true
+            val restoreId = savedFirstVisibleMessageId
+            if (restoreId != null && !isPerformingScrollIntent.value) {
+                val index = messages.indexOfFirst {
+                    it is ChatView.Message && it.id == restoreId
+                }
+                if (index >= 0) {
+                    lazyListState.scrollToItem(index)
+                    return@LaunchedEffect
+                }
+            }
+        }
         if (wasAtBottom && !isPerformingScrollIntent.value) {
             lazyListState.animateScrollToItem(0)
         } else {

--- a/feature-discussions/src/main/java/com/anytypeio/anytype/feature_discussions/ui/DiscussionScreen.kt
+++ b/feature-discussions/src/main/java/com/anytypeio/anytype/feature_discussions/ui/DiscussionScreen.kt
@@ -47,7 +47,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -113,6 +115,9 @@ import com.anytypeio.anytype.feature_discussions.presentation.DiscussionInputMod
 import com.anytypeio.anytype.feature_discussions.presentation.DiscussionView
 import com.anytypeio.anytype.feature_discussions.presentation.DiscussionViewModel
 import com.anytypeio.anytype.feature_discussions.presentation.DiscussionViewModel.MentionPanelState
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.mapNotNull
 import timber.log.Timber
 
 @Composable
@@ -463,8 +468,41 @@ fun DiscussionCommentList(
 ) {
     val listState = rememberLazyListState()
 
+    // Persists the last visible comment ID across Fragment recreation so we can
+    // restore scroll position when returning from MediaActivity.
+    var savedLastVisibleCommentId by rememberSaveable { mutableStateOf<String?>(null) }
+    var scrollRestored by remember { mutableStateOf(false) }
+
+    // Track the last visible comment ID (bottom of the visible area, i.e. newest).
+    LaunchedEffect(listState) {
+        snapshotFlow {
+            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()
+            lastVisible?.let { comments.getOrNull(it.index) }
+        }
+            .filterNotNull()
+            .mapNotNull { item -> (item as? DiscussionView.Comment)?.id }
+            .distinctUntilChanged()
+            .collect { id ->
+                savedLastVisibleCommentId = id
+            }
+    }
+
     LaunchedEffect(comments.isNotEmpty()) {
         if (comments.isNotEmpty()) {
+            // After Fragment recreation, restore to previously visible comment.
+            if (!scrollRestored) {
+                scrollRestored = true
+                val restoreId = savedLastVisibleCommentId
+                if (restoreId != null) {
+                    val index = comments.indexOfFirst {
+                        it is DiscussionView.Comment && it.id == restoreId
+                    }
+                    if (index >= 0) {
+                        listState.scrollToItem(index)
+                        return@LaunchedEffect
+                    }
+                }
+            }
             listState.scrollToItem(comments.lastIndex)
         }
     }


### PR DESCRIPTION
## Summary
- Save the currently visible message/comment ID via `rememberSaveable` in `ChatScreen` and `DiscussionCommentList`
- When the Fragment is recreated after returning from `MediaActivity`, scroll to the saved position instead of jumping to bottom
- Root cause: with "Don't Keep Activities" enabled (or under OS memory pressure), launching `MediaActivity` causes the host Activity and Fragment to be fully destroyed (`onDestroy` → `onCreate`). The DI component is released in `onDestroy`, so a fresh ViewModel starts with empty state, causing the chat to reload and auto-scroll to bottom

## Changes
- **`ChatScreen.kt`**: Track topmost visible message ID via `rememberSaveable`, restore scroll on first message load after recreation
- **`DiscussionScreen.kt`**: Same pattern for discussion comments

## Test plan
- [ ] Enable "Don't Keep Activities" in developer settings
- [ ] Open a chat with many messages, scroll to a mid-point
- [ ] Tap on an image/video/audio attachment to open MediaActivity
- [ ] Press back — scroll position should be approximately restored
- [ ] Disable "Don't Keep Activities", repeat — should work as before
- [ ] Verify scroll-to-bottom still works when new messages arrive while at bottom
- [ ] Verify initial scroll-to-unread behavior still works on fresh chat open
- [ ] Repeat for discussion screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)