### PR TITLE
DROID-4496 Handle CancellationException in object type loading and update tests

### DIFF
--- a/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModel.kt
+++ b/feature-create-object/src/main/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModel.kt
@@ -21,6 +21,7 @@ import com.anytypeio.anytype.presentation.notifications.UploadSuccessSnackbar
 import com.anytypeio.anytype.presentation.notifications.toSnackbarVariant
 import com.anytypeio.anytype.presentation.objects.sortByTypePriority
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -128,8 +129,13 @@ class NewCreateObjectViewModel @Inject constructor(
                     }
                     Timber.d("Loaded ${types.size} object types with custom sort order")
                 }
+            } catch (e: CancellationException) {
+                // Normal coroutine cancellation (screen closed, retry()) — not an
+                // error. Re-throw so it is not logged/reported to Sentry and does
+                // not corrupt state.error.
+                throw e
             } catch (e: Exception) {
-                Timber.e(e, "Failed to load object types")
+                Timber.w(e, "Failed to load object types")
                 _state.update {
                     it.copy(
                         isLoading = false,

--- a/feature-create-object/src/test/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModelTest.kt
+++ b/feature-create-object/src/test/java/com/anytypeio/anytype/feature_create_object/presentation/NewCreateObjectViewModelTest.kt
@@ -25,6 +25,7 @@ import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
@@ -252,6 +253,34 @@ class NewCreateObjectViewModelTest {
             assertFalse(state.isLoading)
             assertTrue(state.objectTypes.isEmpty())
             assertTrue(state.filteredObjectTypes.isEmpty())
+        }
+    }
+
+    @Test
+    fun `retry should not surface a cancellation error from the cancelled observe job`() = runTest {
+        // Arrange
+        val pageType = StubObjectType(
+            uniqueKey = "ot-page",
+            name = "Page",
+            recommendedLayout = ObjectType.Layout.BASIC.code.toDouble()
+        )
+        storeOfObjectTypes.merge(listOf(pageType))
+        spaceViewContainer.setSpaceUxType(SpaceUxType.DATA)
+
+        val vm = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Act - Retry cancels the existing observe job (JobCancellationException)
+        // and starts a fresh one. The cancellation must not land in state.error.
+        vm.onAction(CreateObjectAction.Retry)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Assert
+        vm.state.test {
+            val state = awaitItem()
+            assertNull(state.error)
+            assertFalse(state.isLoading)
+            assertEquals(1, state.objectTypes.size)
         }
     }
 


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/open/blob/main/templates/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
