### PR TITLE
DROID-4476 Protocol | Enhancement | MW v0.50.0-rc05

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-middlewareVersion = "v0.50.0-rc03"
+middlewareVersion = "v0.50.0-rc05"
 kotlinVersion = "2.2.10"
 kspVersion = "2.3.4"
 

--- a/protocol/src/main/proto/models.proto
+++ b/protocol/src/main/proto/models.proto
@@ -1492,10 +1492,11 @@ message MembershipV2 {
     }
 
     enum Period {
-        Unlimited = 0;
+        Unlimited = 0 [deprecated = true];
         Monthly = 1;
         Yearly = 2;
         ThreeYears = 3;
+        Lifetime = 4;
     }
 
     message Invoice {
@@ -1546,6 +1547,7 @@ message MembershipV2 {
         string offer = 11;
 
         Features features = 12;
+        repeated Amount pricesLifetime = 13;
     }
 
     message PurchaseInfo {
@@ -1573,11 +1575,15 @@ message MembershipV2 {
 
     message CartProduct {
         Product product = 1;    
-        // otherwise - monthly
+        // otherwise - monthly or isLifetime
         bool isYearly = 2;
         // set to true if you want to remove this item from the customer
         // it's like setting -1 to some product
         bool remove = 3;
+        // if true - then this is lifetime product (no matter what isYearly above is)
+        // unfortunately we do not use Period here to keep compatibility with old versions 
+        // that still use isYearly! 
+        bool isLifetime = 4;
     }
 
     message Cart {
@@ -1591,6 +1597,13 @@ message MembershipV2 {
         // the next invoice amount will also be generated
         Amount totalNextInvoice = 3;
         uint64 nextInvoiceDate = 4;
+        repeated string appliedPromocodes = 5;
+    }
+
+    message CryptoCheckout {
+        string invoiceURL = 1;
+        Amount total = 2;
+        bool isCanCancel = 3;
     }
 
     message Data {
@@ -1598,6 +1611,7 @@ message MembershipV2 {
         Invoice nextInvoice = 2;
         string teamOwnerID = 3;
         PaymentProvider paymentProvider = 4;
+        repeated string appliedPromocodes = 5;
     }
 }
 


### PR DESCRIPTION
## Summary
- Bump middleware version from `v0.50.0-rc03` to `v0.50.0-rc05`
- Update protobuf models for MembershipV2:
  - Add `Lifetime` period type (deprecate `Unlimited`)
  - Add lifetime pricing support (`pricesLifetime`, `isLifetime` in CartProduct)
  - Add `appliedPromocodes` to CartCheckout and MembershipV2 Data
  - Add `CryptoCheckout` message type

## Test plan
- [ ] Verify project builds successfully
- [ ] Verify membership-related features work correctly with updated protos

🤖 Generated with [Claude Code](https://claude.com/claude-code)