### PR TITLE
Chats | Fix | Floating top toolbar overlay with message clearance

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/ui/chats/ChatFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/chats/ChatFragment.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
@@ -165,35 +166,12 @@ class ChatFragment : Fragment() {
             Scaffold(
                 modifier = Modifier.fillMaxSize(),
                 containerColor = Color.Transparent,
-                contentWindowInsets = WindowInsets(0.dp),
-                topBar = {
-                    ChatTopToolbar(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .statusBarsPadding(),
-                        header = vm.header.collectAsStateWithLifecycle().value,
-                        onBackButtonClicked = {
-                            vm.onBackButtonPressed(isExitingVault = popUpToVault)
-                        },
-                        onTitleClick = {
-                            WidgetOverlayFragment.show(parentFragmentManager, space)
-                        },
-                        onSpaceIconClicked = vm::onSpaceIconClicked,
-                        onInviteMembersClicked = vm::onInviteMembersClicked,
-                        onEditInfo = vm::onEditInfo,
-                        onPin = vm::onPinChatAsWidget,
-                        onCopyLink = vm::onCopyChatLink,
-                        onMoveToBin = vm::onMoveToBin,
-                        onNotificationSettingChanged = vm::onNotificationSettingChanged,
-                        onSearchClick = vm::onSearchTriggered,
-                        onSpaceSettingsClicked = vm::onOpenSpaceSettings
-                    )
-                }
+                contentWindowInsets = WindowInsets(0.dp)
             ) { paddingValues ->
                 ChatScreenWrapper(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(paddingValues)
+                        .padding(bottom = paddingValues.calculateBottomPadding())
                         .navigationBarsPadding(),
                     vm = vm,
                     onAttachObjectClicked = { showGlobalSearchBottomSheet = true },
@@ -271,6 +249,31 @@ class ChatFragment : Fragment() {
                     resolveMemberAvatar = vm::resolveMemberAvatar
                 )
             }
+
+            // Floating top toolbar overlay — pills float above the messages so
+            // the message list can scroll behind them.
+            ChatTopToolbar(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .fillMaxWidth()
+                    .statusBarsPadding(),
+                header = vm.header.collectAsStateWithLifecycle().value,
+                onBackButtonClicked = {
+                    vm.onBackButtonPressed(isExitingVault = popUpToVault)
+                },
+                onTitleClick = {
+                    WidgetOverlayFragment.show(parentFragmentManager, space)
+                },
+                onSpaceIconClicked = vm::onSpaceIconClicked,
+                onInviteMembersClicked = vm::onInviteMembersClicked,
+                onEditInfo = vm::onEditInfo,
+                onPin = vm::onPinChatAsWidget,
+                onCopyLink = vm::onCopyChatLink,
+                onMoveToBin = vm::onMoveToBin,
+                onNotificationSettingChanged = vm::onNotificationSettingChanged,
+                onSearchClick = vm::onSearchTriggered,
+                onSpaceSettingsClicked = vm::onOpenSpaceSettings
+            )
             } // close Box
 
             if (showNotificationPermissionDialog) {

--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/MessageList.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/MessageList.kt
@@ -7,9 +7,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -68,11 +71,14 @@ fun Messages(
     Timber.d("DROID-2966 Messages composition")
     val scope = rememberCoroutineScope()
 
+    val topClearance = WindowInsets.statusBars.asPaddingValues().calculateTopPadding() +
+        ChatToolbarHeight + 8.dp
+
     LazyColumn(
         modifier = modifier,
         reverseLayout = true,
         state = scrollState,
-        contentPadding = PaddingValues(top = 90.dp),
+        contentPadding = PaddingValues(top = topClearance),
     ) {
         itemsIndexed(
             messages,

--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/MessageList.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/MessageList.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -71,6 +72,7 @@ fun Messages(
         modifier = modifier,
         reverseLayout = true,
         state = scrollState,
+        contentPadding = PaddingValues(top = 90.dp),
     ) {
         itemsIndexed(
             messages,

--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/Toolbars.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/Toolbars.kt
@@ -50,7 +50,7 @@ import com.anytypeio.anytype.feature_chats.R
 import com.anytypeio.anytype.feature_chats.presentation.ChatViewModel
 
 
-private val ChatToolbarHeight = 44.dp
+internal val ChatToolbarHeight = 44.dp
 private val ChatToolbarPillSize = 44.dp
 private val ChatToolbarHorizontalPadding = 16.dp
 private val ChatToolbarPillGap = 4.dp


### PR DESCRIPTION
## Summary

- Make the chat top toolbar a transparent floating overlay so messages render edge-to-edge and visibly scroll behind the pill buttons (back / title / `…`), instead of being pushed below an opaque reserved strip.
- Reserve 90.dp of top `contentPadding` on the messages `LazyColumn` so the topmost message at the scroll extreme rests below the floating pills (status bar + 44.dp toolbar + buffer) and stays interactive.

## Why

`ChatTopToolbar` was mounted in `Scaffold.topBar`, which forced a `paddingValues` top inset on `ChatScreenWrapper` and prevented messages from ever entering the toolbar area. The pills already use a 60% opacity `navigation_panel` background and 20.dp shadow, so they are designed to float over content. Without clearance at the top, the oldest message could land permanently behind the pills with no way to interact with it.

## Test plan

- [ ] Build: `./gradlew :app:assembleDebug`
- [ ] Open a chat with many messages; confirm no opaque strip behind the pills — wallpaper/background is continuous from status bar through the pill row
- [ ] Scroll up: older messages visibly scroll behind the pills (subtle 60% white tint)
- [ ] Scroll fully to the oldest message: it rests with breathing room below the pills and is fully tappable
- [ ] Scroll back to bottom: latest message sits above the chat box; chat box pinned correctly with IME / nav bar insets
- [ ] Tap each pill (back / title / `…`); dropdown menu still anchors to the `…` pill
- [ ] Open inline / overlay search — both still render correctly
- [ ] Verify mute icon, space icon, and chat-object icon variants still render inside the title pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)