### PR TITLE
DROID-4472 Navigation | Fix | Bottom sheet top padding above dragger

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/ui/editor/cover/SelectCoverGalleryFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/editor/cover/SelectCoverGalleryFragment.kt
@@ -6,9 +6,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.core.os.bundleOf
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -23,6 +25,7 @@ import com.anytypeio.anytype.core_utils.ext.GetImageContract
 import com.anytypeio.anytype.core_utils.ext.Mimetype
 import com.anytypeio.anytype.core_utils.ext.arg
 import com.anytypeio.anytype.core_utils.ext.dimen
+import com.anytypeio.anytype.core_utils.ext.fixBottomSheetNavigationBarGap
 import com.anytypeio.anytype.core_utils.ext.parseImagePath
 import com.anytypeio.anytype.core_utils.ext.subscribe
 import com.anytypeio.anytype.core_utils.ext.toast
@@ -85,6 +88,8 @@ abstract class SelectCoverGalleryFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        setupBottomToolbarInsets()
 
         binding.btnRemove.clicks()
             .onEach { vm.onRemoveCover(ctx) }
@@ -149,6 +154,18 @@ abstract class SelectCoverGalleryFragment :
         }
 
         skipCollapsed()
+    }
+
+    private fun setupBottomToolbarInsets() {
+        val bottomToolbar = binding.bottomToolbar
+        val initialBottomMargin = (bottomToolbar.layoutParams as LinearLayout.LayoutParams)
+            .bottomMargin
+
+        fixBottomSheetNavigationBarGap { navigationBars ->
+            bottomToolbar.updateLayoutParams<LinearLayout.LayoutParams> {
+                bottomMargin = initialBottomMargin + navigationBars.bottom
+            }
+        }
     }
 
     override fun onStart() {

--- a/app/src/main/java/com/anytypeio/anytype/ui/editor/modals/IconPickerFragmentBase.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/editor/modals/IconPickerFragmentBase.kt
@@ -6,8 +6,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
+import android.widget.LinearLayout
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
+import androidx.core.view.updateLayoutParams
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
@@ -16,6 +18,7 @@ import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.core_utils.ext.GetImageContract
 import com.anytypeio.anytype.core_utils.ext.Mimetype
 import com.anytypeio.anytype.core_utils.ext.arg
+import com.anytypeio.anytype.core_utils.ext.fixBottomSheetNavigationBarGap
 import com.anytypeio.anytype.core_utils.ext.invisible
 import com.anytypeio.anytype.core_utils.ext.parseImagePath
 import com.anytypeio.anytype.core_utils.ext.subscribe
@@ -96,6 +99,19 @@ abstract class IconPickerFragmentBase<T> :
         }
         skipCollapsed()
         expand()
+        setupBottomToolbarInsets()
+    }
+
+    private fun setupBottomToolbarInsets() {
+        val bottomToolbar = binding.bottomToolbar
+        val initialBottomMargin = (bottomToolbar.layoutParams as LinearLayout.LayoutParams)
+            .bottomMargin
+
+        fixBottomSheetNavigationBarGap(applyTopSystemBarInset = false) { navigationBars ->
+            bottomToolbar.updateLayoutParams<LinearLayout.LayoutParams> {
+                bottomMargin = initialBottomMargin + navigationBars.bottom
+            }
+        }
     }
 
     private fun setupRecycler() {
@@ -210,4 +226,3 @@ abstract class IconPickerFragmentBase<T> :
         private const val SELECT_IMAGE_CODE = 1
     }
 }
-

--- a/app/src/main/java/com/anytypeio/anytype/ui/editor/modals/IconPickerFragmentBase.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/editor/modals/IconPickerFragmentBase.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.EditText
 import android.widget.LinearLayout
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
@@ -24,7 +23,7 @@ import com.anytypeio.anytype.core_utils.ext.parseImagePath
 import com.anytypeio.anytype.core_utils.ext.subscribe
 import com.anytypeio.anytype.core_utils.ext.toast
 import com.anytypeio.anytype.core_utils.ext.visible
-import com.anytypeio.anytype.core_utils.ui.BaseBottomSheetTextInputFragment
+import com.anytypeio.anytype.core_utils.ui.BaseBottomSheetFragment
 import com.anytypeio.anytype.databinding.FragmentPageIconPickerBinding
 import com.anytypeio.anytype.device.launchMediaPicker
 import com.anytypeio.anytype.library_page_icon_picker_widget.ui.DocumentEmojiIconPickerAdapter
@@ -36,7 +35,7 @@ import com.anytypeio.anytype.presentation.picker.IconPickerViewModel.ViewState
 import timber.log.Timber
 
 abstract class IconPickerFragmentBase<T> :
-    BaseBottomSheetTextInputFragment<FragmentPageIconPickerBinding>() {
+    BaseBottomSheetFragment<FragmentPageIconPickerBinding>() {
 
     protected val context: Id
         get() = arg(ARG_CONTEXT_ID_KEY)
@@ -74,8 +73,6 @@ abstract class IconPickerFragmentBase<T> :
             onPermissionSuccess = { _, _ -> openGallery() }
         )
     }
-
-    override val textInput: EditText get() = binding.filterInputField
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/anytypeio/anytype/ui/editor/sheets/ObjectMenuBaseFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/editor/sheets/ObjectMenuBaseFragment.kt
@@ -21,6 +21,7 @@ import com.anytypeio.anytype.core_ui.layout.SpacingItemDecoration
 import com.anytypeio.anytype.core_ui.reactive.click
 import com.anytypeio.anytype.core_utils.ext.arg
 import com.anytypeio.anytype.core_utils.ext.argOrNull
