### PR TITLE
DROID-4427 Sets | Fix | Open image objects in MediaActivity instead of Chrome

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/ui/sets/ObjectSetFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/sets/ObjectSetFragment.kt
@@ -1403,15 +1403,21 @@ open class ObjectSetFragment :
             }
             is ObjectSetCommand.PlayMedia -> {
                 runCatching {
+                    val mediaType = when (command.layout) {
+                        ObjectType.Layout.IMAGE -> MediaActivity.TYPE_IMAGE
+                        ObjectType.Layout.VIDEO -> MediaActivity.TYPE_VIDEO
+                        ObjectType.Layout.AUDIO -> MediaActivity.TYPE_AUDIO
+                        else -> return@runCatching
+                    }
                     MediaActivity.start(
                         context = requireContext(),
-                        mediaType = if (command.isVideo) MediaActivity.TYPE_VIDEO else MediaActivity.TYPE_AUDIO,
+                        mediaType = mediaType,
                         obj = command.targetObjectId,
                         name = command.name,
                         space = space
                     )
                 }.onFailure {
-                    Timber.e(it, "Error while launching media player")
+                    Timber.e(it, "Error while launching media viewer")
                 }
             }
             is ObjectSetCommand.CopyLinkToClipboard -> {

--- a/app/src/main/java/com/anytypeio/anytype/ui/sets/ObjectSetFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/sets/ObjectSetFragment.kt
@@ -1407,7 +1407,10 @@ open class ObjectSetFragment :
                         ObjectType.Layout.IMAGE -> MediaActivity.TYPE_IMAGE
                         ObjectType.Layout.VIDEO -> MediaActivity.TYPE_VIDEO
                         ObjectType.Layout.AUDIO -> MediaActivity.TYPE_AUDIO
-                        else -> return@runCatching
+                        else -> {
+                            Timber.w("PlayMedia dispatched with unsupported layout: ${command.layout}")
+                            return@runCatching
+                        }
                     }
                     MediaActivity.start(
                         context = requireContext(),

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetCommand.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetCommand.kt
@@ -130,7 +130,7 @@ sealed class ObjectSetCommand {
     data class PlayMedia(
         val targetObjectId: Id,
         val name: String,
-        val isVideo: Boolean
+        val layout: ObjectType.Layout
     ) : ObjectSetCommand()
 
     data class CopyLinkToClipboard(val link: String) : ObjectSetCommand()

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
@@ -1469,18 +1469,25 @@ class ObjectSetViewModel(
             val layout = obj.layout
             val name = fieldParser.getObjectName(obj)
             when (layout) {
+                ObjectType.Layout.IMAGE -> dispatch(
+                    ObjectSetCommand.PlayMedia(
+                        targetObjectId = targetId,
+                        name = name,
+                        layout = ObjectType.Layout.IMAGE
+                    )
+                )
                 ObjectType.Layout.VIDEO -> dispatch(
                     ObjectSetCommand.PlayMedia(
                         targetObjectId = targetId,
                         name = name,
-                        isVideo = true
+                        layout = ObjectType.Layout.VIDEO
                     )
                 )
                 ObjectType.Layout.AUDIO -> dispatch(
                     ObjectSetCommand.PlayMedia(
                         targetObjectId = targetId,
                         name = name,
-                        isVideo = false
+                        layout = ObjectType.Layout.AUDIO
                     )
                 )
                 else -> {
@@ -2241,12 +2248,22 @@ class ObjectSetViewModel(
             val layout = obj.layout
             val name = fieldParser.getObjectName(obj)
             when (layout) {
+                ObjectType.Layout.IMAGE -> {
+                    dispatch(
+                        ObjectSetCommand.PlayMedia(
+                            targetObjectId = obj.id,
+                            name = name,
+                            layout = ObjectType.Layout.IMAGE
+                        )
+                    )
+                    return
+                }
                 ObjectType.Layout.VIDEO -> {
                     dispatch(
                         ObjectSetCommand.PlayMedia(
                             targetObjectId = obj.id,
                             name = name,
-                            isVideo = true
+                            layout = ObjectType.Layout.VIDEO
                         )
                     )
                     return
@@ -2256,7 +2273,7 @@ class ObjectSetViewModel(
                         ObjectSetCommand.PlayMedia(
                             targetObjectId = obj.id,
                             name = name,
-                            isVideo = false
+                            layout = ObjectType.Layout.AUDIO
                         )
                     )
                     return


### PR DESCRIPTION
## Summary
- Linear: [DROID-4427](https://linear.app/anytype/issue/DROID-4427/images-opening-in-chrome-instead-of-in-app-viewer) — image objects opened from a Set/Collection launched a Chrome Custom Tab pointing at the file gateway URL instead of the in-app `MediaActivity` viewer.
- Root cause: `ObjectSetViewModel.onOpenFile()` and `proceedWithNavigation(obj)` only branched on `VIDEO`/`AUDIO` for file layouts. `Layout.IMAGE` fell through to `urlBuilder.getUrlBasedOnFileLayout(...)` → `ObjectSetCommand.Browse(url)` → Custom Tab.
- Fix: extend `ObjectSetCommand.PlayMedia` to carry `ObjectType.Layout`, add an `IMAGE` arm to both VM functions, and map the layout to the existing `MediaActivity.TYPE_*` constants in `ObjectSetFragment` (mirrors the in-editor image flow already used by `EditorFragment.Command.OpenFullScreenImage`).
- Non-image, non-AV file layouts (`FILE`, `PDF`, etc.) keep their existing browser fallback.

## Test plan
- [x] `./gradlew :presentation:compileDebugKotlin :app:compileDebugKotlin` — both succeed.
- [x] `./gradlew :presentation:testDebugUnitTest` — green; no test relied on the old `isVideo` shape.
- [ ] Manual on a debug build:
  - [ ] Open a Space → Images → tap an image. Expect the in-app `MediaActivity` viewer to open (not Chrome).
  - [ ] Tap a video and an audio object — confirm AV playback still launches `MediaActivity`.
  - [ ] Tap a generic FILE / PDF object — confirm it still opens via Custom Tab.
  - [ ] Press back from the image viewer — confirm clean return to the Set.
  - [ ] Open an image block inside a regular page — confirm the editor's existing image viewer is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)