### PR TITLE
DROID-4361 Notifications | Drop orphaned chat_notifications_* string keys

### DIFF
--- a/localization/src/main/res/values-be-rBY/strings.xml
+++ b/localization/src/main/res/values-be-rBY/strings.xml
@@ -2170,8 +2170,6 @@
     <string name="select_space">Select Channel</string>
     <string name="add_a_comment">Add a comment...</string>
     <string name="send">Send</string>
-    <string name="chat_notifications_receive_all">Receive all</string>
-    <string name="chat_notifications_mute_all">Mute all</string>
     <string name="chat_specific_notifications">Chat specific notifications</string>
     <string name="notify_me_about">Notify me about</string>
     <string name="error_while_downloading_object">Error while downloading object: %1$s</string>

--- a/localization/src/main/res/values-de-rDE/strings.xml
+++ b/localization/src/main/res/values-de-rDE/strings.xml
@@ -2142,8 +2142,6 @@ Bitte mache hier genaue Angaben zu deinen Bedarf.</string>
     <string name="select_space">Kanal auswählen</string>
     <string name="add_a_comment">Kommentar hinzufügen...</string>
     <string name="send">Senden</string>
-    <string name="chat_notifications_receive_all">Alle empfangen</string>
-    <string name="chat_notifications_mute_all">Alle stummschalten</string>
     <string name="chat_specific_notifications">Chat-spezifische Benachrichtigungen</string>
     <string name="notify_me_about">Benachrichtigen über</string>
     <string name="error_while_downloading_object">Fehler beim Herunterladen des Objekts: %1$s</string>

--- a/localization/src/main/res/values-es-rES/strings.xml
+++ b/localization/src/main/res/values-es-rES/strings.xml
@@ -2141,8 +2141,6 @@ En concreto,
     <string name="select_space">Seleccionar canal</string>
     <string name="add_a_comment">Añade un comentario…</string>
     <string name="send">Enviar</string>
-    <string name="chat_notifications_receive_all">Recibir todas</string>
-    <string name="chat_notifications_mute_all">Silenciar todas</string>
     <string name="chat_specific_notifications">Notificaciones del chat</string>
     <string name="notify_me_about">Notifícame sobre</string>
     <string name="error_while_downloading_object">Error al descargar el objeto %1$s</string>

--- a/localization/src/main/res/values-fr-rFR/strings.xml
+++ b/localization/src/main/res/values-fr-rFR/strings.xml
@@ -2139,8 +2139,6 @@ Merci de décrire ici vos besoins spécifiques.</string>
     <string name="select_space">Select Channel</string>
     <string name="add_a_comment">Add a comment...</string>
     <string name="send">Send</string>
-    <string name="chat_notifications_receive_all">Receive all</string>
-    <string name="chat_notifications_mute_all">Mute all</string>
     <string name="chat_specific_notifications">Chat specific notifications</string>
     <string name="notify_me_about">Notify me about</string>
     <string name="error_while_downloading_object">Error while downloading object: %1$s</string>

--- a/localization/src/main/res/values-in-rID/strings.xml
+++ b/localization/src/main/res/values-in-rID/strings.xml
@@ -2127,8 +2127,6 @@ Harap berikan detail spesifik kebutuhan Anda di sini.</string>
     <string name="select_space">Pilih Saluran</string>
     <string name="add_a_comment">Tambahkan komentar …</string>
     <string name="send">Kirim</string>
-    <string name="chat_notifications_receive_all">Terima semua</string>
-    <string name="chat_notifications_mute_all">Senyapkan semua</string>
     <string name="chat_specific_notifications">Pemberitahuan spesifik obrolan</string>
     <string name="notify_me_about">Beri notifikasi tentang</string>
     <string name="error_while_downloading_object">Galat saat mengunduh objek: %1$s</string>

--- a/localization/src/main/res/values-it-rIT/strings.xml
+++ b/localization/src/main/res/values-it-rIT/strings.xml
@@ -2143,8 +2143,6 @@ Please provide specific details of your needs here.</string>
     <string name="select_space">Select Channel</string>
     <string name="add_a_comment">Aggiungi un commento...</string>
     <string name="send">Invia</string>
