### PR TITLE
Handle pending membership status in OptionMembership

### DIFF
--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/foundation/Foundation.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/foundation/Foundation.kt
@@ -167,7 +167,8 @@ fun OptionMembership(
                 }
             }
 
-            else -> {
+            Status.STATUS_PENDING,
+            Status.STATUS_PENDING_FINALIZATION -> {
                 Box(
                     modifier = Modifier
                         .align(Alignment.CenterEnd)
@@ -181,6 +182,9 @@ fun OptionMembership(
                     )
                 }
             }
+
+            Status.STATUS_UNKNOWN,
+            null -> Unit
         }
         Row(
             verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
## Summary
Updated the `OptionMembership` composable to explicitly handle pending membership statuses and unknown/null states, replacing a generic `else` clause with specific status cases.

## Key Changes
- Replaced the catch-all `else` branch with explicit handling for `Status.STATUS_PENDING` and `Status.STATUS_PENDING_FINALIZATION`
- Added explicit handling for `Status.STATUS_UNKNOWN` and `null` cases that render no UI (`Unit`)
- Maintains the same visual behavior (loading indicator box) for pending states while making the status handling more explicit and maintainable

## Implementation Details
- The pending status cases now display a centered loading indicator box with circular progress
- Unknown and null statuses are handled as no-op cases, improving code clarity over the previous catch-all pattern
- This change makes the membership status handling more exhaustive and easier to maintain as new statuses are added

https://claude.ai/code/session_01LNxEAPckDfUReEGukbwF3b