### PR TITLE
DROID-4514 Integrate middleware v0.50.6

### DIFF
--- a/core-models/src/main/java/com/anytypeio/anytype/core_models/multiplayer/Multiplayer.kt
+++ b/core-models/src/main/java/com/anytypeio/anytype/core_models/multiplayer/Multiplayer.kt
@@ -37,18 +37,19 @@ enum class SpaceMemberPermissions(
     READER(0),
     WRITER(1),
     OWNER(2),
-    NO_PERMISSIONS(3);
+    NO_PERMISSIONS(3),
+    ADMIN(4);
 
     fun isOwner(): Boolean {
         return this == OWNER
     }
 
     fun isOwnerOrEditor(): Boolean {
-        return this == OWNER || this == WRITER
+        return this == OWNER || this == WRITER || this == ADMIN
     }
 
     fun isAtLeastReader(): Boolean {
-        return this == OWNER || this == WRITER || this == READER
+        return this == OWNER || this == WRITER || this == READER || this == ADMIN
     }
 }
 

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/multiplayer/SpaceListScreen.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/multiplayer/SpaceListScreen.kt
@@ -233,7 +233,8 @@ fun SpaceListCardItem(
             text = when(permissions) {
                 SpaceMemberPermissions.OWNER -> stringResource(id = R.string.multiplayer_owner)
                 SpaceMemberPermissions.READER -> stringResource(id = R.string.multiplayer_can_view)
-                SpaceMemberPermissions.WRITER -> stringResource(id = R.string.multiplayer_can_edit)
+                SpaceMemberPermissions.WRITER,
+                SpaceMemberPermissions.ADMIN -> stringResource(id = R.string.multiplayer_can_edit)
                 SpaceMemberPermissions.NO_PERMISSIONS -> EMPTY_STRING_VALUE
             },
             style = Relations2,

--- a/domain/src/main/java/com/anytypeio/anytype/domain/invite/GetCurrentInviteAccessLevel.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/invite/GetCurrentInviteAccessLevel.kt
@@ -77,7 +77,9 @@ class GetCurrentInviteAccessLevel @Inject constructor(
             InviteType.WITHOUT_APPROVE -> {
                 // WITHOUT_APPROVE type - check permissions to determine editor vs viewer
                 when (spaceInviteLink.permissions) {
-                    SpaceMemberPermissions.OWNER, SpaceMemberPermissions.WRITER -> SpaceInviteLinkAccessLevel.EditorAccess(
+                    SpaceMemberPermissions.OWNER,
+                    SpaceMemberPermissions.WRITER,
+                    SpaceMemberPermissions.ADMIN -> SpaceInviteLinkAccessLevel.EditorAccess(
                         spaceInviteLink.scheme
                     )
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-middlewareVersion = "v0.50.4"
+middlewareVersion = "v0.50.6"
 kotlinVersion = "2.2.10"
 kspVersion = "2.3.4"
 

--- a/middleware/src/main/java/com/anytypeio/anytype/middleware/mappers/ToCoreModelMappers.kt
+++ b/middleware/src/main/java/com/anytypeio/anytype/middleware/mappers/ToCoreModelMappers.kt
@@ -990,6 +990,7 @@ fun MParticipantPermission.toCore(): SpaceMemberPermissions {
         ParticipantPermissions.Writer -> SpaceMemberPermissions.WRITER
         ParticipantPermissions.Owner -> SpaceMemberPermissions.OWNER
         ParticipantPermissions.NoPermissions -> SpaceMemberPermissions.NO_PERMISSIONS
+        ParticipantPermissions.Admin -> SpaceMemberPermissions.ADMIN
     }
 }
 

--- a/middleware/src/main/java/com/anytypeio/anytype/middleware/mappers/ToMiddlewareModelMappers.kt
+++ b/middleware/src/main/java/com/anytypeio/anytype/middleware/mappers/ToMiddlewareModelMappers.kt
@@ -563,6 +563,7 @@ fun SpaceMemberPermissions.toMw() : MParticipantPermission = when(this) {
     SpaceMemberPermissions.WRITER -> MParticipantPermission.Writer
     SpaceMemberPermissions.OWNER -> MParticipantPermission.Owner
     SpaceMemberPermissions.NO_PERMISSIONS -> MParticipantPermission.NoPermissions
+    SpaceMemberPermissions.ADMIN -> MParticipantPermission.Admin
 }
 
 fun NameServiceNameType.toMw(): MNameServiceNameType = when (this) {

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/analytics/AnalyticSpaceHelperDelegate.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/analytics/AnalyticSpaceHelperDelegate.kt
@@ -43,6 +43,7 @@ class DefaultAnalyticsParamsProvider @Inject constructor(
                 SpaceMemberPermissions.WRITER -> "Writer"
                 SpaceMemberPermissions.OWNER -> "Owner"
                 SpaceMemberPermissions.NO_PERMISSIONS -> "NoPermissions"
+                SpaceMemberPermissions.ADMIN -> "Admin"
                 null -> EMPTY_STRING_VALUE
             },
             spaceType = when (spaceType) {

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomeScreenViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomeScreenViewModel.kt
@@ -889,6 +889,7 @@ class HomeScreenViewModel(
                     userPermissions.value = permission
                     when (permission) {
                         SpaceMemberPermissions.WRITER,
+                        SpaceMemberPermissions.ADMIN,
                         SpaceMemberPermissions.OWNER -> {
                             if (mode.value == InteractionMode.ReadOnly) {
                                 mode.value = InteractionMode.Default

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/multiplayer/ShareSpaceViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/multiplayer/ShareSpaceViewModel.kt
@@ -1064,7 +1064,8 @@ private fun ObjectWrapper.SpaceMember.getParticipantInfo(
             // Status text shows permission level for active participants
             val statusText = when (permissions) {
                 SpaceMemberPermissions.READER -> stringResourceProvider.getMultiplayerViewer()
-                SpaceMemberPermissions.WRITER -> stringResourceProvider.getMultiplayerEditor()
+                SpaceMemberPermissions.WRITER,
+                SpaceMemberPermissions.ADMIN -> stringResourceProvider.getMultiplayerEditor()
                 SpaceMemberPermissions.OWNER -> stringResourceProvider.getMultiplayerOwner()
                 SpaceMemberPermissions.NO_PERMISSIONS -> stringResourceProvider.getMultiplayerNoPermissions()
                 null -> null

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/multiplayer/ShareSpaceViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/multiplayer/ShareSpaceViewModel.kt
@@ -1089,9 +1089,12 @@ private fun ObjectWrapper.SpaceMember.getParticipantInfo(
                     add(
                         ContextAction(
                             title = stringResourceProvider.getMultiplayerEditor(),
-                            isSelected = permissions == SpaceMemberPermissions.WRITER,
+                            isSelected = permissions == SpaceMemberPermissions.WRITER ||
+                                    permissions == SpaceMemberPermissions.ADMIN,
                             isDestructive = false,
-                            isEnabled = canChangeReaderToWriter || permissions == SpaceMemberPermissions.WRITER,
+                            isEnabled = canChangeReaderToWriter ||
+                                    permissions == SpaceMemberPermissions.WRITER ||
+                                    permissions == SpaceMemberPermissions.ADMIN,
                             actionType = ActionType.CAN_EDIT
                         )
                     )

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/navigation/NavPanelState.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/navigation/NavPanelState.kt
@@ -51,6 +51,7 @@ sealed class NavPanelState {
         ): NavPanelState {
             val createEnabled = when (permission) {
                 SpaceMemberPermissions.WRITER,
+                SpaceMemberPermissions.ADMIN,
                 SpaceMemberPermissions.OWNER -> true
                 else -> false
             }
@@ -62,6 +63,7 @@ sealed class NavPanelState {
                         isActive = spaceAccess != SpaceAccessType.DEFAULT
                     )
                 SpaceMemberPermissions.WRITER,
+                SpaceMemberPermissions.ADMIN,
                 SpaceMemberPermissions.READER,
                 SpaceMemberPermissions.NO_PERMISSIONS ->
                     defaultLeft(

--- a/protocol/src/main/proto/models.proto
+++ b/protocol/src/main/proto/models.proto
@@ -1069,6 +1069,7 @@ enum ParticipantPermissions {
     Writer = 1;
     Owner = 2;
     NoPermissions = 3;
+    Admin = 4;
 }
 
 enum InviteType {


### PR DESCRIPTION
## Summary
Integrates Go middleware **v0.50.6** and updates generated protobuf definitions.

The new proto adds a `ParticipantPermissions.Admin(4)` value. This PR maps it to a full `ADMIN` value in the core `SpaceMemberPermissions` enum and handles it consistently across the app:

- **Core model**: add `ADMIN(4)`; treated as editor-capable in `isOwnerOrEditor()` / `isAtLeastReader()` (not owner).
- **Mappers**: `Admin → ADMIN` (to-core) and `ADMIN → Admin` (to-middleware).
- **UI / navigation**: admin shown as "can edit", gets editable interaction mode, create enabled, default nav button.
- **Invite access**: admin maps to `EditorAccess`.
- **Analytics**: distinct `"Admin"` label.

## Notes
Admin is currently treated as editor-equivalent across the UI since the core model previously had no admin tier. If admin should have distinct UI/permissions beyond editor, that's a follow-up — analytics is the only place it's separately labeled.

## Test plan
- `./gradlew compileDebugAndroidTestSources` → passes
- `make test_debug_all` → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)