### PR TITLE
DROID-4477 Channel Creation | Fix | Back from Create Channel reopens member list

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/ext/FragmentResultContract.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ext/FragmentResultContract.kt
@@ -5,4 +5,7 @@ data object FragmentResultContract {
     const val ATTACH_TO_CHAT_TARGET_ID_KEY = "fragment.result.attach-to-chat.target-id"
     const val ATTACH_TO_CHAT_SPACE_ID_KEY = "fragment.result.attach-to-chat.space-id"
     const val ATTACH_TO_CHAT_CHAT_ID_KEY = "fragment.result.attach-to-chat.chat-id"
+
+    const val CREATE_SPACE_BACK_TO_SELECT_MEMBERS_KEY =
+        "fragment.result.create-space.back-to-select-members"
 }

--- a/app/src/main/java/com/anytypeio/anytype/ui/spaces/CreateSpaceFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/spaces/CreateSpaceFragment.kt
@@ -1,5 +1,6 @@
 package com.anytypeio.anytype.ui.spaces
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -24,6 +25,7 @@ import com.anytypeio.anytype.core_utils.ext.parseImagePath
 import com.anytypeio.anytype.core_utils.ext.toast
 import com.anytypeio.anytype.core_utils.ui.BaseBottomSheetComposeFragment
 import com.anytypeio.anytype.di.common.componentManager
+import com.anytypeio.anytype.ext.FragmentResultContract
 import com.anytypeio.anytype.presentation.spaces.CreateSpaceViewModel
 import com.anytypeio.anytype.ui.home.WidgetsScreenFragment
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -69,6 +71,7 @@ class CreateSpaceFragment : BaseBottomSheetComposeFragment() {
                 )
             },
             onBackClicked = {
+                notifyBackToSelectMembersIfNeeded()
                 findNavController().popBackStack()
             },
             onSpaceIconUploadClicked = {
@@ -132,6 +135,20 @@ class CreateSpaceFragment : BaseBottomSheetComposeFragment() {
         (dialog as? BottomSheetDialog)?.findViewById<FrameLayout>(
             com.google.android.material.R.id.design_bottom_sheet
         )?.setBackgroundColor(requireContext().color(android.R.color.transparent))
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        notifyBackToSelectMembersIfNeeded()
+        super.onCancel(dialog)
+    }
+
+    private fun notifyBackToSelectMembersIfNeeded() {
+        if (channelType == ChannelCreationType.GROUP) {
+            parentFragmentManager.setFragmentResult(
+                FragmentResultContract.CREATE_SPACE_BACK_TO_SELECT_MEMBERS_KEY,
+                Bundle.EMPTY
+            )
+        }
     }
 
     override fun injectDependencies() {

--- a/app/src/main/java/com/anytypeio/anytype/ui/vault/VaultFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/vault/VaultFragment.kt
@@ -27,6 +27,7 @@ import com.anytypeio.anytype.core_utils.insets.EDGE_TO_EDGE_MIN_SDK
 import com.anytypeio.anytype.core_utils.intents.ActivityCustomTabsHelper
 import com.anytypeio.anytype.core_utils.ui.BaseComposeFragment
 import com.anytypeio.anytype.di.common.componentManager
+import com.anytypeio.anytype.ext.FragmentResultContract
 import com.anytypeio.anytype.other.DefaultDeepLinkResolver
 import com.anytypeio.anytype.feature_vault.presentation.VaultCommand
 import com.anytypeio.anytype.feature_vault.presentation.VaultErrors
@@ -201,6 +202,16 @@ class VaultFragment : BaseComposeFragment() {
         }
         LaunchedEffect(Unit) {
             vm.navigations.collect { command -> proceed(command) }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        parentFragmentManager.setFragmentResultListener(
+            FragmentResultContract.CREATE_SPACE_BACK_TO_SELECT_MEMBERS_KEY,
+            viewLifecycleOwner
+        ) { _, _ ->
+            vm.onCreateSpaceBackPressed()
         }
     }
 

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModel.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModel.kt
@@ -173,6 +173,10 @@ class VaultViewModel(
     private val _selectedMemberIds = MutableStateFlow<List<Id>>(emptyList())
     private val _membershipFeatures = MutableStateFlow(MembershipFeatures())
 
+    // Tracks whether the current group-creation flow went through the SelectMembers
+    // step, so we know to reopen it when the user presses back on CreateSpace.
+    private var didShowSelectMembersForGroupCreation = false
+
     private val previewFlow: StateFlow<ChatPreviewContainer.PreviewState> =
         chatPreviewContainer.observePreviewsWithAttachments()
             .filterIsInstance<ChatPreviewContainer.PreviewState.Ready>() // wait until ready
@@ -860,8 +864,10 @@ class VaultViewModel(
                     )
                     _selectMembersSearchQuery.value = ""
                     _selectedMemberIds.value = emptyList()
+                    didShowSelectMembersForGroupCreation = true
                     showSelectMembersSheet.value = true
                 } else {
+                    didShowSelectMembersForGroupCreation = false
                     commands.emit(
                         VaultCommand.CreateNewSpace(
                             channelType = ChannelCreationType.GROUP
@@ -924,6 +930,13 @@ class VaultViewModel(
         showSelectMembersSheet.value = false
         _selectMembersSearchQuery.value = ""
         _selectedMemberIds.value = emptyList()
+        didShowSelectMembersForGroupCreation = false
+    }
+
+    fun onCreateSpaceBackPressed() {
+        if (didShowSelectMembersForGroupCreation) {
+            showSelectMembersSheet.value = true
+        }
     }
 
     fun onSharedSpaceLimitUpgradeClicked() {


### PR DESCRIPTION
## Summary
- Fixes [DROID-4477](https://linear.app/anytype/issue/DROID-4477/the-back-button-when-creating-a-group-should-open-the-list-of-members): pressing **Back** on the Create Channel screen during a group creation flow left the user on the empty Vault instead of reopening the SelectMembers sheet.
- `VaultViewModel` now tracks whether the current flow went through the SelectMembers step (`didShowSelectMembersForGroupCreation`) so we only reopen the sheet when it was actually shown — important because GROUP creation can also bypass SelectMembers when the user has no 1-1 participants.
- `CreateSpaceFragment` signals back/cancel via a fragment result (`CREATE_SPACE_BACK_TO_SELECT_MEMBERS_KEY`); `VaultFragment` listens and calls `vm.onCreateSpaceBackPressed()`. Both UI back arrow (`onBackClicked`) and system back / swipe-down / outside-tap (`onCancel`) trigger the result. Successful creation uses `popBackStack()` directly and does NOT fire `onCancel`, so the sheet is correctly not reopened on success. Selected members and search query are preserved across the round-trip.

## Test plan
- [ ] Build a group channel from a Vault that has 1-1 participants → tap members → **Next** → **Back** (UI arrow) → SelectMembers reopens with the same selections
- [ ] Same flow but use the system back gesture instead of the UI arrow → SelectMembers reopens
- [ ] Same flow but swipe the Create Channel sheet down → SelectMembers reopens
- [ ] Build a group channel from a Vault with **no** 1-1 participants (SelectMembers is skipped) → tap **Back** on Create Channel → returns to Vault (SelectMembers does NOT appear)
- [ ] Build a Personal channel → tap **Back** on Create Channel → returns to Vault (SelectMembers does NOT appear)
- [ ] Successfully create a group channel → returns to the new space (SelectMembers does NOT briefly flash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)