### PR TITLE
Add BSD-3-Clause license and PhotoView dependency allowlist

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,7 @@ licensee {
     // Allow common open source licenses
     allow("Apache-2.0")
     allow("MIT")
+    allow("BSD-3-Clause")
 
     // Google/Android SDK Terms
     allowUrl("https://developer.android.com/studio/terms.html") {
@@ -40,6 +41,9 @@ licensee {
     }
     allowDependency("com.github.komputing", "KBase58", "0.4") {
         because("KBase58 is MIT-licensed (verified in repository)")
+    }
+    allowDependency("com.github.chrisbanes", "PhotoView", "2.3.0") {
+        because("PhotoView is Apache-2.0 licensed (verified in repository); JitPack metadata may be missing")
     }
 
     // Internal Anytype middleware library


### PR DESCRIPTION
## Summary
Updated the license allowlist configuration to support additional open source licenses and explicitly allow the PhotoView dependency.

## Key Changes
- Added `BSD-3-Clause` to the list of allowed open source licenses
- Added explicit allowlist entry for PhotoView (v2.3.0) with verification note that it is Apache-2.0 licensed despite potential missing JitPack metadata

## Details
These changes enable the project to use dependencies under the BSD-3-Clause license and ensure PhotoView is properly recognized in the license compliance checks. The PhotoView allowlist entry includes a note explaining that while the dependency is Apache-2.0 licensed, JitPack metadata may not reflect this accurately.

https://claude.ai/code/session_016bKNQGCqNTbB1bgrcnbcJs