### PR TITLE
DROID-4463 Chats | Restrict homepage management to space owner

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreen.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreen.kt
@@ -303,14 +303,16 @@ fun WidgetsScreen(
 
             // "Home" widget — shortcut back to the space homepage (Chat / Page / Collection).
             // Hidden when homepage is widgets. Non-reorderable.
-            if (homeWidget != null) {
+            // DROID-4463: hidden entirely in 1-on-1 channels (Chat is always home);
+            // long-press Change Home menu gated to owners of regular channels.
+            val spaceViewSuccess = spaceView as? HomeScreenViewModel.SpaceViewState.Success
+            if (homeWidget != null && spaceViewSuccess?.isOneToOneSpace != true) {
                 item(key = WidgetView.Home.WIDGET_HOME_ID) {
                     HomeWidgetCard(
                         item = homeWidget,
                         onWidgetClicked = viewModel::onHomeWidgetClicked,
                         onChangeHomeClicked = viewModel::onHomeWidgetChangeHomeClicked,
-                        isOneToOneSpace = (spaceView as? HomeScreenViewModel.SpaceViewState.Success)
-                            ?.isOneToOneSpace == true
+                        canChangeHome = spaceViewSuccess?.canChangeHome == true
                     )
                 }
             }

--- a/app/src/main/java/com/anytypeio/anytype/ui/widgets/types/HomeWidgetCard.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/widgets/types/HomeWidgetCard.kt
@@ -49,7 +49,7 @@ fun HomeWidgetCard(
     onWidgetClicked: () -> Unit,
     onChangeHomeClicked: () -> Unit,
     modifier: Modifier = Modifier,
-    isOneToOneSpace: Boolean = false
+    canChangeHome: Boolean = true
 ) {
     val isMenuExpanded = remember { mutableStateOf(false) }
     val haptic = LocalHapticFeedback.current
@@ -65,15 +65,16 @@ fun HomeWidgetCard(
             .clip(RoundedCornerShape(24.dp))
             .combinedClickable(
                 onClick = onWidgetClicked,
-                onLongClick = if (isOneToOneSpace) {
-                    // DROID-4469: no context menu in 1-on-1 (only action would be
-                    // Change Home, which is hidden for 1-on-1 channels).
-                    null
-                } else {
+                onLongClick = if (canChangeHome) {
                     {
                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                         isMenuExpanded.value = true
                     }
+                } else {
+                    // DROID-4463: only owners of regular channels can change home.
+                    // Editors/Viewers see the widget read-only; 1-on-1 channels
+                    // hide the widget entirely (DROID-4469).
+                    null
                 }
             )
             .alpha(if (isMenuExpanded.value) 0.8f else 1f),

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomeScreenViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomeScreenViewModel.kt
@@ -753,6 +753,10 @@ class HomeScreenViewModel(
                         membersCount = spaceMemberCount,
                         spaceChatId = spaceView.getSingleValue<String>(Relations.CHAT_ID),
                         isOneToOneSpace = spaceView.isOneToOneSpace,
+                        canChangeHome = HomepageManagementRule.canManageHomepage(
+                            isOneToOneSpace = spaceView.isOneToOneSpace,
+                            permission = permissions
+                        ),
                         spaceAccessType = spaceView.spaceAccessType ?: SpaceAccessType.PRIVATE,
                         memberGlobalName = otherMember?.globalName,
                         memberIdentity = otherMember?.identity
@@ -3844,6 +3848,7 @@ class HomeScreenViewModel(
             val spaceChatId: Id? = null,
             val spaceAccessType: SpaceAccessType,
             val isOneToOneSpace: Boolean,
+            val canChangeHome: Boolean = false,
             val memberGlobalName: String? = null,
             val memberIdentity: String? = null,
         ) : SpaceViewState() {
@@ -3888,12 +3893,19 @@ class HomeScreenViewModel(
 
     private fun proceedWithHomepageObservation() {
         viewModelScope.launch {
-            spaceViewSubscriptionContainer
-                .observe(vmParams.spaceId)
-                .collect { spaceView ->
-                    // 1-on-1 channels always open on Chat and have no homepage-change UI.
-                    // See DROID-4469.
-                    if (spaceView.isOneToOneSpace) {
+            combine(
+                spaceViewSubscriptionContainer.observe(vmParams.spaceId),
+                userPermissions
+            ) { spaceView, permission -> spaceView to permission }
+                .collect { (spaceView, permission) ->
+                    // DROID-4463: only the space owner may configure the homepage in
+                    // regular channels; 1-on-1 channels always open on Chat and have
+                    // no homepage-change UI (DROID-4469).
+                    val canManage = HomepageManagementRule.canManageHomepage(
+                        isOneToOneSpace = spaceView.isOneToOneSpace,
+                        permission = permission
+                    )
+                    if (!canManage) {
                         showHomepagePicker.value = false
                         return@collect
                     }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomepageManagementRule.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomepageManagementRule.kt
@@ -1,0 +1,17 @@
+package com.anytypeio.anytype.presentation.home
+
+import com.anytypeio.anytype.core_models.multiplayer.SpaceMemberPermissions
+
+/**
+ * DROID-4463: homepage-setting visibility rule.
+ *
+ * In regular channels, only the space owner may configure the homepage.
+ * In 1-on-1 channels Chat is always the homepage (see DROID-4469), so no
+ * participant — owner or otherwise — configures it via the UI.
+ */
+object HomepageManagementRule {
+    fun canManageHomepage(
+        isOneToOneSpace: Boolean,
+        permission: SpaceMemberPermissions?
+    ): Boolean = !isOneToOneSpace && permission?.isOwner() == true
+}

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/spaces/SpaceSettingsViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/spaces/SpaceSettingsViewModel.kt
@@ -82,6 +82,7 @@ import com.anytypeio.anytype.presentation.common.BaseViewModel
 import com.anytypeio.anytype.presentation.extension.sendAnalyticsChangeMessageNotificationState
 import com.anytypeio.anytype.presentation.multiplayer.SpaceLimitsState
 import com.anytypeio.anytype.presentation.multiplayer.spaceLimitsState
+import com.anytypeio.anytype.presentation.home.HomepageManagementRule
 import com.anytypeio.anytype.presentation.home.SpaceHomePickerDelegate
 import com.anytypeio.anytype.presentation.home.SpaceHomePickerState
 import com.anytypeio.anytype.presentation.home.SpaceHomepageResolver
@@ -565,10 +566,14 @@ class SpaceSettingsViewModel(
                     add(UiSpaceSettingsItem.Fields)
 
                     add(UiSpaceSettingsItem.Section.Preferences)
-                    // DROID-4469: Hide the "Home" row entirely in 1-on-1 channels.
-                    // 1-on-1 channels always open on Chat and have no
-                    // homepage-change UI.
-                    if (!spaceView.isOneToOneSpace) {
+                    // DROID-4463: Home row only for owners of regular channels.
+                    // Editors/Viewers cannot change the homepage; 1-on-1 channels
+                    // always open on Chat and have no homepage-change UI (DROID-4469).
+                    if (HomepageManagementRule.canManageHomepage(
+                            isOneToOneSpace = spaceView.isOneToOneSpace,
+                            permission = permission
+                        )
+                    ) {
                         add(spaceHomeSettingItem)
                         add(Spacer(id = "after-space-home", height = 8))
                     }

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/home/HomepageManagementRuleTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/home/HomepageManagementRuleTest.kt
@@ -1,0 +1,111 @@
+package com.anytypeio.anytype.presentation.home
+
+import com.anytypeio.anytype.core_models.multiplayer.SpaceMemberPermissions
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class HomepageManagementRuleTest {
+
+    @Test
+    fun `owner in regular space can manage homepage`() {
+        assertTrue(
+            HomepageManagementRule.canManageHomepage(
+                isOneToOneSpace = false,
+                permission = SpaceMemberPermissions.OWNER
+            )
+        )
+    }
+
+    @Test
+    fun `writer in regular space cannot manage homepage`() {
+        assertFalse(
+            HomepageManagementRule.canManageHomepage(
+                isOneToOneSpace = false,
+                permission = SpaceMemberPermissions.WRITER
+            )
+        )
+    }
+
+    @Test
+    fun `reader in regular space cannot manage homepage`() {
+        assertFalse(
+            HomepageManagementRule.canManageHomepage(
+                isOneToOneSpace = false,
+                permission = SpaceMemberPermissions.READER
+            )
+        )
+    }
+
+    @Test
+    fun `no permission in regular space cannot manage homepage`() {
+        assertFalse(
+            HomepageManagementRule.canManageHomepage(
+                isOneToOneSpace = false,
+                permission = SpaceMemberPermissions.NO_PERMISSIONS
+            )
+        )
+    }
+
+    @Test
+    fun `null permission in regular space cannot manage homepage`() {
+        assertFalse(
+            HomepageManagementRule.canManageHomepage(
+                isOneToOneSpace = false,
+                permission = null
+            )
+        )
+    }
+
+    @Test
+    fun `owner in one-on-one space cannot manage homepage`() {
+        assertFalse(
+            HomepageManagementRule.canManageHomepage(
+                isOneToOneSpace = true,
+                permission = SpaceMemberPermissions.OWNER
+            )
+        )
+    }
+
+    @Test
+    fun `writer in one-on-one space cannot manage homepage`() {
+        assertFalse(
+            HomepageManagementRule.canManageHomepage(
+                isOneToOneSpace = true,
+                permission = SpaceMemberPermissions.WRITER
+            )
+        )
+    }
+
+    @Test
+    fun `null permission in one-on-one space cannot manage homepage`() {
+        assertFalse(
+            HomepageManagementRule.canManageHomepage(
+                isOneToOneSpace = true,
+                permission = null
+            )
+        )
+    }
+
+    @Test
+    fun `matrix covers all combinations`() {
+        val cases = listOf(
+            Triple(false, SpaceMemberPermissions.OWNER, true),
+            Triple(false, SpaceMemberPermissions.WRITER, false),
+            Triple(false, SpaceMemberPermissions.READER, false),
+            Triple(false, SpaceMemberPermissions.NO_PERMISSIONS, false),
+            Triple(true, SpaceMemberPermissions.OWNER, false),
+            Triple(true, SpaceMemberPermissions.WRITER, false),
+            Triple(true, SpaceMemberPermissions.READER, false),
+            Triple(true, SpaceMemberPermissions.NO_PERMISSIONS, false),
+        )
+        for ((isOneToOne, permission, expected) in cases) {
+            assertEquals(
+                expected,
+                HomepageManagementRule.canManageHomepage(isOneToOne, permission),
+                message = "isOneToOne=$isOneToOne, permission=$permission"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Owner-only homepage configuration in regular channels; Editors/Viewers keep the read-only Home widget but lose the auto picker, the "Change Home" menu, and the Space Settings Home row.
- Home widget hidden entirely in 1-on-1 channels (Chat is always home); complements [DROID-4469](https://linear.app/anytype/issue/DROID-4469).
- Extracted pure `HomepageManagementRule.canManageHomepage(isOneToOneSpace, permission)` helper with an exhaustive unit-test matrix; wired into three assembly sites (picker auto-show, Settings Home row, Home widget menu).

Linear: [DROID-4463](https://linear.app/anytype/issue/DROID-4463/homepage-setting-restrict-to-owner-one-on-one-handling)

## What changed
- **New**: `presentation/.../home/HomepageManagementRule.kt` + test file (9 tests, RED → GREEN).
- **`HomeScreenViewModel.proceedWithHomepageObservation()`**: now `combine(spaceView, userPermissions)` and gates the auto Homepage Picker on `canManageHomepage`. Replaces the prior 1-on-1-only gate.
- **`HomeScreenViewModel.SpaceViewState.Success`**: gains `canChangeHome: Boolean`; populated in `proceedWithSpaceViewSubscription`.
- **`SpaceSettingsViewModel`**: Home row in Preferences gated on `canManageHomepage` (was `!isOneToOneSpace`).
- **`WidgetsScreen.kt`**: outer `if` skips the Home widget when `isOneToOneSpace`; passes `canChangeHome` to the card.
- **`HomeWidgetCard.kt`**: param renamed `isOneToOneSpace: Boolean = false` → `canChangeHome: Boolean = true` (inverted semantics, default matches preview).

Defense-in-depth gate in `SpaceHomePickerDelegate.show()` from #3223 is retained.

## Test plan
- [ ] Regular space, **Owner**, no homepage: picker auto-shows; selecting Chat/Page/Collection sets homepage.
- [ ] Regular space, **Editor**: no picker auto-show; Home row **hidden** in Space Settings; Home widget visible; long-press does nothing.
- [ ] Regular space, **Viewer**: same as Editor.
- [ ] 1-on-1 DM, both participants: Home widget **hidden** on widgets list; Home row hidden in Settings; no picker; Chat opens as home.
- [ ] Owner → Space Settings → Home row → picker opens, selection applies.
- [ ] Owner → Home widget long-press → Change Home → picker opens, selection applies.
- [ ] Permission demotion mid-session (Owner → Editor): Home row disappears from Settings; long-press on Home widget disables.
- [ ] `./gradlew :app:assembleDebug` — succeeds.
- [ ] `:presentation:testDebugUnitTest` — failure count unchanged vs base (122 pre-existing failures, no new ones; new `HomepageManagementRuleTest` passes 9/9).

## Notes
- No unit tests for the VM assembly sites (B/C/D) — stubbing the `combine()` cascade in `HomeScreenViewModel` / `SpaceSettingsViewModel` is out of scope, matching the precedent set in #3223. The helper has full coverage; the wiring is small and independently reviewable.
- `UiEvent.OnSpaceHomeClicked` in `SpaceSettingsViewModel` relies on the UI gate (Home row hidden) to prevent non-owners from invoking the picker — no additional handler guard, matching the "UI is the gate" pattern from #3223. Can revisit if a defense-in-depth check is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)