### PR TITLE
DROID-4487 Widgets | Feature | Allow collapsing My Favorites section

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreen.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreen.kt
@@ -158,23 +158,29 @@ fun WidgetsScreen(
     val personalFavoritesWidgetView = personalFavoritesWidget as? WidgetView.SetOfObjects
     val isMyFavoritesSectionCollapsed = collapsedSections.contains(SECTION_MY_FAVORITES)
 
+    // Track previous collapse state for my favorites section
     val wasMyFavoritesCollapsed = remember { mutableStateOf(isMyFavoritesSectionCollapsed) }
     val hadMyFavoritesItems = remember { mutableStateOf(personalFavoritesWidgetView?.elements?.isNotEmpty() == true) }
 
+    // When section becomes expanded, keep the flag true to prevent flicker
     if (!isMyFavoritesSectionCollapsed && wasMyFavoritesCollapsed.value) {
         hadMyFavoritesItems.value = true
     }
 
+    // Update previous state
     wasMyFavoritesCollapsed.value = isMyFavoritesSectionCollapsed
 
+    // Set flag when items are present
     if (personalFavoritesWidgetView?.elements?.isNotEmpty() == true) {
         hadMyFavoritesItems.value = true
     }
 
+    // Reset flag when section is collapsed and has no items
     if (isMyFavoritesSectionCollapsed && personalFavoritesWidgetView?.elements?.isEmpty() == true) {
         hadMyFavoritesItems.value = false
     }
 
+    // Show header if: has items OR is collapsed OR was previously shown
     val shouldShowPersonalFavoritesSection = personalFavoritesWidgetView != null &&
         (personalFavoritesWidgetView.elements.isNotEmpty() || isMyFavoritesSectionCollapsed || hadMyFavoritesItems.value)
 

--- a/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreen.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreen.kt
@@ -151,12 +151,32 @@ fun WidgetsScreen(
     val shouldShowUnreadSection = unreadWidgetView != null &&
         (unreadWidgetView.elements.isNotEmpty() || isUnreadSectionCollapsed || hadUnreadItems.value)
 
-    // My Favorites section visibility: purely data-driven — shown iff the
-    // user has at least one personal favorite in this space. No user-toggle
-    // collapse (see SectionSettings.isUserConfigurable).
+    // My Favorites section visibility: data-driven — shown iff the user has
+    // at least one personal favorite in this space. The section can also be
+    // collapsed by tapping its header (DROID-4487); when collapsed, the
+    // header stays so the user can re-expand.
     val personalFavoritesWidgetView = personalFavoritesWidget as? WidgetView.SetOfObjects
-    val shouldShowPersonalFavoritesSection =
-        personalFavoritesWidgetView != null && personalFavoritesWidgetView.elements.isNotEmpty()
+    val isMyFavoritesSectionCollapsed = collapsedSections.contains(SECTION_MY_FAVORITES)
+
+    val wasMyFavoritesCollapsed = remember { mutableStateOf(isMyFavoritesSectionCollapsed) }
+    val hadMyFavoritesItems = remember { mutableStateOf(personalFavoritesWidgetView?.elements?.isNotEmpty() == true) }
+
+    if (!isMyFavoritesSectionCollapsed && wasMyFavoritesCollapsed.value) {
+        hadMyFavoritesItems.value = true
+    }
+
+    wasMyFavoritesCollapsed.value = isMyFavoritesSectionCollapsed
+
+    if (personalFavoritesWidgetView?.elements?.isNotEmpty() == true) {
+        hadMyFavoritesItems.value = true
+    }
+
+    if (isMyFavoritesSectionCollapsed && personalFavoritesWidgetView?.elements?.isEmpty() == true) {
+        hadMyFavoritesItems.value = false
+    }
+
+    val shouldShowPersonalFavoritesSection = personalFavoritesWidgetView != null &&
+        (personalFavoritesWidgetView.elements.isNotEmpty() || isMyFavoritesSectionCollapsed || hadMyFavoritesItems.value)
 
     // Recently Edited section visibility logic
     val recentlyEditedView = recentlyEditedWidget as? WidgetView.RecentlyEdited
@@ -493,28 +513,30 @@ fun WidgetsScreen(
                                     key = SECTION_MY_FAVORITES,
                                 ) {
                                     MyFavoritesSectionHeader(
-                                        onSectionClicked = {} // Not user-collapsible per spec
+                                        onSectionClicked = viewModel::onSectionMyFavoritesClicked
                                     )
                                 }
                             }
-                            item(key = "my_favorites_widget_content") {
-                                ReorderableItem(
-                                    enabled = false,
-                                    state = reorderableState,
-                                    key = "my_favorites_widget_content",
-                                ) {
-                                    MyFavoritesWidget(
-                                        item = personalFavoritesWidgetView,
-                                        mode = mode,
-                                        onWidgetObjectClicked = { obj ->
-                                            viewModel.onWidgetElementClicked(
-                                                personalFavoritesWidgetView.id, obj
-                                            )
-                                        },
-                                        onObjectCheckboxClicked = viewModel::onObjectCheckboxClicked,
-                                        onReordered = viewModel::onMyFavoritesReordered,
-                                        reorderFailedSignal = myFavoritesReorderFailedSignal
-                                    )
+                            if (!isMyFavoritesSectionCollapsed) {
+                                item(key = "my_favorites_widget_content") {
+                                    ReorderableItem(
+                                        enabled = false,
+                                        state = reorderableState,
+                                        key = "my_favorites_widget_content",
+                                    ) {
+                                        MyFavoritesWidget(
+                                            item = personalFavoritesWidgetView,
+                                            mode = mode,
+                                            onWidgetObjectClicked = { obj ->
+                                                viewModel.onWidgetElementClicked(
+                                                    personalFavoritesWidgetView.id, obj
+                                                )
+                                            },
+                                            onObjectCheckboxClicked = viewModel::onObjectCheckboxClicked,
+                                            onReordered = viewModel::onMyFavoritesReordered,
+                                            reorderFailedSignal = myFavoritesReorderFailedSignal
+                                        )
+                                    }
                                 }
                             }
                         }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomeScreenViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomeScreenViewModel.kt
@@ -3725,6 +3725,7 @@ class HomeScreenViewModel(
             widget.sectionType == SectionType.UNREAD -> collapsedSections.contains(Widget.Source.SECTION_UNREAD)
             widget.sectionType == SectionType.TYPES -> collapsedSections.contains(Widget.Source.SECTION_OBJECT_TYPE)
             widget.sectionType == SectionType.RECENTLY_EDITED -> collapsedSections.contains(Widget.Source.SECTION_RECENTLY_EDITED)
+            widget.sectionType == SectionType.MY_FAVORITES -> collapsedSections.contains(Widget.Source.SECTION_MY_FAVORITES)
             else -> false
         }
     }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomeScreenViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomeScreenViewModel.kt
@@ -161,6 +161,7 @@ import com.anytypeio.anytype.presentation.widgets.TreePath
 import com.anytypeio.anytype.presentation.widgets.TreeWidgetBranchStateHolder
 import com.anytypeio.anytype.presentation.widgets.ViewId
 import com.anytypeio.anytype.presentation.widgets.Widget
+import com.anytypeio.anytype.presentation.widgets.Widget.Source.Companion.SECTION_MY_FAVORITES
 import com.anytypeio.anytype.presentation.widgets.Widget.Source.Companion.SECTION_OBJECT_TYPE
 import com.anytypeio.anytype.presentation.widgets.Widget.Source.Companion.SECTION_PINNED
 import com.anytypeio.anytype.presentation.widgets.Widget.Source.Companion.SECTION_RECENTLY_EDITED
@@ -3694,6 +3695,21 @@ class HomeScreenViewModel(
                 currentCollapsedSections.minus(SECTION_RECENTLY_EDITED)
             } else {
                 currentCollapsedSections.plus(SECTION_RECENTLY_EDITED)
+            }
+
+            userSettingsRepository.setCollapsedSectionIds(vmParams.spaceId, newCollapsedSections.toList())
+        }
+    }
+
+    fun onSectionMyFavoritesClicked() {
+        viewModelScope.launch {
+            val currentCollapsedSections = userSettingsRepository.getCollapsedSectionIds(vmParams.spaceId).first().toSet()
+            val isCurrentlyCollapsed = currentCollapsedSections.contains(SECTION_MY_FAVORITES)
+
+            val newCollapsedSections = if (isCurrentlyCollapsed) {
+                currentCollapsedSections.minus(SECTION_MY_FAVORITES)
+            } else {
+                currentCollapsedSections.plus(SECTION_MY_FAVORITES)
             }
 
             userSettingsRepository.setCollapsedSectionIds(vmParams.spaceId, newCollapsedSections.toList())


### PR DESCRIPTION
## Summary
- Make the **My Favorites** section header tappable to collapse/expand its content, matching the existing Unread / Recently Edited pattern.
- Persist collapsed state via `userSettingsRepository.setCollapsedSectionIds` keyed on `SECTION_MY_FAVORITES`.
- Keep the header visible while collapsed (even if the user has zero personal favorites) so the section can be re-expanded; the row only disappears once it is empty AND not collapsed.

## Test Plan
- [ ] Tap the **My Favorites** header → content collapses; header remains.
- [ ] Tap again → content re-expands.
- [ ] Collapse, restart the app → state is persisted across app launches.
- [ ] With zero personal favorites and section expanded → row stays hidden.
- [ ] Add a favorite, then collapse → header still shown after the favorite is removed (until expanded again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)