### PR TITLE
Search | Fix | Open image search results in MediaActivity instead of Chrome

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/ui/search/GlobalSearchFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/search/GlobalSearchFragment.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.fragment.findNavController
 import com.anytypeio.anytype.R
 import com.anytypeio.anytype.core_models.Id
+import com.anytypeio.anytype.core_models.ObjectType
 import com.anytypeio.anytype.core_models.misc.OpenObjectNavigation
 import com.anytypeio.anytype.core_models.primitives.SpaceId
 import com.anytypeio.anytype.core_ui.extensions.isKeyboardVisible
@@ -101,15 +102,24 @@ class GlobalSearchFragment : BaseBottomSheetComposeFragment() {
                         }
                         is GlobalSearchViewModel.SearchCommand.PlayMedia -> {
                             runCatching {
+                                val mediaType = when (command.layout) {
+                                    ObjectType.Layout.IMAGE -> MediaActivity.TYPE_IMAGE
+                                    ObjectType.Layout.VIDEO -> MediaActivity.TYPE_VIDEO
+                                    ObjectType.Layout.AUDIO -> MediaActivity.TYPE_AUDIO
+                                    else -> {
+                                        Timber.w("PlayMedia dispatched with unsupported layout: ${command.layout}")
+                                        return@runCatching
+                                    }
+                                }
                                 MediaActivity.start(
                                     context = requireContext(),
-                                    mediaType = if (command.isVideo) MediaActivity.TYPE_VIDEO else MediaActivity.TYPE_AUDIO,
+                                    mediaType = mediaType,
                                     obj = command.targetObjectId,
                                     name = command.name,
                                     space = space
                                 )
                             }.onFailure {
-                                Timber.e(it, "Error while launching media player")
+                                Timber.e(it, "Error while launching media viewer")
                             }
                         }
                         is GlobalSearchViewModel.SearchCommand.CopyLinkToClipboard -> {

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/search/GlobalSearchViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/search/GlobalSearchViewModel.kt
@@ -436,18 +436,25 @@ class GlobalSearchViewModel @Inject constructor(
         viewModelScope.launch {
             val layout = item.layout
             when (layout) {
+                ObjectType.Layout.IMAGE -> commands.emit(
+                    SearchCommand.PlayMedia(
+                        targetObjectId = item.id,
+                        name = item.title,
+                        layout = ObjectType.Layout.IMAGE
+                    )
+                )
                 ObjectType.Layout.VIDEO -> commands.emit(
                     SearchCommand.PlayMedia(
                         targetObjectId = item.id,
                         name = item.title,
-                        isVideo = true
+                        layout = ObjectType.Layout.VIDEO
                     )
                 )
                 ObjectType.Layout.AUDIO -> commands.emit(
                     SearchCommand.PlayMedia(
                         targetObjectId = item.id,
                         name = item.title,
-                        isVideo = false
+                        layout = ObjectType.Layout.AUDIO
                     )
                 )
                 else -> {
@@ -702,7 +709,7 @@ class GlobalSearchViewModel @Inject constructor(
         data class PlayMedia(
             val targetObjectId: Id,
             val name: String,
-            val isVideo: Boolean
+            val layout: ObjectType.Layout
         ) : SearchCommand()
         data class CopyLinkToClipboard(val link: String) : SearchCommand()
     }


### PR DESCRIPTION
## Summary
- Follow-up to [#3245 (DROID-4427)](https://github.com/anyproto/anytype-kotlin/pull/3245), which fixed the same bug for Sets/Collections. Code review noted that `GlobalSearchViewModel.onOpenFile()` had the identical structural defect.
- Tapping an image object from **Global Search** routed it through `SearchCommand.Browse(url)` and opened a Chrome Custom Tab, instead of the in-app `MediaActivity` viewer.
- Fix mirrors the DROID-4427 pattern: extend `SearchCommand.PlayMedia` to carry `ObjectType.Layout`, add an `IMAGE` arm in `GlobalSearchViewModel.onOpenFile()` (`presentation/.../GlobalSearchViewModel.kt:438`), and map the layout to `MediaActivity.TYPE_*` in `GlobalSearchFragment` (`app/.../GlobalSearchFragment.kt:102`). A `Timber.w()` covers any future unsupported layout instead of silently swallowing it.
- Generic FILE / PDF results keep their existing browser fallback.

## Test plan
- [x] `./gradlew :presentation:compileDebugKotlin :app:compileDebugKotlin` — green.
- [x] `./gradlew :presentation:testDebugUnitTest` — green; no test relied on the old `isVideo` shape of `SearchCommand.PlayMedia`.
- [ ] Manual on a debug build:
  - [ ] Open Global Search, search for an image object, tap it. Expect the in-app `MediaActivity` viewer to open (not Chrome).
  - [ ] Repeat for a video and an audio result — confirm playback still launches `MediaActivity`.
  - [ ] Repeat for a generic FILE / PDF result — confirm it still opens via Custom Tab.
  - [ ] Press back from the image viewer — confirm clean return to search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)