-    <string name="chat_notifications_receive_all">Ricevi tutto</string>
-    <string name="chat_notifications_mute_all">Silenzia tutti</string>
     <string name="chat_specific_notifications">Notifiche specifiche della chat</string>
     <string name="notify_me_about">Avvisami su</string>
     <string name="error_while_downloading_object">Errore durante il download dell\'oggetto: %1$s</string>

--- a/localization/src/main/res/values-ja-rJP/strings.xml
+++ b/localization/src/main/res/values-ja-rJP/strings.xml
@@ -2129,8 +2129,6 @@
     <string name="select_space">Select Channel</string>
     <string name="add_a_comment">コメントを追加...</string>
     <string name="send">送信</string>
-    <string name="chat_notifications_receive_all">Receive all</string>
-    <string name="chat_notifications_mute_all">Mute all</string>
     <string name="chat_specific_notifications">Chat specific notifications</string>
     <string name="notify_me_about">Notify me about</string>
     <string name="error_while_downloading_object">Error while downloading object: %1$s</string>

--- a/localization/src/main/res/values-nl-rNL/strings.xml
+++ b/localization/src/main/res/values-nl-rNL/strings.xml
@@ -2142,8 +2142,6 @@ Geef alsjeblieft specifieke details van jouw wensen hier aan. </string>
     <string name="select_space">Select Channel</string>
     <string name="add_a_comment">Voeg een reactie toe ...</string>
     <string name="send">Verzend</string>
-    <string name="chat_notifications_receive_all">Receive all</string>
-    <string name="chat_notifications_mute_all">Mute all</string>
     <string name="chat_specific_notifications">Chat specific notifications</string>
     <string name="notify_me_about">Notify me about</string>
     <string name="error_while_downloading_object">Error while downloading object: %1$s</string>

--- a/localization/src/main/res/values-no-rNO/strings.xml
+++ b/localization/src/main/res/values-no-rNO/strings.xml
@@ -2142,8 +2142,6 @@ Please provide specific details of your needs here.</string>
     <string name="select_space">Select Channel</string>
     <string name="add_a_comment">Add a comment...</string>
     <string name="send">Send</string>
-    <string name="chat_notifications_receive_all">Receive all</string>
-    <string name="chat_notifications_mute_all">Mute all</string>
     <string name="chat_specific_notifications">Chat specific notifications</string>
     <string name="notify_me_about">Notify me about</string>
     <string name="error_while_downloading_object">Error while downloading object: %1$s</string>

--- a/localization/src/main/res/values-pt-rBR/strings.xml
+++ b/localization/src/main/res/values-pt-rBR/strings.xml
@@ -2139,8 +2139,6 @@ forneça detalhes específicos das suas necessidades aqui.</string>
     <string name="select_space">Select Channel</string>
     <string name="add_a_comment">Add a comment...</string>
     <string name="send">Send</string>
-    <string name="chat_notifications_receive_all">Receive all</string>
-    <string name="chat_notifications_mute_all">Mute all</string>
     <string name="chat_specific_notifications">Chat specific notifications</string>
     <string name="notify_me_about">Notify me about</string>
     <string name="error_while_downloading_object">Error while downloading object: %1$s</string>

--- a/localization/src/main/res/values-ru-rRU/strings.xml
+++ b/localization/src/main/res/values-ru-rRU/strings.xml
@@ -2172,8 +2172,6 @@
     <string name="select_space">Выбрать канал</string>
     <string name="add_a_comment">Добавить комментарий...</string>
     <string name="send">Отправить</string>
-    <string name="chat_notifications_receive_all">Получить все</string>
-    <string name="chat_notifications_mute_all">Заглушить всех</string>
     <string name="chat_specific_notifications">Уведомления для чата</string>
     <string name="notify_me_about">Уведомить меня о</string>
     <string name="error_while_downloading_object">Ошибка при загрузке объекта: %1$s</string>