+import com.anytypeio.anytype.core_utils.ext.fixBottomSheetNavigationBarGap
 import com.anytypeio.anytype.core_utils.ext.shareFile
 import com.anytypeio.anytype.core_utils.ext.throttleFirst
 import com.anytypeio.anytype.core_utils.ext.toast
@@ -73,6 +74,7 @@ abstract class ObjectMenuBaseFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        fixBottomSheetNavigationBarGap(applyTopSystemBarInset = false)
         binding.rvActions.apply {
             layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
             adapter = actionAdapter

--- a/app/src/main/java/com/anytypeio/anytype/ui/editor/sheets/ObjectMenuBaseFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/editor/sheets/ObjectMenuBaseFragment.kt
@@ -98,6 +98,9 @@ abstract class ObjectMenuBaseFragment :
                 )
             }
         }
+
+        skipCollapsed()
+        expand()
     }
 
     override fun onStart() {

--- a/app/src/main/res/layout/fragment_object_menu.xml
+++ b/app/src/main/res/layout/fragment_object_menu.xml
@@ -16,6 +16,7 @@
             android:layout_height="4dp"
             android:layout_gravity="center_horizontal"
             android:layout_marginTop="6dp"
+            android:layout_marginBottom="6dp"
             android:background="@drawable/dragger" />
 
         <androidx.core.widget.NestedScrollView
@@ -220,6 +221,10 @@
                 android:layout_gravity="center_vertical" />
 
         </FrameLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="48dp" />
 
         <View
             android:id="@+id/anchor"

--- a/core-utils/src/main/java/com/anytypeio/anytype/core_utils/ext/AndroidExtension.kt
+++ b/core-utils/src/main/java/com/anytypeio/anytype/core_utils/ext/AndroidExtension.kt
@@ -492,6 +492,15 @@ fun BottomSheetDialogFragment.fixBottomSheetNavigationBarGap(
     applyTopSystemBarInset: Boolean = true,
     onNavigationBarsInsetsChanged: (Insets) -> Unit = {}
 ) {
+    if (!applyTopSystemBarInset) {
+        // The default bottomSheetStyle sets paddingTopSystemWindowInsets=true, so
+        // BottomSheetBehavior installs a listener on design_bottom_sheet that pads the
+        // sheet by the status bar inset whenever it covers the status bar. Replace that
+        // listener with a pass-through so no top padding is applied above sheet content.
+        dialog?.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)?.let { sheet ->
+            ViewCompat.setOnApplyWindowInsetsListener(sheet) { _, insets -> insets }
+        }
+    }
     dialog?.findViewById<View>(com.google.android.material.R.id.container)?.let { container ->
         ViewCompat.setOnApplyWindowInsetsListener(container) { v, insets ->
             val navigationBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars())

--- a/core-utils/src/main/java/com/anytypeio/anytype/core_utils/ext/AndroidExtension.kt
+++ b/core-utils/src/main/java/com/anytypeio/anytype/core_utils/ext/AndroidExtension.kt
@@ -488,15 +488,20 @@ fun BaseBottomSheetComposeFragment.setupBottomSheetBehavior(paddingTop: Int) {
  * for the navigation bar on the container, creating a visible gap below the sheet.
  * This removes that bottom padding so the sheet background extends to the screen edge.
  */
-fun BottomSheetDialogFragment.fixBottomSheetNavigationBarGap() {
+fun BottomSheetDialogFragment.fixBottomSheetNavigationBarGap(
+    applyTopSystemBarInset: Boolean = true,
+    onNavigationBarsInsetsChanged: (Insets) -> Unit = {}
+) {
     dialog?.findViewById<View>(com.google.android.material.R.id.container)?.let { container ->
         ViewCompat.setOnApplyWindowInsetsListener(container) { v, insets ->
+            val navigationBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(systemBars.left, systemBars.top, systemBars.right, 0)
+            onNavigationBarsInsetsChanged(navigationBars)
             WindowInsetsCompat.Builder(insets)
                 .setInsets(WindowInsetsCompat.Type.navigationBars(), Insets.NONE)
                 .build()
         }
+        ViewCompat.requestApplyInsets(container)
     }
 }
 


### PR DESCRIPTION
## Summary
- Honor the `applyTopSystemBarInset` parameter in `fixBottomSheetNavigationBarGap`. Previously the parameter was added but never read, so passing `false` was a no-op.
- When `applyTopSystemBarInset = false`, install a pass-through `OnApplyWindowInsetsListener` on `design_bottom_sheet` before `dialog.show()`. This replaces `BottomSheetDialog`'s edge-to-edge listener before it can register `EdgeToEdgeCallback`, so Material no longer applies a status-bar-height top padding to the sheet — the dragger sits flush at the top.
- Apply the same suppression in `ObjectMenuBaseFragment` so the dragger stays flush both initially and after returning from the icon picker (without it, `EdgeToEdgeCallback.onLayout` re-applied padding on the re-layout that follows the icon picker dismissing).
- Drop the `BaseBottomSheetTextInputFragment` parent on `IconPickerFragmentBase` so the soft keyboard no longer auto-opens when the picker is shown — the user taps the filter field if they want to type.

## Test plan
- [ ] Open object menu → no padding above the dragger
- [ ] From object menu, open Change icon → no padding above the dragger, keyboard does not auto-open
- [ ] Tap filter field in icon picker → keyboard opens
- [ ] Back out of icon picker to object menu → no extra padding appears above the dragger
- [ ] Repeat on a device with gesture navigation; bottom toolbar still respects the navigation bar inset

🤖 Generated with [Claude Code](https://claude.com/claude-code)