### PR TITLE
DROID-4489 Chats | Fix | Restrict pin/unpin to space owner

### DIFF
--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/presentation/ChatViewModel.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/presentation/ChatViewModel.kt
@@ -296,7 +296,8 @@ class ChatViewModel @Inject constructor(
                         }
                         is HeaderView.ChatObject -> {
                             header.value = currentHeader.copy(
-                                canEdit = permission?.isOwnerOrEditor() == true
+                                canEdit = permission?.isOwnerOrEditor() == true,
+                                canPin = permission?.isOwner() == true
                             )
                         }
                         else -> {}
@@ -319,6 +320,7 @@ class ChatViewModel @Inject constructor(
                 val isMuted = notificationSetting == NotificationSetting.MUTE
                     || notificationSetting == NotificationSetting.MENTIONS
                 val canEdit = currentPermission.value?.isOwnerOrEditor() == true
+                val canPin = currentPermission.value?.isOwner() == true
 
                 // 1-1 space
                 if (spaceView.isOneToOneSpace) {
@@ -346,7 +348,8 @@ class ChatViewModel @Inject constructor(
                         isMuted = isMuted,
                         notificationSetting = notificationSetting,
                         isPinned = isPinned,
-                        canEdit = canEdit
+                        canEdit = canEdit,
+                        canPin = canPin
                     )
                 }
                 // Note: if wrapper is null for chat object, header remains Init until wrapper is available
@@ -2706,7 +2709,8 @@ class ChatViewModel @Inject constructor(
             val showAddMembers: Boolean = false,
             val notificationSetting: NotificationSetting = NotificationSetting.ALL,
             val isPinned: Boolean = false,
-            val canEdit: Boolean = true
+            val canEdit: Boolean = true,
+            val canPin: Boolean = false
         ) : HeaderView()
     }
 

--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/ChatMenu.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/ChatMenu.kt
@@ -55,6 +55,7 @@ fun BoxScope.ChatMenu(
     currentNotificationSetting: NotificationSetting,
     isPinned: Boolean = false,
     canEdit: Boolean = true,
+    canPin: Boolean = false,
     onDismissRequest: () -> Unit,
     onPropertiesClick: () -> Unit,
     onEditInfoClick: () -> Unit,
@@ -124,9 +125,13 @@ fun BoxScope.ChatMenu(
                     },
                     onClick = { onEditInfoClick() }
                 )
-                Divider(paddingStart = 0.dp, paddingEnd = 0.dp, height = 8.dp)
+                if (canPin) {
+                    Divider(paddingStart = 0.dp, paddingEnd = 0.dp, height = 8.dp)
+                }
+            }
 
-                // Pin/Unpin - only show if user can edit
+            // Pin/Unpin - only show for Owner (and Admin, when that role exists)
+            if (canPin) {
                 DropdownMenuItem(
                     content = {
                         ChatMenuItemContent(
@@ -139,6 +144,9 @@ fun BoxScope.ChatMenu(
                     },
                     onClick = { onPinClick() }
                 )
+            }
+
+            if (canEdit || canPin) {
                 Divider(paddingStart = 0.dp, paddingEnd = 0.dp)
             }
 
@@ -445,6 +453,7 @@ fun ChatMenuPreview() {
             currentNotificationSetting = NotificationSetting.ALL,
             isPinned = false,
             canEdit = true,
+            canPin = true,
             onDismissRequest = {},
             onPropertiesClick = {},
             onEditInfoClick = {},

--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/Toolbars.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/Toolbars.kt
@@ -222,6 +222,7 @@ fun ChatTopToolbar(
                     currentNotificationSetting = header.notificationSetting,
                     isPinned = header.isPinned,
                     canEdit = header.canEdit,
+                    canPin = header.canPin,
                     onDismissRequest = {
                         showDropdownMenu = false
                     },


### PR DESCRIPTION
## Summary
- Hide the chat header's Pin/Unpin menu item for everyone except the space Owner.
- Edit Info and Move to Bin remain available to Editors (gated on the existing `canEdit`).
- Adds a separate `canPin` flag on `HeaderView.ChatObject`, populated from `SpaceMemberPermissions.isOwner()`, and threads it through `Toolbars` → `ChatMenu`.

Note: the Linear ticket says "Owner and Admin", but `SpaceMemberPermissions` currently has only `OWNER`/`WRITER`/`READER`/`NO_PERMISSIONS`. When Admin is added to the data model, update the two `isOwner()` call sites in `ChatViewModel` to include it.

Linear: https://linear.app/anytype/issue/DROID-4489

## Test plan
- [ ] Open a chat as **Owner** → header menu shows Edit Info, Pin/Unpin, Notifications, Move to Bin.
- [ ] Open a chat as **Editor (Writer)** → header menu shows Edit Info, Notifications, Move to Bin (no Pin/Unpin).
- [ ] Open a chat as **Reader** → header menu shows only Search + Notifications.
- [ ] Toggle Pin → Unpin as Owner; verify chat is added/removed from widgets and the menu label updates accordingly.
- [ ] Demote an Owner to Editor while the chat is open → Pin/Unpin disappears from the menu without reopening the chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)