### PR TITLE
DROID-4318 Navigation | Fix | Widget overlay drops widget-edit commands

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetOverlayFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetOverlayFragment.kt
@@ -49,6 +49,8 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.anytypeio.anytype.R
 import com.anytypeio.anytype.core_models.Block
+import com.anytypeio.anytype.core_models.Id
+import com.anytypeio.anytype.core_models.ObjectWrapper
 import com.anytypeio.anytype.core_models.primitives.SpaceId
 import com.anytypeio.anytype.core_models.primitives.TypeKey
 import com.anytypeio.anytype.core_models.ui.WallpaperResult
@@ -69,7 +71,13 @@ import com.anytypeio.anytype.presentation.home.HomeScreenViewModel
 import com.anytypeio.anytype.presentation.home.HomeScreenVmParams
 import com.anytypeio.anytype.presentation.main.MainViewModel
 import com.anytypeio.anytype.ui.base.navigation
+import com.anytypeio.anytype.ui.objects.creation.WidgetSourceTypeFragment
+import com.anytypeio.anytype.ui.objects.types.pickers.WidgetSourceTypeListener
 import com.anytypeio.anytype.ui.settings.space.SpaceSettingsFragment
+import com.anytypeio.anytype.ui.widgets.CreateChatObjectFragment
+import com.anytypeio.anytype.ui.widgets.CreateChatObjectListener
+import com.anytypeio.anytype.ui.widgets.SelectWidgetSourceFragment
+import com.anytypeio.anytype.ui.widgets.SelectWidgetTypeFragment
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -80,7 +88,9 @@ import timber.log.Timber
 
 private const val WIDGET_OVERLAY_FAB_SCALE = 0.85f
 
