### PR TITLE
DROID-4383 Vault | Feature | Set Compact view as default

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/ui/settings/ProfileSettingsFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/settings/ProfileSettingsFragment.kt
@@ -147,6 +147,7 @@ class ProfileSettingsFragment : BaseBottomSheetComposeFragment() {
                             }
                         },
                         isDebugEnabled = vm.isDebugEnabled.collectAsStateWithLifecycle().value,
+                        showExperimentalFeatures = vm.showExperimentalFeatures,
                         onMiscSectionClicked = vm::onMiscSectionClicked,
                         notificationsDisabled = notificationsDisabled,
                         onOpenNotificationSettings = { showNotificationSettingsModal = true },

--- a/app/src/main/java/com/anytypeio/anytype/ui/spaces/SpaceListFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/spaces/SpaceListFragment.kt
@@ -4,8 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -28,7 +26,6 @@ import com.anytypeio.anytype.core_utils.ui.BaseBottomSheetComposeFragment
 import com.anytypeio.anytype.di.common.componentManager
 import com.anytypeio.anytype.presentation.spaces.SpaceListViewModel
 import com.anytypeio.anytype.ui.multiplayer.LeaveSpaceWarningScreen
-import com.anytypeio.anytype.ui.settings.typography
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 import timber.log.Timber

--- a/app/src/main/java/com/anytypeio/anytype/ui/spaces/SpaceListFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/spaces/SpaceListFragment.kt
@@ -48,26 +48,21 @@ class SpaceListFragment : BaseBottomSheetComposeFragment() {
     ): View = ComposeView(requireContext()).apply {
         setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
         setContent {
-            MaterialTheme(
-                typography = typography,
-                shapes = MaterialTheme.shapes.copy(medium = RoundedCornerShape(16.dp))
-            ) {
-                SpaceListScreen(
-                    state = vm.state.collectAsStateWithLifecycle().value,
-                    onDeleteSpaceClicked = vm::onDeleteSpaceClicked,
-                    onLeaveSpaceClicked = vm::onLeaveSpaceClicked,
-                    onCancelJoinRequestClicked = vm::onCancelJoinSpaceClicked,
-                    onCreateSpaceClicked = {
-                        runCatching {
-                            findNavController().navigate(
-                                R.id.actionCreateSpaceFromVault
-                            )
-                        }.onFailure {
-                            Timber.e(it, "Error while opening create-space screen from vault")
-                        }
+            SpaceListScreen(
+                state = vm.state.collectAsStateWithLifecycle().value,
+                onDeleteSpaceClicked = vm::onDeleteSpaceClicked,
+                onLeaveSpaceClicked = vm::onLeaveSpaceClicked,
+                onCancelJoinRequestClicked = vm::onCancelJoinSpaceClicked,
+                onCreateSpaceClicked = {
+                    runCatching {
+                        findNavController().navigate(
+                            R.id.actionCreateSpaceFromVault
+                        )
+                    }.onFailure {
+                        Timber.e(it, "Error while opening create-space screen from vault")
                     }
-                )
-            }
+                }
+            )
 
             val bottomSheetState = rememberModalBottomSheetState()
             val scope = rememberCoroutineScope()

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/multiplayer/SpaceListScreen.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/multiplayer/SpaceListScreen.kt
@@ -11,13 +11,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.DropdownMenu
-import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Text
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
@@ -65,6 +66,7 @@ fun SpaceListScreen(
 ) {
     Column(
         modifier = Modifier
+            .statusBarsPadding()
             .fillMaxSize()
             .nestedScroll(rememberNestedScrollInteropConnection())
     ) {
@@ -338,7 +340,10 @@ private fun SpaceListItemMenu(
         onDismissRequest = {
             isCardMenuExpanded.value = false
         },
-        offset = DpOffset(x = 0.dp, y = 6.dp)
+        offset = DpOffset(x = 0.dp, y = 6.dp),
+        containerColor = colorResource(R.color.background_secondary),
+        shape = RoundedCornerShape(38.dp),
+        tonalElevation = 8.dp,
     ) {
         actions.forEachIndexed { idx, action ->
             when (action) {
@@ -348,14 +353,15 @@ private fun SpaceListItemMenu(
                             onCancelJoinRequestClicked().also {
                                 isCardMenuExpanded.value = false
                             }
+                        },
+                        text = {
+                            Text(
+                                text = stringResource(R.string.multiplayer_cancel_join_request),
+                                style = BodyRegular,
+                                color = colorResource(id = R.color.palette_system_red)
+                            )
                         }
-                    ) {
-                        Text(
-                            text = stringResource(R.string.multiplayer_cancel_join_request),
-                            style = BodyRegular,
-                            color = colorResource(id = R.color.palette_system_red)
-                        )
-                    }
+                    )
                 }
 
                 SpaceListItemView.Action.DeleteSpace -> {
@@ -364,14 +370,15 @@ private fun SpaceListItemMenu(
                             onDeleteSpaceClicked().also {
                                 isCardMenuExpanded.value = false
                             }
+                        },
+                        text = {
+                            Text(
+                                text = stringResource(R.string.delete_space),
+                                style = BodyRegular,
+                                color = colorResource(id = R.color.palette_system_red)
+                            )
                         }
-                    ) {
-                        Text(
-                            text = stringResource(R.string.delete_space),
-                            style = BodyRegular,
-                            color = colorResource(id = R.color.palette_system_red)
-                        )
-                    }
+                    )
                 }
 
                 SpaceListItemView.Action.LeaveSpace -> {
@@ -380,14 +387,15 @@ private fun SpaceListItemMenu(
                             onLeaveSpaceClicked().also {
                                 isCardMenuExpanded.value = false
                             }
+                        },
+                        text = {
+                            Text(
+                                text = stringResource(R.string.multiplayer_leave_space),
+                                style = BodyRegular,
+                                color = colorResource(id = R.color.palette_system_red)
+                            )
                         }
-                    ) {
-                        Text(
-                            text = stringResource(R.string.multiplayer_leave_space),
-                            style = BodyRegular,
-                            color = colorResource(id = R.color.palette_system_red)
-                        )
-                    }
+                    )
                 }
             }
         }

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/multiplayer/SpaceListScreen.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/multiplayer/SpaceListScreen.kt
@@ -342,7 +342,6 @@ private fun SpaceListItemMenu(
         },
         offset = DpOffset(x = 0.dp, y = 6.dp),
         containerColor = colorResource(R.color.background_secondary),