--- a/localization/src/main/res/values-tr-rTR/strings.xml
+++ b/localization/src/main/res/values-tr-rTR/strings.xml
@@ -2142,8 +2142,6 @@ Lütfen ihtiyaçlarınızla ilgili özel ayrıntıları burada belirtin.</string
     <string name="select_space">Kanal Seç</string>
     <string name="add_a_comment">Yorum ekle...</string>
     <string name="send">Gönder</string>
-    <string name="chat_notifications_receive_all">Tümünü al</string>
-    <string name="chat_notifications_mute_all">Tümünü sustur</string>
     <string name="chat_specific_notifications">Sohbete özel bildirimler</string>
     <string name="notify_me_about">Beni bilgilendir</string>
     <string name="error_while_downloading_object">Nesne indirilirken hata oluştu: %1$s</string>

--- a/localization/src/main/res/values-uk-rUA/strings.xml
+++ b/localization/src/main/res/values-uk-rUA/strings.xml
@@ -2170,8 +2170,6 @@ Please provide specific details of your needs here.</string>
     <string name="select_space">Select Channel</string>
     <string name="add_a_comment">Add a comment...</string>
     <string name="send">Send</string>
-    <string name="chat_notifications_receive_all">Receive all</string>
-    <string name="chat_notifications_mute_all">Mute all</string>
     <string name="chat_specific_notifications">Chat specific notifications</string>
     <string name="notify_me_about">Notify me about</string>
     <string name="error_while_downloading_object">Error while downloading object: %1$s</string>

--- a/localization/src/main/res/values-zh-rCN/strings.xml
+++ b/localization/src/main/res/values-zh-rCN/strings.xml
@@ -2122,8 +2122,6 @@
     <string name="select_space">选择频道</string>
     <string name="add_a_comment">添加评论...</string>
     <string name="send">发送</string>
-    <string name="chat_notifications_receive_all">接收全部</string>
-    <string name="chat_notifications_mute_all">全部静音</string>
     <string name="chat_specific_notifications">特定聊天通知</string>
     <string name="notify_me_about">通知范围</string>
     <string name="error_while_downloading_object">下载对象时出错：%1$s</string>

--- a/localization/src/main/res/values-zh-rTW/strings.xml
+++ b/localization/src/main/res/values-zh-rTW/strings.xml
@@ -2128,8 +2128,6 @@ Please provide specific details of your needs here.</string>
     <string name="select_space">Select Channel</string>
     <string name="add_a_comment">Add a comment...</string>
     <string name="send">Send</string>
-    <string name="chat_notifications_receive_all">Receive all</string>
-    <string name="chat_notifications_mute_all">Mute all</string>
     <string name="chat_specific_notifications">Chat specific notifications</string>
     <string name="notify_me_about">Notify me about</string>
     <string name="error_while_downloading_object">Error while downloading object: %1$s</string>

--- a/localization/src/main/res/values/strings.xml
+++ b/localization/src/main/res/values/strings.xml
@@ -2479,8 +2479,6 @@ Please provide specific details of your needs here.</string>
     <string name="select_space">Select Channel</string>
     <string name="add_a_comment">Add a comment...</string>
     <string name="send">Send</string>
-    <string name="chat_notifications_receive_all">Receive all</string>
-    <string name="chat_notifications_mute_all">Mute all</string>
     <string name="chat_specific_notifications">Chat specific notifications</string>
     <string name="notify_me_about">Notify me about</string>
 


### PR DESCRIPTION
## Summary
- Post-DROID-4361 cleanup: removes the two unreferenced string keys `chat_notifications_receive_all` and `chat_notifications_mute_all` from `values/strings.xml` and all 15 locale variants.
- Found during an audit of the six merged DROID-4361 commits — no Kotlin call sites remain for either key after the entry-point rework, so they're dead weight.
- 16 files, 32 line deletions, no code changes.

## Test plan
- [ ] `./gradlew assembleDebug` still succeeds (no missing-resource errors)
- [ ] `./gradlew lintDebug` passes with no new warnings
- [ ] Spot-check: Chat, DM, and Channel notification menus still render correct labels (unaffected paths — sanity check only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)