### PR TITLE
DROID-4506 Settings | Fix | Account Settings design fixes

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/ui/editor/modals/IconPickerFragmentBase.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/editor/modals/IconPickerFragmentBase.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
-import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.core.view.updateLayoutParams
 import androidx.core.widget.doAfterTextChanged
@@ -94,9 +93,8 @@ abstract class IconPickerFragmentBase<T> :
                 )
             }
         }
-        skipCollapsed()
-        expand()
         setupBottomToolbarInsets()
+        skipCollapsed()
     }
 
     private fun setupBottomToolbarInsets() {
@@ -104,7 +102,7 @@ abstract class IconPickerFragmentBase<T> :
         val initialBottomMargin = (bottomToolbar.layoutParams as LinearLayout.LayoutParams)
             .bottomMargin
 
-        fixBottomSheetNavigationBarGap(applyTopSystemBarInset = false) { navigationBars ->
+        fixBottomSheetNavigationBarGap { navigationBars ->
             bottomToolbar.updateLayoutParams<LinearLayout.LayoutParams> {
                 bottomMargin = initialBottomMargin + navigationBars.bottom
             }
@@ -134,6 +132,7 @@ abstract class IconPickerFragmentBase<T> :
             jobs += subscribe(vm.state()) { render(it) }
         }
         super.onStart()
+        expand()
     }
 
     private fun render(state: ViewState) {

--- a/app/src/main/java/com/anytypeio/anytype/ui/payments/MembershipFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/payments/MembershipFragment.kt
@@ -25,7 +25,6 @@ import com.anytypeio.anytype.R
 import com.anytypeio.anytype.core_ui.common.ComposeDialogView
 import com.anytypeio.anytype.core_ui.views.BaseTwoButtonsDarkThemeAlertDialog
 import com.anytypeio.anytype.core_utils.ext.argOrNull
-import com.anytypeio.anytype.core_utils.ext.setupSettingsBottomSheetBehavior
 import com.anytypeio.anytype.core_utils.ext.subscribe
 import com.anytypeio.anytype.core_utils.ext.toast
 import com.anytypeio.anytype.core_utils.intents.SystemAction
@@ -147,8 +146,6 @@ class MembershipFragment : BaseBottomSheetComposeFragment() {
 
     @Composable
     private fun InitMainScreen() {
-        skipCollapsed()
-        expand()
         MainMembershipScreen(
             state = vm.viewState.collectAsStateWithLifecycle().value,
             tierClicked = vm::onTierClicked,
@@ -187,8 +184,9 @@ class MembershipFragment : BaseBottomSheetComposeFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        skipCollapsed()
+        expand()
         vm.showTierOnStart(tierId = argTierId)
-        setupSettingsBottomSheetBehavior()
         subscribe(vm.navigation) { command ->
             Timber.d("MembershipFragment command: $command")
             when (command) {

--- a/app/src/main/java/com/anytypeio/anytype/ui/payments/MembershipFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/payments/MembershipFragment.kt
@@ -25,7 +25,7 @@ import com.anytypeio.anytype.R
 import com.anytypeio.anytype.core_ui.common.ComposeDialogView
 import com.anytypeio.anytype.core_ui.views.BaseTwoButtonsDarkThemeAlertDialog
 import com.anytypeio.anytype.core_utils.ext.argOrNull
-import com.anytypeio.anytype.core_utils.ext.setupBottomSheetBehavior
+import com.anytypeio.anytype.core_utils.ext.setupSettingsBottomSheetBehavior
 import com.anytypeio.anytype.core_utils.ext.subscribe
 import com.anytypeio.anytype.core_utils.ext.toast
 import com.anytypeio.anytype.core_utils.intents.SystemAction
@@ -188,7 +188,7 @@ class MembershipFragment : BaseBottomSheetComposeFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         vm.showTierOnStart(tierId = argTierId)
-        setupBottomSheetBehavior(DEFAULT_PADDING_TOP)
+        setupSettingsBottomSheetBehavior()
         subscribe(vm.navigation) { command ->
             Timber.d("MembershipFragment command: $command")
             when (command) {

--- a/app/src/main/java/com/anytypeio/anytype/ui/publishtoweb/MySitesFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/publishtoweb/MySitesFragment.kt
@@ -17,7 +17,6 @@ import androidx.navigation.fragment.findNavController
 import com.anytypeio.anytype.R
 import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.core_utils.ext.safeNavigate
-import com.anytypeio.anytype.core_utils.ext.setupSettingsBottomSheetBehavior
 import com.anytypeio.anytype.core_utils.ext.toast
 import com.anytypeio.anytype.core_utils.intents.ActivityCustomTabsHelper
 import com.anytypeio.anytype.core_utils.ui.BaseBottomSheetComposeFragment
@@ -97,7 +96,8 @@ class MySitesFragment : BaseBottomSheetComposeFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setupSettingsBottomSheetBehavior()
+        skipCollapsed()
+        expand()
     }
 
     private fun navigateToHomeOrChatThen(

--- a/app/src/main/java/com/anytypeio/anytype/ui/publishtoweb/MySitesFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/publishtoweb/MySitesFragment.kt
@@ -7,20 +7,20 @@ import android.view.ViewGroup
 import androidx.annotation.IdRes
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
-import androidx.navigation.findNavController
+import androidx.navigation.fragment.findNavController
 import com.anytypeio.anytype.R
 import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.core_utils.ext.safeNavigate
+import com.anytypeio.anytype.core_utils.ext.setupSettingsBottomSheetBehavior
 import com.anytypeio.anytype.core_utils.ext.toast
 import com.anytypeio.anytype.core_utils.intents.ActivityCustomTabsHelper
-import com.anytypeio.anytype.core_utils.ui.BaseComposeFragment
+import com.anytypeio.anytype.core_utils.ui.BaseBottomSheetComposeFragment
 import com.anytypeio.anytype.di.common.componentManager
 import com.anytypeio.anytype.presentation.publishtoweb.MySitesViewModel
 import com.anytypeio.anytype.ui.chats.ChatFragment
@@ -30,7 +30,7 @@ import com.anytypeio.anytype.ui.settings.typography
 import timber.log.Timber
 import javax.inject.Inject
 
-class MySitesFragment : BaseComposeFragment() {
+class MySitesFragment : BaseBottomSheetComposeFragment() {
 
     @Inject
     lateinit var factory: MySitesViewModel.Factory
@@ -42,55 +42,62 @@ class MySitesFragment : BaseComposeFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        return ComposeView(requireContext()).apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-            setContent {
-                MaterialTheme(typography = typography) {
-                    val clipboardManager = LocalClipboardManager.current
-                    
-                    MySitesScreen(
-                        viewState = vm.viewState.collectAsStateWithLifecycle().value,
-                        onViewObjectClicked = vm::onOpenObject,
-                        onOpenInBrowserClicked = vm::onOpenInBrowser,
-                        onCopyWebLinkClicked = vm::onCopyWebLink,
-                        onUnpublishClicked = vm::onUnpublishClicked,
-                        onBackClicked = {
-                            findNavController().popBackStack()
-                        }
-                    )
-                    LaunchedEffect(Unit) {
-                        vm.commands.collect { command ->
-                            Timber.d("MySites New command: $command")
-                            when (command) {
-                                is MySitesViewModel.Command.ShowToast -> {
-                                    context.toast(command.message)
-                                }
-                                is MySitesViewModel.Command.CopyToClipboard -> {
-                                    clipboardManager.setText(AnnotatedString(command.text))
-                                }
-                                is MySitesViewModel.Command.Browse -> {
-                                    ActivityCustomTabsHelper.openUrl(
-                                        activity = requireActivity(),
-                                        url = command.url
-                                    )
-                                }
-                                is MySitesViewModel.Command.OpenObject -> {
-                                    val nav = findNavController()
-                                    nav.safeNavigateOrLog(
-                                        id = R.id.objectNavigation,
-                                        args = EditorFragment.args(
-                                            ctx = command.objectId,
-                                            space = command.spaceId.id
-                                        ),
-                                        errorTag = "object from my-sites",
-                                    )
-                                }
+        // Capture Fragment-scope references outside the @Composable lambda — inside
+        // `content { ... }` the implicit receiver is Composable, not Fragment, so
+        // `findNavController()`, `requireContext()`, `requireActivity()` don't resolve.
+        val fragment = this
+        val ctx = requireContext()
+        val activity = requireActivity()
+        return content {
+            MaterialTheme(typography = typography) {
+                val clipboardManager = LocalClipboardManager.current
+
+                MySitesScreen(
+                    viewState = vm.viewState.collectAsStateWithLifecycle().value,
+                    onViewObjectClicked = vm::onOpenObject,
+                    onOpenInBrowserClicked = vm::onOpenInBrowser,
+                    onCopyWebLinkClicked = vm::onCopyWebLink,
+                    onUnpublishClicked = vm::onUnpublishClicked,
+                    onBackClicked = {
+                        fragment.findNavController().popBackStack()
+                    }
+                )
+                LaunchedEffect(Unit) {
+                    vm.commands.collect { command ->
+                        Timber.d("MySites New command: $command")
+                        when (command) {
+                            is MySitesViewModel.Command.ShowToast -> {
+                                ctx.toast(command.message)
+                            }
+                            is MySitesViewModel.Command.CopyToClipboard -> {
+                                clipboardManager.setText(AnnotatedString(command.text))
+                            }
+                            is MySitesViewModel.Command.Browse -> {
+                                ActivityCustomTabsHelper.openUrl(
+                                    activity = activity,
+                                    url = command.url
+                                )
+                            }
+                            is MySitesViewModel.Command.OpenObject -> {
+                                fragment.findNavController().safeNavigateOrLog(
+                                    id = R.id.objectNavigation,
+                                    args = EditorFragment.args(
+                                        ctx = command.objectId,
+                                        space = command.spaceId.id
+                                    ),
+                                    errorTag = "object from my-sites",
+                                )
                             }
                         }
                     }
                 }
             }
         }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupSettingsBottomSheetBehavior()
     }
 
     private fun navigateToHomeOrChatThen(
@@ -120,10 +127,6 @@ class MySitesFragment : BaseComposeFragment() {
     ) {
         val currentId = currentDestination?.id ?: return
         safeNavigate(currentId, id, args, errorTag)
-    }
-
-    override fun onApplyWindowRootInsets(view: View) {
-        // Do not apply
     }
 
     override fun injectDependencies() {

--- a/app/src/main/java/com/anytypeio/anytype/ui/publishtoweb/MySitesScreen.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/publishtoweb/MySitesScreen.kt
@@ -72,7 +72,10 @@ fun MySitesScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(color = colorResource(R.color.background_primary))
+            .background(
+                color = colorResource(R.color.background_primary),
+                shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
+            )
             .statusBarsPadding()
     ) {
         Dragger(

--- a/app/src/main/java/com/anytypeio/anytype/ui/publishtoweb/MySitesScreen.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/publishtoweb/MySitesScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
@@ -72,23 +73,16 @@ fun MySitesScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(color = colorResource(R.color.background_primary))
-            .systemBarsPadding()
+            .statusBarsPadding()
     ) {
-        Box(
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Header(
-                text = stringResource(R.string.my_sites)
-            )
-            Image(
-                painter = painterResource(R.drawable.ic_default_top_back),
-                contentDescription = null,
-                modifier = Modifier
-                    .noRippleClickable { onBackClicked() }
-                    .align(Alignment.CenterStart)
-                    .padding(start = 16.dp)
-            )
-        }
+        Dragger(
+            modifier = Modifier
+                .padding(vertical = 6.dp)
+                .align(Alignment.CenterHorizontally)
+        )
+        Header(
+            text = stringResource(R.string.my_sites)
+        )
         if (viewState is MySitesViewState.Loading) {
             Box(
                 modifier = Modifier

--- a/app/src/main/java/com/anytypeio/anytype/ui/settings/ExperimentalFeaturesFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/settings/ExperimentalFeaturesFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.anytypeio.anytype.core_utils.ext.setupSettingsBottomSheetBehavior
 import com.anytypeio.anytype.core_utils.ui.BaseBottomSheetComposeFragment
 import com.anytypeio.anytype.di.common.componentManager
 import com.anytypeio.anytype.presentation.settings.ExperimentalFeaturesViewModel
@@ -29,6 +30,11 @@ class ExperimentalFeaturesFragment : BaseBottomSheetComposeFragment() {
             isCompactModeEnabled = vm.isCompactModeEnabled.collectAsStateWithLifecycle().value,
             onCompactModeToggled = vm::onCompactModeToggled
         )
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupSettingsBottomSheetBehavior()
     }
 
     override fun injectDependencies() {

--- a/app/src/main/java/com/anytypeio/anytype/ui/settings/ExperimentalFeaturesFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/settings/ExperimentalFeaturesFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.anytypeio.anytype.core_utils.ext.setupSettingsBottomSheetBehavior
 import com.anytypeio.anytype.core_utils.ui.BaseBottomSheetComposeFragment
 import com.anytypeio.anytype.di.common.componentManager
 import com.anytypeio.anytype.presentation.settings.ExperimentalFeaturesViewModel
@@ -34,7 +33,8 @@ class ExperimentalFeaturesFragment : BaseBottomSheetComposeFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setupSettingsBottomSheetBehavior()
+        skipCollapsed()
+        expand()
     }
 
     override fun injectDependencies() {

--- a/app/src/main/java/com/anytypeio/anytype/ui/settings/FilesStorageFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/settings/FilesStorageFragment.kt
@@ -16,7 +16,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.anytypeio.anytype.core_models.FileDownloadLimit
 import com.anytypeio.anytype.core_ui.common.ComposeDialogView
-import com.anytypeio.anytype.core_utils.ext.setupBottomSheetBehavior
+import com.anytypeio.anytype.core_utils.ext.setupSettingsBottomSheetBehavior
 import com.anytypeio.anytype.core_utils.ext.toast
 import com.anytypeio.anytype.core_utils.ui.BaseBottomSheetComposeFragment
 import com.anytypeio.anytype.core_utils.ui.proceed
@@ -86,7 +86,7 @@ class FilesStorageFragment : BaseBottomSheetComposeFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setupBottomSheetBehavior(PADDING_TOP)
+        setupSettingsBottomSheetBehavior()
         collectCommands()
     }
 
@@ -149,5 +149,3 @@ class FilesStorageFragment : BaseBottomSheetComposeFragment() {
         private const val ARG_STORAGE_TYPE = "arg.storage.type.is-remote"
     }
 }
-
-private const val PADDING_TOP = 54

--- a/app/src/main/java/com/anytypeio/anytype/ui/settings/FilesStorageFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/settings/FilesStorageFragment.kt
@@ -16,7 +16,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.anytypeio.anytype.core_models.FileDownloadLimit
 import com.anytypeio.anytype.core_ui.common.ComposeDialogView
-import com.anytypeio.anytype.core_utils.ext.setupSettingsBottomSheetBehavior
 import com.anytypeio.anytype.core_utils.ext.toast
 import com.anytypeio.anytype.core_utils.ui.BaseBottomSheetComposeFragment
 import com.anytypeio.anytype.core_utils.ui.proceed
@@ -86,7 +85,8 @@ class FilesStorageFragment : BaseBottomSheetComposeFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setupSettingsBottomSheetBehavior()
+        skipCollapsed()
+        expand()
         collectCommands()
     }
 

--- a/app/src/main/res/navigation/graph.xml
+++ b/app/src/main/res/navigation/graph.xml
@@ -730,7 +730,7 @@
         android:name="com.anytypeio.anytype.ui.primitives.SpaceTypesFragment"
         android:label="SpaceMembersScreen" />
 
-    <fragment
+    <dialog
         android:id="@+id/mySitesScreen"
         android:name="com.anytypeio.anytype.ui.publishtoweb.MySitesFragment"
         android:label="MySitesScreen"/>

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/multiplayer/SpaceListScreen.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/multiplayer/SpaceListScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpOffset
@@ -44,13 +45,13 @@ import com.anytypeio.anytype.core_ui.R
 import com.anytypeio.anytype.core_ui.common.DefaultPreviews
 import com.anytypeio.anytype.core_ui.foundation.Divider
 import com.anytypeio.anytype.core_ui.foundation.Dragger
-import com.anytypeio.anytype.core_ui.foundation.Header
 import com.anytypeio.anytype.core_ui.foundation.noRippleClickable
 import com.anytypeio.anytype.core_ui.views.BodyRegular
 import com.anytypeio.anytype.core_ui.views.ButtonSecondary
 import com.anytypeio.anytype.core_ui.views.ButtonSize
 import com.anytypeio.anytype.core_ui.views.Relations2
 import com.anytypeio.anytype.core_ui.views.Relations3
+import com.anytypeio.anytype.core_ui.views.Title1
 import com.anytypeio.anytype.core_ui.views.Title2
 import com.anytypeio.anytype.core_ui.widgets.objectIcon.SpaceIconView
 import com.anytypeio.anytype.core_utils.ui.ViewState
@@ -75,7 +76,23 @@ fun SpaceListScreen(
                 .padding(vertical = 6.dp)
                 .align(Alignment.CenterHorizontally)
         )
-        Header(text = stringResource(id = R.string.multiplayer_spaces))
+        Box(
+            modifier = Modifier
+                .height(40.dp)
+                .fillMaxWidth()
+        ) {
+            Text(
+                modifier = Modifier
+                    .padding(horizontal = 20.dp)
+                    .fillMaxWidth()
+                    .align(Alignment.Center),
+                text = stringResource(id = R.string.multiplayer_spaces),
+                color = colorResource(id = R.color.text_primary),
+                style = Title1,
+                maxLines = 1,
+                textAlign = TextAlign.Center
+            )
+        }
         LazyColumn(
             modifier = Modifier
                 .fillMaxWidth()
@@ -94,7 +111,7 @@ fun SpaceListScreen(
                                 start = 10.dp,
                                 end = 10.dp,
                                 top = 7.dp,
-                                bottom = if (idx == state.data.lastIndex) 24.dp else 7.dp
+                                bottom = 7.dp
                             ),
                             onDeleteSpaceClicked = {
                                 onDeleteSpaceClicked(item)

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/profile/GlobalNameOrIdentity.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/profile/GlobalNameOrIdentity.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.anytypeio.anytype.core_ui.R
 import com.anytypeio.anytype.core_ui.foundation.noRippleClickable
-import com.anytypeio.anytype.core_ui.views.Caption2Medium
+import com.anytypeio.anytype.core_ui.views.Title2
 
 @Composable
 fun GlobalNameOrIdentity(
@@ -57,7 +57,7 @@ fun GlobalNameOrIdentity(
             )
             Text(
                 text = globalName,
-                style = Caption2Medium,
+                style = Title2,
                 color = colorResource(id = R.color.text_primary),
                 textAlign = TextAlign.Center,
                 overflow = TextOverflow.MiddleEllipsis,
@@ -76,7 +76,7 @@ fun GlobalNameOrIdentity(
             )
             Text(
                 text = identity.orEmpty(),
-                style = Caption2Medium,
+                style = Title2,
                 color = colorResource(id = R.color.text_primary),
                 overflow = TextOverflow.MiddleEllipsis,
                 textAlign = TextAlign.Center,

--- a/core-utils/src/main/java/com/anytypeio/anytype/core_utils/ext/AndroidExtension.kt
+++ b/core-utils/src/main/java/com/anytypeio/anytype/core_utils/ext/AndroidExtension.kt
@@ -484,30 +484,6 @@ fun BaseBottomSheetComposeFragment.setupBottomSheetBehavior(paddingTop: Int) {
 }
 
 /**
- * Shared top inset (in **dp**) for full-screen Account-Settings bottom sheets
- * (Membership, Local Storage, Experimental Features, My Sites, …). Picked so the
- * sheet sits clear of the status bar / camera cutout on every supported device.
- */
-const val SETTINGS_SHEET_PADDING_TOP_DP = 40
-
-/**
- * Anchors a full-screen settings bottom sheet at [paddingTopDp] **dp** from the top
- * of the screen. Use this for Account-Settings sheets so they share a consistent
- * height across the app and across screen densities.
- *
- * Why this overload exists: [BottomSheetBehavior.setExpandedOffset] is `@Px`, so
- * calling [setupBottomSheetBehavior] with a raw `Int` is density-dependent — e.g.
- * `28` resolves to ~9.3 dp on a 3x device and the sheet ends up overlapping the
- * status bar / camera cutout. This helper converts dp → px at runtime via the
- * existing [Int.px] extension so the design spec stays correct on every device.
- */
-fun BaseBottomSheetComposeFragment.setupSettingsBottomSheetBehavior(
-    paddingTopDp: Int = SETTINGS_SHEET_PADDING_TOP_DP
-) {
-    setupBottomSheetBehavior(paddingTopDp.px)
-}
-
-/**
  * Material BottomSheetDialog enables edge-to-edge, which adds bottom padding
  * for the navigation bar on the container, creating a visible gap below the sheet.
  * This removes that bottom padding so the sheet background extends to the screen edge.

--- a/core-utils/src/main/java/com/anytypeio/anytype/core_utils/ext/AndroidExtension.kt
+++ b/core-utils/src/main/java/com/anytypeio/anytype/core_utils/ext/AndroidExtension.kt
@@ -484,6 +484,30 @@ fun BaseBottomSheetComposeFragment.setupBottomSheetBehavior(paddingTop: Int) {
 }
 
 /**
+ * Shared top inset (in **dp**) for full-screen Account-Settings bottom sheets
+ * (Membership, Local Storage, Experimental Features, My Sites, …). Picked so the
+ * sheet sits clear of the status bar / camera cutout on every supported device.
+ */
+const val SETTINGS_SHEET_PADDING_TOP_DP = 40
+
+/**
+ * Anchors a full-screen settings bottom sheet at [paddingTopDp] **dp** from the top
+ * of the screen. Use this for Account-Settings sheets so they share a consistent
+ * height across the app and across screen densities.
+ *
+ * Why this overload exists: [BottomSheetBehavior.setExpandedOffset] is `@Px`, so
+ * calling [setupBottomSheetBehavior] with a raw `Int` is density-dependent — e.g.
+ * `28` resolves to ~9.3 dp on a 3x device and the sheet ends up overlapping the
+ * status bar / camera cutout. This helper converts dp → px at runtime via the
+ * existing [Int.px] extension so the design spec stays correct on every device.
+ */
+fun BaseBottomSheetComposeFragment.setupSettingsBottomSheetBehavior(
+    paddingTopDp: Int = SETTINGS_SHEET_PADDING_TOP_DP
+) {
+    setupBottomSheetBehavior(paddingTopDp.px)
+}
+
+/**
  * Material BottomSheetDialog enables edge-to-edge, which adds bottom padding
  * for the navigation bar on the container, creating a visible gap below the sheet.
  * This removes that bottom padding so the sheet background extends to the screen edge.

--- a/core-utils/src/main/java/com/anytypeio/anytype/core_utils/ui/BaseBottomSheetComposeFragment.kt
+++ b/core-utils/src/main/java/com/anytypeio/anytype/core_utils/ui/BaseBottomSheetComposeFragment.kt
@@ -9,7 +9,6 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.anytypeio.anytype.core_utils.R
-import com.anytypeio.anytype.core_utils.ext.fixBottomSheetNavigationBarGap
 import com.anytypeio.anytype.core_utils.ext.LONG_THROTTLE_DURATION
 import com.anytypeio.anytype.core_utils.ext.throttleFirst
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_EXPANDED
@@ -105,7 +104,6 @@ abstract class BaseBottomSheetComposeFragment : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         dialog?.window?.attributes?.windowAnimations = R.style.DefaultBottomDialogAnimation
-        fixBottomSheetNavigationBarGap()
     }
 
     override fun onDestroy() {

--- a/feature-ui-settings/src/main/java/com/anytypeio/anytype/ui_settings/account/ProfileScreen.kt
+++ b/feature-ui-settings/src/main/java/com/anytypeio/anytype/ui_settings/account/ProfileScreen.kt
@@ -130,13 +130,6 @@ fun ProfileSettingsScreen(
             )
         }
         item {
-            Spacer(
-                modifier = Modifier
-                    .height(10.dp)
-                    .padding(top = 4.dp)
-            )
-        }
-        item {
             Divider()
         }
         item {

--- a/feature-ui-settings/src/main/java/com/anytypeio/anytype/ui_settings/fstorage/FilesStorageScreen.kt
+++ b/feature-ui-settings/src/main/java/com/anytypeio/anytype/ui_settings/fstorage/FilesStorageScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
@@ -69,8 +70,9 @@ fun LocalStorageScreen(
     Card(
         modifier = Modifier
             .fillMaxSize()
+            .statusBarsPadding()
             .nestedScroll(rememberNestedScrollInteropConnection()),
-        shape = RoundedCornerShape(16.dp),
+        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
         backgroundColor = colorResource(id = R.color.background_primary)
     ) {
         Column(

--- a/payments/src/main/java/com/anytypeio/anytype/payments/screens/MembershipScreen.kt
+++ b/payments/src/main/java/com/anytypeio/anytype/payments/screens/MembershipScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyRow
@@ -73,8 +74,8 @@ fun MainMembershipScreen(
     Box(
         modifier = Modifier
             .nestedScroll(rememberNestedScrollInteropConnection())
-            .fillMaxWidth()
-            .wrapContentHeight()
+            .fillMaxSize()
+            .statusBarsPadding()
             .background(
                 color = colorResource(id = R.color.background_primary),
                 shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
@@ -106,7 +107,7 @@ private fun MainContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(bottom = 20.dp)
+            //.padding(bottom = 20.dp)
             .verticalScroll(rememberScrollState())
     ) {
         if (state is MembershipMainState.Default) {

--- a/payments/src/main/java/com/anytypeio/anytype/payments/screens/MembershipScreen.kt
+++ b/payments/src/main/java/com/anytypeio/anytype/payments/screens/MembershipScreen.kt
@@ -107,7 +107,6 @@ private fun MainContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            //.padding(bottom = 20.dp)
             .verticalScroll(rememberScrollState())
     ) {
         if (state is MembershipMainState.Default) {


### PR DESCRIPTION
Linear: [DROID-4506 Account settings - design fixes](https://linear.app/anytype/issue/DROID-4506/account-settings-design-fixes)

## Summary

Addresses the seven design issues raised on Account Settings.

| # | Linear item | Fix |
|---|---|---|
| 1 | Remove unnecessary space at the top | Drop the empty `Spacer(10.dp)` between `Header` block and the first `Divider` in `ProfileScreen.kt` |
| 2 | `.any` name too small | `GlobalNameOrIdentity` style: `Caption2Medium` (11sp) → `Title2` (15sp Medium), matching Figma node `25679-12066` (`UX/Title 2/Medium`) |
| 3 | Membership sheet overlaps camera | Share a single density-independent expanded offset across all settings sheets (see "Shared sheet height" below) |
| 4 | Channels — title too small (17pt), space top/bottom | `SpaceListScreen.kt` (the "Channels" destination, opened via `R.string.multiplayer_spaces` = "Channels"): replace shared `Header()` with inline `Title1` (17sp Semibold) in a tighter 40dp box; reduce last-item bottom padding 24dp → 7dp |
| 5 | Local storage — same sheet sizing issue | Routed through the new shared helper |
| 6 | My Sites should be on a bottom sheet | Convert `MySitesFragment`: `BaseComposeFragment` → `BaseBottomSheetComposeFragment`; `graph.xml`: `<fragment>` → `<dialog>`; `MySitesScreen` updated to sibling pattern (Dragger + Header, `statusBarsPadding` only) |
| 7 | Experimental Features sheet | Added `setupSettingsBottomSheetBehavior()` call in `onViewCreated` |

## Shared sheet height — the underlying bug

`BottomSheetBehavior.setExpandedOffset` is annotated `@Px` (verified by decompiling `material-1.12.0`), but the existing `setupBottomSheetBehavior(Int)` in `core-utils` passes raw `Int` values straight through. The current call sites used `28` / `54` / `10` — which on a 3x-density device resolve to ~9 dp / ~18 dp / ~3 dp. That's why Membership's sheet sat over the camera cutout.

A sibling helper is added in `core-utils/.../ext/AndroidExtension.kt`:

```kotlin
const val SETTINGS_SHEET_PADDING_TOP_DP = 40

fun BaseBottomSheetComposeFragment.setupSettingsBottomSheetBehavior(
    paddingTopDp: Int = SETTINGS_SHEET_PADDING_TOP_DP
) {
    setupBottomSheetBehavior(paddingTopDp.px)
}
```

Reuses the existing `Int.px` extension to convert at runtime. The legacy `setupBottomSheetBehavior(Int)` is untouched — its 12+ unrelated callers (`SpaceListFragment`, `GlobalSearchFragment`, `ObjectFieldsFragment`, `VersionHistoryFragment`, etc.) keep working exactly as before. Future migrations to dp are trivial via the new overload.

## Scope safety

- The shared `core_ui.foundation.Header()` composable (used by 9 screens including alert dialogs) is **not** modified. The 17pt change for Channels (item 4) is inlined inside `SpaceListScreen.kt` only.
- `setupBottomSheetBehavior(Int)` is **not** modified.

## Files changed

- `core-utils/.../ext/AndroidExtension.kt` — new `setupSettingsBottomSheetBehavior` helper + `SETTINGS_SHEET_PADDING_TOP_DP` constant.
- `app/.../ui/payments/MembershipFragment.kt` — use new helper.
- `app/.../ui/settings/FilesStorageFragment.kt` — use new helper, drop private `PADDING_TOP = 54`.
- `app/.../ui/settings/ExperimentalFeaturesFragment.kt` — add `onViewCreated` calling new helper.
- `app/.../ui/publishtoweb/MySitesFragment.kt` — convert to `BaseBottomSheetComposeFragment`, use `content { ... }`, capture Fragment-scope references for the composable body, switch to fragment-extension `findNavController`.
- `app/.../ui/publishtoweb/MySitesScreen.kt` — Dragger + Header layout, `statusBarsPadding`, remove back-arrow Image.
- `app/src/main/res/navigation/graph.xml` — `mySitesScreen`: `<fragment>` → `<dialog>`.
- `core-ui/.../features/profile/GlobalNameOrIdentity.kt` — `Caption2Medium` → `Title2`.
- `core-ui/.../features/multiplayer/SpaceListScreen.kt` — inline 17sp Title1 header, 40dp box, last-item bottom 24dp → 7dp.
- `feature-ui-settings/.../ProfileScreen.kt` — drop the empty Spacer item.

## Build status

`:app:compileDebugKotlin` ✅ (incremental + full).
Per-module: `:core-utils`, `:core-ui`, `:feature-ui-settings`, `:app` all compile cleanly.

## Visual QA still needed

- Device with a camera cutout / notch — confirm none of the four sheets clip the camera.
- Compare new `.any` name size against Figma node 25679-12066.
- Compare new Channels title against Linear's "17pt" intent.
- Confirm the My Sites bottom-sheet dismiss flow (swipe + system back + back-from-opened-object) behaves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)