-        shape = RoundedCornerShape(38.dp),
         tonalElevation = 8.dp,
     ) {
         actions.forEachIndexed { idx, action ->

--- a/feature-ui-settings/src/main/java/com/anytypeio/anytype/ui_settings/account/ProfileScreen.kt
+++ b/feature-ui-settings/src/main/java/com/anytypeio/anytype/ui_settings/account/ProfileScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -113,7 +115,8 @@ fun ProfileSettingsScreen(
     LazyColumn(
         modifier = Modifier
             .nestedScroll(rememberNestedScrollInteropConnection())
-            .fillMaxSize(),
+            .fillMaxSize()
+            .statusBarsPadding(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         item {

--- a/feature-ui-settings/src/main/java/com/anytypeio/anytype/ui_settings/account/ProfileScreen.kt
+++ b/feature-ui-settings/src/main/java/com/anytypeio/anytype/ui_settings/account/ProfileScreen.kt
@@ -89,6 +89,7 @@ fun ProfileSettingsScreen(
     onLogoutClicked: () -> Unit,
     isLogoutInProgress: Boolean,
     isDebugEnabled: Boolean,
+    showExperimentalFeatures: Boolean,
     onNameChange: (String) -> Unit,
     onProfileIconClick: () -> Unit,
     account: AccountProfile,
@@ -245,15 +246,17 @@ fun ProfileSettingsScreen(
                     onClick = onDebugClicked
                 )
             }
-            item {
-                Divider(paddingStart = 16.dp, paddingEnd = 16.dp)
-            }
-            item {
-                Option(
-                    image = R.drawable.ic_settings_debug,
-                    text = stringResource(R.string.experimental_features),
-                    onClick = onExperimentalFeaturesClicked
-                )
+            if (showExperimentalFeatures) {
+                item {
+                    Divider(paddingStart = 16.dp, paddingEnd = 16.dp)
+                }
+                item {
+                    Option(
+                        image = R.drawable.ic_settings_debug,
+                        text = stringResource(R.string.experimental_features),
+                        onClick = onExperimentalFeaturesClicked
+                    )
+                }
             }
         }
         item {
@@ -716,6 +719,7 @@ private fun ProfileSettingPreview() {
         onDebugClicked = {},
         onExperimentalFeaturesClicked = {},
         isDebugEnabled = true,
+        showExperimentalFeatures = true,
         notificationsDisabled = true,
         onOpenNotificationSettings = {},
         onMySitesClicked = {},
@@ -792,6 +796,7 @@ private fun ProfileSettingLongGlobalNamePreview() {
         onDebugClicked = {},
         onExperimentalFeaturesClicked = {},
         isDebugEnabled = false,
+        showExperimentalFeatures = false,
         notificationsDisabled = false,
         onOpenNotificationSettings = {},
         onMySitesClicked = {},

--- a/feature-ui-settings/src/main/java/com/anytypeio/anytype/ui_settings/account/ProfileSettingsViewModel.kt
+++ b/feature-ui-settings/src/main/java/com/anytypeio/anytype/ui_settings/account/ProfileSettingsViewModel.kt
@@ -71,6 +71,8 @@ class ProfileSettingsViewModel(
 
     val isDebugEnabled = MutableStateFlow(false)
 
+    val showExperimentalFeatures: Boolean = BuildConfig.DEBUG
+
     val profileQrCodeState = MutableStateFlow<UiProfileQrCodeState>(UiProfileQrCodeState.Hidden)
 
     val notificationsDisabled: StateFlow<Boolean> =

--- a/persistence/src/main/java/com/anytypeio/anytype/persistence/repo/DefaultUserSettingsCache.kt
+++ b/persistence/src/main/java/com/anytypeio/anytype/persistence/repo/DefaultUserSettingsCache.kt
@@ -55,7 +55,7 @@ class DefaultUserSettingsCache(
 ) : UserSettingsCache {
 
     private val _compactModeFlow = MutableStateFlow(
-        prefs.getBoolean(COMPACT_MODE_ENABLED_KEY, false)
+        prefs.getBoolean(COMPACT_MODE_ENABLED_KEY, true)
     )
 
     private val _fileDownloadLimitFlow = MutableStateFlow(
@@ -768,7 +768,7 @@ class DefaultUserSettingsCache(
     }
 
     override suspend fun getCompactModeEnabled(): Boolean {
-        return prefs.getBoolean(COMPACT_MODE_ENABLED_KEY, false)
+        return prefs.getBoolean(COMPACT_MODE_ENABLED_KEY, true)
     }
 
     override suspend fun setCompactModeEnabled(enabled: Boolean) {

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/settings/ExperimentalFeaturesViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/settings/ExperimentalFeaturesViewModel.kt
@@ -14,7 +14,7 @@ class ExperimentalFeaturesViewModel(
     private val userSettingsRepository: UserSettingsRepository
 ) : ViewModel() {
 
-    private val _isCompactModeEnabled = MutableStateFlow(false)
+    private val _isCompactModeEnabled = MutableStateFlow(true)
     val isCompactModeEnabled: StateFlow<Boolean> = _isCompactModeEnabled.asStateFlow()
 
     init {


### PR DESCRIPTION
## Summary
- Default compact mode to `true` for new users in `DefaultUserSettingsCache` (initial flow value + getter). Users with an explicit prior choice keep it because the pref key remains set.
- Hide the **Experimental Features** entry from Profile/Vault settings in release builds via a new `showExperimentalFeatures = BuildConfig.DEBUG` flag wired through `ProfileSettingsViewModel` → `ProfileScreen`. The **Debug** entry remains gated by the existing `isDebugEnabled` 5-tap unlock.
- Updated `ExperimentalFeaturesViewModel` initial state for consistency with the new default.

## Test plan
- [ ] Fresh install on a release build: vault renders in compact mode by default; Experimental Features entry is **not** present even after 5-tap-unlocking the debug menu.
- [ ] Fresh install on a debug build: vault renders in compact mode by default; Experimental Features entry is present alongside Debug.
- [ ] Existing user who had explicitly disabled compact mode: setting is preserved on upgrade.
- [ ] Existing user who had explicitly enabled compact mode: setting is preserved on upgrade.
- [ ] Toggle compact mode off in debug build via Experimental Features: vault re-renders in non-compact layout; toggle persists across app restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)