### PR TITLE
DROID-4481 Multiplayer | Fix | Reserve owner's writer seat when adding members to new space

### DIFF
--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModel.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModel.kt
@@ -257,7 +257,7 @@ class VaultViewModel(
             }
         val subtitle = buildMembersSubtitle(
             selectedCount = selectedIds.size,
-            writersLimit = features.spaceWriters,
+            availableWriterSlots = (features.spaceWriters - 1).coerceAtLeast(0),
             readersLimit = features.spaceReaders
         )
         SelectMembersUiState.Content(
@@ -888,7 +888,10 @@ class VaultViewModel(
                 current - identity
             } else {
                 val features = _membershipFeatures.value
-                val limit = features.spaceWriters + features.spaceReaders
+                // Reserve the owner's writer seat: only (spaceWriters - 1) writer slots
+                // are addable from the client. spaceWriters == 0 means "no tier limit".
+                val availableWriterSlots = (features.spaceWriters - 1).coerceAtLeast(0)
+                val limit = availableWriterSlots + features.spaceReaders
                 if (limit > 0 && current.size >= limit) {
                     current
                 } else {
@@ -949,13 +952,13 @@ class VaultViewModel(
 
     private fun buildMembersSubtitle(
         selectedCount: Int,
-        writersLimit: Int,
+        availableWriterSlots: Int,
         readersLimit: Int
     ): String {
-        if (writersLimit == 0 && readersLimit == 0) return ""
-        val editors = minOf(selectedCount, writersLimit)
-        val viewers = maxOf(selectedCount - writersLimit, 0)
-        return stringResourceProvider.getChannelMembersSubtitle(editors, writersLimit, viewers, readersLimit)
+        if (availableWriterSlots == 0 && readersLimit == 0) return ""
+        val editors = minOf(selectedCount, availableWriterSlots)
+        val viewers = maxOf(selectedCount - availableWriterSlots, 0)
+        return stringResourceProvider.getChannelMembersSubtitle(editors, availableWriterSlots, viewers, readersLimit)
     }
 
     private suspend fun getSharedSpaceLimitInfo(): Pair<Int, Int> {

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/spaces/CreateSpaceViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/spaces/CreateSpaceViewModel.kt
@@ -389,9 +389,12 @@ class CreateSpaceViewModel(
         val identities = vmParams.selectedMemberIdentities
         if (identities.isNotEmpty()) {
             val writersLimit = vmParams.writersLimit
-            // Split identities: first N as writers, rest as readers
-            val writers = if (writersLimit > 0) identities.take(writersLimit) else identities
-            val readers = if (writersLimit > 0) identities.drop(writersLimit) else emptyList()
+            // Reserve owner's writer seat: of the tier's writersLimit, the owner already
+            // occupies one. Only (writersLimit - 1) slots remain for client-added members.
+            // writersLimit == 0 means "no tier limit" → all selections become writers.
+            val availableWriterSlots = (writersLimit - 1).coerceAtLeast(0)
+            val writers = if (writersLimit > 0) identities.take(availableWriterSlots) else identities
+            val readers = if (writersLimit > 0) identities.drop(availableWriterSlots) else emptyList()
 
             if (writers.isNotEmpty()) {
                 addSpaceMembers.async(

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/spaces/CreateSpaceViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/spaces/CreateSpaceViewModelTest.kt
@@ -35,6 +35,7 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
@@ -313,6 +314,150 @@ class CreateSpaceViewModelTest {
 
     // endregion
 
+    // region Group Channel - Writer/Reader Split (DROID-4481)
+
+    @Test
+    fun `writers limit 2 with 3 selected - reserves owner seat - 1 writer + 2 readers`() = runTest {
+        // Given — tier writersLimit=2 means owner + 1 addable writer.
+        val members = listOf("identity-1", "identity-2", "identity-3")
+        val vmParams = givenGroupParams(members = members, writersLimit = 2)
+        stubCreateSpaceSuccess()
+        stubMakeShareableSuccess()
+        stubGenerateInviteLinkSuccess()
+        stubAddMembersSuccess()
+        stubSpaceManagerSet()
+        stubSaveCurrentSpace()
+        stubShareableLimitNotReached()
+
+        val vm = buildViewModel(vmParams)
+        advanceUntilIdle()
+
+        // When
+        vm.onCreateSpace("Group Channel")
+        advanceUntilIdle()
+
+        // Then — first call: 1 writer, second call: 2 readers
+        val captor = argumentCaptor<AddSpaceMembers.Params>()
+        verify(addSpaceMembers, org.mockito.kotlin.times(2)).async(captor.capture())
+        val writerCall = captor.allValues[0]
+        val readerCall = captor.allValues[1]
+        assertEquals(SpaceMemberPermissions.WRITER, writerCall.permissions)
+        assertEquals(listOf("identity-1"), writerCall.identities)
+        assertEquals(SpaceMemberPermissions.READER, readerCall.permissions)
+        assertEquals(listOf("identity-2", "identity-3"), readerCall.identities)
+    }
+
+    @Test
+    fun `writers limit 1 with 3 selected - no writer slots - all 3 readers`() = runTest {
+        // Given — tier writersLimit=1 means owner is the only writer; no addable writer slots.
+        val members = listOf("identity-1", "identity-2", "identity-3")
+        val vmParams = givenGroupParams(members = members, writersLimit = 1)
+        stubCreateSpaceSuccess()
+        stubMakeShareableSuccess()
+        stubGenerateInviteLinkSuccess()
+        stubAddMembersSuccess()
+        stubSpaceManagerSet()
+        stubSaveCurrentSpace()
+        stubShareableLimitNotReached()
+
+        val vm = buildViewModel(vmParams)
+        advanceUntilIdle()
+
+        // When
+        vm.onCreateSpace("Group Channel")
+        advanceUntilIdle()
+
+        // Then — single call with all members as readers
+        val captor = argumentCaptor<AddSpaceMembers.Params>()
+        verify(addSpaceMembers, org.mockito.kotlin.times(1)).async(captor.capture())
+        val readerCall = captor.firstValue
+        assertEquals(SpaceMemberPermissions.READER, readerCall.permissions)
+        assertEquals(members, readerCall.identities)
+    }
+
+    @Test
+    fun `writers limit 0 with 3 selected - no tier limit - all 3 writers`() = runTest {
+        // Given — writersLimit=0 means "no tier limit"; preserve existing unlimited semantics.
+        val members = listOf("identity-1", "identity-2", "identity-3")
+        val vmParams = givenGroupParams(members = members, writersLimit = 0)
+        stubCreateSpaceSuccess()
+        stubMakeShareableSuccess()
+        stubGenerateInviteLinkSuccess()
+        stubAddMembersSuccess()
+        stubSpaceManagerSet()
+        stubSaveCurrentSpace()
+        stubShareableLimitNotReached()
+
+        val vm = buildViewModel(vmParams)
+        advanceUntilIdle()
+
+        // When
+        vm.onCreateSpace("Group Channel")
+        advanceUntilIdle()
+
+        // Then — single call with all members as writers
+        val captor = argumentCaptor<AddSpaceMembers.Params>()
+        verify(addSpaceMembers, org.mockito.kotlin.times(1)).async(captor.capture())
+        val writerCall = captor.firstValue
+        assertEquals(SpaceMemberPermissions.WRITER, writerCall.permissions)
+        assertEquals(members, writerCall.identities)
+    }
+
+    @Test
+    fun `writers limit 5 with 2 selected - all under cap - both writers no readers`() = runTest {
+        // Given — tier allows 4 addable writers (5 - 1 owner); 2 selected fit entirely as writers.
+        val members = listOf("identity-1", "identity-2")
+        val vmParams = givenGroupParams(members = members, writersLimit = 5)
+        stubCreateSpaceSuccess()
+        stubMakeShareableSuccess()
+        stubGenerateInviteLinkSuccess()
+        stubAddMembersSuccess()
+        stubSpaceManagerSet()
+        stubSaveCurrentSpace()
+        stubShareableLimitNotReached()
+
+        val vm = buildViewModel(vmParams)
+        advanceUntilIdle()
+
+        // When
+        vm.onCreateSpace("Group Channel")
+        advanceUntilIdle()
+
+        // Then — single call: both writers, no reader call
+        val captor = argumentCaptor<AddSpaceMembers.Params>()
+        verify(addSpaceMembers, org.mockito.kotlin.times(1)).async(captor.capture())
+        val writerCall = captor.firstValue
+        assertEquals(SpaceMemberPermissions.WRITER, writerCall.permissions)
+        assertEquals(members, writerCall.identities)
+    }
+
+    @Test
+    fun `group creation with empty selection - no addSpaceMembers calls`() = runTest {
+        // Given
+        val vmParams = givenGroupParams(members = emptyList(), writersLimit = 3)
+        stubCreateSpaceSuccess()
+        stubMakeShareableSuccess()
+        stubGenerateInviteLinkSuccess()
+        stubAddMembersSuccess()
+        stubSpaceManagerSet()
+        stubSaveCurrentSpace()
+        stubShareableLimitNotReached()
+
+        val vm = buildViewModel(vmParams)
+        advanceUntilIdle()
+
+        // When
+        vm.onCreateSpace("Group Channel")
+        advanceUntilIdle()
+
+        // Then — finishes without adding members
+        verify(addSpaceMembers, never()).async(any())
+        verify(spaceManager).set(any(), any())
+        assertNull(vm.createSpaceError.value)
+    }
+
+    // endregion
+
     // region Helpers
 
     private fun givenPersonalParams(
@@ -323,10 +468,12 @@ class CreateSpaceViewModelTest {
     )
 
     private fun givenGroupParams(
-        members: List<String> = emptyList()
+        members: List<String> = emptyList(),
+        writersLimit: Int = 0
     ) = CreateSpaceViewModel.VmParams(
         channelType = ChannelCreationType.GROUP,
-        selectedMemberIdentities = members
+        selectedMemberIdentities = members,
+        writersLimit = writersLimit
     )
 
     private fun stubSpaceViews() {


### PR DESCRIPTION
## Summary
- Linear: [DROID-4481](https://linear.app/anytype/issue/DROID-4481/members-are-not-loaded-into-the-space-when-added-above-the-tier-limit)
- The owner of a freshly-created shared space already occupies one of the tier's writer slots. The Android client did not account for this, so picking N members up to the tier `writersLimit` caused `Rpc.Space.ParticipantsAddList` to exceed the cap and the middleware returned `104 limitReached`. Only one member was loaded, the rest were dropped.

## Changes
- `CreateSpaceViewModel.proceedWithAddMembers()` — split now uses `availableWriterSlots = max(0, writersLimit - 1)` for the writer/reader partition. Preserves the existing `writersLimit == 0 → no tier limit` semantics.
- `VaultViewModel.onMemberToggled()` — selection cap is now `availableWriterSlots + spaceReaders` instead of `spaceWriters + spaceReaders`.
- `VaultViewModel.buildMembersSubtitle()` — caller passes `availableWriterSlots`, so the picker subtitle's editor/viewer count matches the actual RPC split.
- 5 new unit tests in `CreateSpaceViewModelTest` covering `writersLimit` ∈ {0, 1, 2, 5} and empty selection.

## Test plan
- [x] `./gradlew :presentation:testDebugUnitTest` — 14/14 in `CreateSpaceViewModelTest` pass locally
- [x] `./gradlew :feature-vault:testDebugUnitTest` — green locally
- [ ] Manual: on a staging tier with `spaceWriters = 2`, create a group channel with 3+ contacts; confirm 1 writer + 2 readers are added (no `104` toast) and all members appear in the new space
- [ ] Manual: verify picker subtitle reads `1 editor / 1 limit, …` (not `2 editor / 2 limit`)
- [ ] Manual: tier with `spaceWriters = 1` → all selected members added as readers, no writer call

🤖 Generated with [Claude Code](https://claude.com/claude-code)