-class WidgetOverlayFragment : BottomSheetDialogFragment() {
+class WidgetOverlayFragment : BottomSheetDialogFragment(),
+    WidgetSourceTypeListener,
+    CreateChatObjectListener {
 
     @Inject
     lateinit var factory: HomeScreenViewModel.Factory
@@ -149,9 +159,13 @@ class WidgetOverlayFragment : BottomSheetDialogFragment() {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     vm.commands.collect { command ->
-                        // Most HomeScreenViewModel commands are widget-host flows
-                        // owned by WidgetsScreenFragment. The overlay handles the
-                        // two that originate from its own bottom buttons.
+                        // The overlay hosts the full WidgetsScreen, so it must
+                        // forward widget-edit commands to nav-graph dialog
+                        // destinations / child-fragment dialogs the same way
+                        // WidgetsScreenFragment does. Other commands
+                        // (Deeplink.*, OpenVault, HandleChatSpaceBackNavigation,
+                        // etc.) are not reachable from this surface and stay
+                        // intentionally unhandled.
                         when (command) {
                             is Command.OpenGlobalSearchScreen -> {
                                 runCatching {
@@ -162,6 +176,81 @@ class WidgetOverlayFragment : BottomSheetDialogFragment() {
                                     Timber.e(it, "Error opening global search from overlay")
                                 }
                                 dismissAfterGesture()
+                            }
+                            is Command.ChangeWidgetType -> {
+                                runCatching {
+                                    findNavController().navigate(
+                                        R.id.selectWidgetTypeScreen,
+                                        SelectWidgetTypeFragment.args(
+                                            ctx = command.ctx,
+                                            widget = command.widget,
+                                            source = command.source,
+                                            type = command.type,
+                                            layout = command.layout,
+                                            isInEditMode = command.isInEditMode
+                                        )
+                                    )
+                                }.onFailure {
+                                    Timber.e(it, "Error navigating to SelectWidgetType from overlay")
+                                }
+                            }
+                            is Command.ChangeWidgetSource -> {
+                                runCatching {
+                                    findNavController().navigate(
+                                        R.id.selectWidgetSourceScreen,
+                                        SelectWidgetSourceFragment.args(
+                                            ctx = command.ctx,
+                                            widget = command.widget,
+                                            source = command.source,
+                                            type = command.type,
+                                            isInEditMode = command.isInEditMode,
+                                            spaceId = command.space
+                                        )
+                                    )
+                                }.onFailure {
+                                    Timber.e(it, "Error navigating to ChangeWidgetSource from overlay")
+                                }
+                            }
+                            is Command.SelectWidgetSource -> {
+                                runCatching {
+                                    findNavController().navigate(
+                                        R.id.selectWidgetSourceScreen,
+                                        SelectWidgetSourceFragment.args(
+                                            ctx = command.ctx,
+                                            target = command.target,
+                                            isInEditMode = command.isInEditMode,
+                                            spaceId = command.space
+                                        )
+                                    )
+                                }.onFailure {
+                                    Timber.e(it, "Error navigating to SelectWidgetSource from overlay")
+                                }
+                            }
+                            is Command.SelectWidgetType -> {
+                                runCatching {
+                                    findNavController().navigate(
+                                        R.id.selectWidgetTypeScreen,
+                                        SelectWidgetTypeFragment.args(
+                                            ctx = command.ctx,
+                                            source = command.source,
+                                            layout = command.layout,
+                                            target = command.target,
+                                            isInEditMode = command.isInEditMode
+                                        )
+                                    )
+                                }.onFailure {
+                                    Timber.e(it, "Error navigating to SelectWidgetType (new) from overlay")
+                                }
+                            }
+                            is Command.CreateSourceForNewWidget -> {
+                                WidgetSourceTypeFragment.new(
+                                    space = command.space.id,
+                                    widgetId = command.widgets
+                                ).show(childFragmentManager, null)
+                            }
+                            is Command.CreateChatObject -> {
+                                CreateChatObjectFragment.new(space = command.space.id)
+                                    .show(childFragmentManager, "create-chat-object-dialog")
                             }
                             else -> {
                                 Timber.d("WidgetOverlay vm command (ignored): $command")
@@ -311,6 +400,21 @@ class WidgetOverlayFragment : BottomSheetDialogFragment() {
         componentManager().createObjectFeatureComponent.release(createObjectComponentKey())
         componentManager().widgetOverlayComponent.release()
         super.onDestroy()
+    }
+
+    override fun onSetNewWidgetSource(objType: ObjectWrapper.Type, widgetId: Id) {
+        vm.onNewWidgetSourceTypeSelected(type = objType, widgets = widgetId)
+    }
+
+    override fun onChatObjectCreated(objectId: Id) {
+        Timber.d("Chat object created from widget overlay: $objectId")
+        runCatching {
+            navigation().openChat(
+                target = objectId,
+                space = space,
+                popUpToVault = false
+            )
+        }.onFailure { Timber.e(it, "Error opening chat from overlay after object creation") }
     }
 
     private fun handleCreateObjectAction(action: CreateObjectAction) {

--- a/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetOverlayFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetOverlayFragment.kt
@@ -243,14 +243,22 @@ class WidgetOverlayFragment : BottomSheetDialogFragment(),
                                 }
                             }
                             is Command.CreateSourceForNewWidget -> {
-                                WidgetSourceTypeFragment.new(
-                                    space = command.space.id,
-                                    widgetId = command.widgets
-                                ).show(childFragmentManager, null)
+                                runCatching {
+                                    WidgetSourceTypeFragment.new(
+                                        space = command.space.id,
+                                        widgetId = command.widgets
+                                    ).show(childFragmentManager, null)
+                                }.onFailure {
+                                    Timber.e(it, "Error showing WidgetSourceTypeFragment from overlay")
+                                }
                             }
                             is Command.CreateChatObject -> {
-                                CreateChatObjectFragment.new(space = command.space.id)
-                                    .show(childFragmentManager, "create-chat-object-dialog")
+                                runCatching {
+                                    CreateChatObjectFragment.new(space = command.space.id)
+                                        .show(childFragmentManager, "create-chat-object-dialog")
+                                }.onFailure {
+                                    Timber.e(it, "Error showing CreateChatObjectFragment from overlay")
+                                }
                             }
                             else -> {
                                 Timber.d("WidgetOverlay vm command (ignored): $command")
@@ -408,6 +416,9 @@ class WidgetOverlayFragment : BottomSheetDialogFragment(),
 
     override fun onChatObjectCreated(objectId: Id) {
         Timber.d("Chat object created from widget overlay: $objectId")
+        // Match the proceed(Navigation) contract: dismiss the sheet first so it
+        // does not remain on the back stack beneath the newly-opened chat.
+        dismiss()
         runCatching {
             navigation().openChat(
                 target = objectId,


### PR DESCRIPTION
## Summary

- `WidgetOverlayFragment.commands.collect` only handled `OpenGlobalSearchScreen` and silently dropped every other command (logged as `WidgetOverlay vm command (ignored): …`). Since the overlay hosts the full `WidgetsScreen`, widget-menu actions ("Change Widget type", "Change source", "Add widget below", create-source / create-chat-object flows) emitted commands that went nowhere — the dropdown closed and nothing else happened.
- Forwards six widget-edit commands (`ChangeWidgetType`, `ChangeWidgetSource`, `SelectWidgetSource`, `SelectWidgetType`, `CreateSourceForNewWidget`, `CreateChatObject`) to the same destinations `WidgetsScreenFragment.proceed(command)` uses — top-level `selectWidgetTypeScreen` / `selectWidgetSourceScreen` dialogs via `findNavController()`, and `WidgetSourceTypeFragment` / `CreateChatObjectFragment` via `childFragmentManager`. The overlay stays open during these actions so the user returns to the widgets surface afterwards.
- Implements `WidgetSourceTypeListener` and `CreateChatObjectListener` on `WidgetOverlayFragment` so picker results route back into the overlay's `HomeScreenViewModel`, mirroring `WidgetsScreenFragment.kt:745-782`.

## Test plan

- [ ] Build: `./gradlew :app:assembleDebug` (compiles clean — verified locally)
- [ ] On device: open a host that exposes the Widget Overlay (chat / editor / object set), expand the overlay, long-press a custom (non-bundled) widget, tap **Change Widget type** → `SelectWidgetTypeFragment` opens; pick a different type → widget type updates and the overlay still shows the updated widget.
- [ ] Verify "Add widget below" → `SelectWidgetSourceFragment` opens.
- [ ] Verify create-new-source flow → `WidgetSourceTypeFragment` appears as a child dialog of the overlay; selecting a type calls back into the overlay's VM.
- [ ] Verify chat-object creation flow → `CreateChatObjectFragment` appears as a child dialog; created chat object opens via `navigation().openChat(...)`.
- [ ] `adb logcat | grep WidgetOverlay` no longer prints `vm command (ignored): ChangeWidgetType` after pressing the menu item.
- [ ] Regression: same flows still work on `WidgetsScreenFragment` (the non-overlay widgets screen is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)