### PR TITLE
DROID-4523 Fix one-shot command loss on cold start (Splash, Main, Home/Navigation, relation values)

### DIFF
--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomeScreenViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomeScreenViewModel.kt
@@ -2910,6 +2910,9 @@ class HomeScreenViewModel(
             }
         }
 
+        // viewModelScope is already cancelled here, so no send() can race this close().
+        // Explicit about intent: nothing consumes the channel once the VM is gone.
+        commandsChannel.close()
         super.onCleared()
     }
 

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomeScreenViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/home/HomeScreenViewModel.kt
@@ -185,10 +185,12 @@ import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import com.anytypeio.anytype.presentation.notifications.UploadSuccessSnackbar
 import com.anytypeio.anytype.presentation.notifications.toSnackbarVariant
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -308,7 +310,16 @@ class HomeScreenViewModel(
 
     private val mutex = Mutex()
 
-    val commands = MutableSharedFlow<Command>()
+    /**
+     * One-shot commands. Backed by an unbounded [Channel] (not a `replay = 0`
+     * [MutableSharedFlow]) so a command emitted while the fragment isn't collecting —
+     * e.g. the deeplink commands fired from [onResume] during the activity
+     * stop -> resume gap on cold start — is buffered and delivered to the next
+     * subscriber instead of being silently dropped (DROID-4523). The single
+     * collecting fragment makes [receiveAsFlow]'s single-consumer semantics correct.
+     */
+    private val commandsChannel = Channel<Command>(Channel.UNLIMITED)
+    val commands: Flow<Command> = commandsChannel.receiveAsFlow()
     val mode = MutableStateFlow<InteractionMode>(InteractionMode.Default)
 
     val showHomepagePicker = MutableStateFlow(vmParams.showHomepagePicker)
@@ -1226,7 +1237,7 @@ class HomeScreenViewModel(
                                     target = dispatch.target
                                 )
                             } else {
-                                commands.emit(
+                                commandsChannel.send(
                                     Command.SelectWidgetType(
                                         ctx = config.widgets,
                                         source = dispatch.source,
@@ -1251,7 +1262,7 @@ class HomeScreenViewModel(
                                     target = dispatch.target
                                 )
                             } else {
-                                commands.emit(
+                                commandsChannel.send(
                                     Command.SelectWidgetType(
                                         ctx = config.widgets,
                                         source = dispatch.source,
@@ -1280,7 +1291,7 @@ class HomeScreenViewModel(
                             )
                         }
                         is WidgetDispatchEvent.NewWithWidgetWithNewSource -> {
-                            commands.emit(
+                            commandsChannel.send(
                                 Command.CreateSourceForNewWidget(
                                     space = SpaceId(config.space),
                                     widgets = config.widgets
@@ -1442,7 +1453,7 @@ class HomeScreenViewModel(
                     analytics = analytics,
                     isInEditMode = isInEditMode()
                 )
-                commands.emit(
+                commandsChannel.send(
                     Command.SelectWidgetSource(
                         ctx = config.widgets,
                         isInEditMode = isInEditMode(),
@@ -1480,7 +1491,7 @@ class HomeScreenViewModel(
         viewModelScope.launch {
             val permission = userPermissionProvider.get(vmParams.spaceId)
             if (permission?.isOwnerOrEditor() == true) {
-                commands.emit(Command.CreateNewType(vmParams.spaceId.id))
+                commandsChannel.send(Command.CreateNewType(vmParams.spaceId.id))
             } else {
                 sendToast("You don't have permission to create new type")
             }
@@ -2074,7 +2085,7 @@ class HomeScreenViewModel(
                     analytics = analytics,
                     isInEditMode = isInEditMode()
                 )
-                commands.emit(
+                commandsChannel.send(
                     Command.SelectWidgetSource(
                         ctx = config.widgets,
                         target = widget,
@@ -2094,7 +2105,7 @@ class HomeScreenViewModel(
             viewModelScope.launch {
                 val config = spaceManager.getConfig()
                 if (config != null) {
-                    commands.emit(
+                    commandsChannel.send(
                         Command.ChangeWidgetType(
                             ctx = config.widgets,
                             widget = widget,
@@ -2123,7 +2134,7 @@ class HomeScreenViewModel(
             viewModelScope.launch {
                 val config = spaceManager.getConfig()
                 if (config != null) {
-                    commands.emit(
+                    commandsChannel.send(
                         Command.ChangeWidgetSource(
                             ctx = config.widgets,
                             widget = widget,
@@ -2288,7 +2299,7 @@ class HomeScreenViewModel(
         when (deeplink) {
             is DeepLinkResolver.Action.Import.Experience -> {
                 viewModelScope.launch {
-                    commands.emit(
+                    commandsChannel.send(
                         Command.Deeplink.GalleryInstallation(
                             deepLinkType = deeplink.type,
                             deepLinkSource = deeplink.source
@@ -2300,7 +2311,7 @@ class HomeScreenViewModel(
             is DeepLinkResolver.Action.Invite -> {
                 viewModelScope.launch {
                     delay(1000)
-                    commands.emit(Command.Deeplink.Invite(deeplink.link))
+                    commandsChannel.send(Command.Deeplink.Invite(deeplink.link))
                 }
             }
             is DeepLinkResolver.Action.Unknown -> {
@@ -2319,7 +2330,7 @@ class HomeScreenViewModel(
                             is DeepLinkToObjectDelegate.Result.Error -> {
                                 val link = deeplink.invite
                                 if (link != null && result is DeepLinkToObjectDelegate.Result.Error.PermissionNeeded) {
-                                    commands.emit(
+                                    commandsChannel.send(
                                         Command.Deeplink.Invite(
                                             link = spaceInviteResolver.createInviteLink(
                                                 contentId = link.cid,
@@ -2328,7 +2339,7 @@ class HomeScreenViewModel(
                                         )
                                     )
                                 } else {
-                                    commands.emit(Command.Deeplink.DeepLinkToObjectNotWorking)
+                                    commandsChannel.send(Command.Deeplink.DeepLinkToObjectNotWorking)
                                 }
                             }
                             is DeepLinkToObjectDelegate.Result.Success -> {
@@ -2340,7 +2351,7 @@ class HomeScreenViewModel(
             }
             is DeepLinkResolver.Action.DeepLinkToMembership -> {
                 viewModelScope.launch {
-                    commands.emit(
+                    commandsChannel.send(
                         Command.Deeplink.MembershipScreen(
                             tierId = deeplink.tierId
                         )
@@ -2819,7 +2830,7 @@ class HomeScreenViewModel(
             navPanelState.value.leftButtonClickAnalytics(analytics)
         }
         viewModelScope.launch {
-            commands.emit(Command.ShareSpace(vmParams.spaceId))
+            commandsChannel.send(Command.ShareSpace(vmParams.spaceId))
         }
     }
 
@@ -2831,7 +2842,7 @@ class HomeScreenViewModel(
         proceedWithCloseOpenObjects()
         viewModelScope.launch {
             val currentSpaceView = _spaceViewState.value as? SpaceViewState.Success
-            commands.emit(
+            commandsChannel.send(
                 Command.HandleChatSpaceBackNavigation(
                     isOneToOneSpace = currentSpaceView?.isOneToOneSpace == true,
                     spaceChatId = currentSpaceView?.spaceChatId
@@ -2904,7 +2915,7 @@ class HomeScreenViewModel(
 
     fun onSearchIconClicked() {
         viewModelScope.launch {
-            commands.emit(
+            commandsChannel.send(
                 Command.OpenGlobalSearchScreen(space = vmParams.spaceId.id)
             )
         }
@@ -3009,14 +3020,14 @@ class HomeScreenViewModel(
     fun onManageSectionsClicked() {
         Timber.d("onManageSectionsClicked")
         viewModelScope.launch {
-            commands.emit(Command.OpenManageSections)
+            commandsChannel.send(Command.OpenManageSections)
         }
     }
 
     fun onMembersClicked() {
         Timber.d("onMembersClicked")
         viewModelScope.launch {
-            commands.emit(ShareSpace(vmParams.spaceId))
+            commandsChannel.send(ShareSpace(vmParams.spaceId))
         }
     }
 
@@ -3026,14 +3037,14 @@ class HomeScreenViewModel(
             val spaceView = spaceViewSubscriptionContainer.get(vmParams.spaceId)
             if (spaceView == null) {
                 Timber.w("Space view not found for mute toggle")
-                commands.emit(Command.Toast.UnableToChangeNotificationSettings)
+                commandsChannel.send(Command.Toast.UnableToChangeNotificationSettings)
                 return@launch
             }
 
             val targetSpaceId = spaceView.targetSpaceId
             if (targetSpaceId == null) {
                 Timber.w("Target space ID is null for mute toggle")
-                commands.emit(Command.Toast.UnableToChangeNotificationSettings)
+                commandsChannel.send(Command.Toast.UnableToChangeNotificationSettings)
                 return@launch
             }
 
@@ -3055,7 +3066,7 @@ class HomeScreenViewModel(
             ).fold(
                 onSuccess = {
                     Timber.d("Successfully set notification mode to $newMode")
-                    commands.emit(
+                    commandsChannel.send(
                         if (newMode == NotificationState.DISABLE) {
                             Command.Toast.SpaceMuted
                         } else {
@@ -3065,7 +3076,7 @@ class HomeScreenViewModel(
                 },
                 onFailure = { error ->
                     Timber.e(error, "Failed to set notification mode")
-                    commands.emit(Command.Toast.FailedToChangeNotificationSettings)
+                    commandsChannel.send(Command.Toast.FailedToChangeNotificationSettings)
                 }
             )
         }
@@ -3136,14 +3147,14 @@ class HomeScreenViewModel(
                 }
             }
             UiEvent.OnInviteClicked -> {
-                viewModelScope.launch { commands.emit(ShareSpace(space)) }
+                viewModelScope.launch { commandsChannel.send(ShareSpace(space)) }
             }
             UiEvent.OnLeaveSpaceClicked -> {
-                viewModelScope.launch { commands.emit(Command.ShowLeaveSpaceWarning) }
+                viewModelScope.launch { commandsChannel.send(Command.ShowLeaveSpaceWarning) }
             }
             is UiEvent.OnShareLinkClicked -> {
                 viewModelScope.launch {
-                    commands.emit(Command.ShareInviteLink(uiEvent.link))
+                    commandsChannel.send(Command.ShareInviteLink(uiEvent.link))
                 }
             }
             is UiEvent.OnCopyLinkClicked -> {
@@ -3345,7 +3356,7 @@ class HomeScreenViewModel(
             // Check if chat creation is allowed for the current space.
             val currentSpaceState = spaceViewState.value as? SpaceViewState.Success
             if (currentSpaceState?.canCreateAdditionalChats == true) {
-                commands.emit(
+                commandsChannel.send(
                     Command.CreateChatObject(
                         space = SpaceId(space)
                     )
@@ -3702,7 +3713,7 @@ class HomeScreenViewModel(
             val currentSpaceState = spaceViewState.value as? SpaceViewState.Success
             if (currentSpaceState?.canCreateAdditionalChats == true) {
                 viewModelScope.launch {
-                    commands.emit(Command.CreateChatObject(vmParams.spaceId))
+                    commandsChannel.send(Command.CreateChatObject(vmParams.spaceId))
                 }
             } else {
                 Timber.d("Chat creation not allowed in current space")
@@ -4359,7 +4370,7 @@ class HomeScreenViewModel(
 
     fun onInviteMembersWidgetClicked() {
         viewModelScope.launch {
-            commands.emit(Command.ShareSpace(vmParams.spaceId))
+            commandsChannel.send(Command.ShareSpace(vmParams.spaceId))
         }
     }
 

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/main/MainViewModel.kt
@@ -73,7 +73,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
@@ -82,6 +83,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -132,8 +134,20 @@ class MainViewModel(
 
     private var spaceStatusMonitorJob: Job? = null
 
-    val commands = MutableSharedFlow<Command>(replay = 0)
-    val toasts = MutableSharedFlow<String>(replay = 0)
+    /**
+     * One-shot commands / toasts. Backed by unbounded [Channel]s (not `replay = 0`
+     * SharedFlows) so an item emitted while [MainActivity] is not collecting — e.g.
+     * during the activity stop -> resume gap on cold start, or while `onRestore()`
+     * runs in `onCreate` before the `repeatOnLifecycle(STARTED)` collectors attach —
+     * is buffered and delivered to the next subscriber instead of being silently
+     * dropped (DROID-4523). Each has exactly one collector in [MainActivity], so the
+     * single-consumer semantics of [receiveAsFlow] are correct here.
+     */
+    private val commandsChannel = Channel<Command>(Channel.UNLIMITED)
+    val commands: Flow<Command> = commandsChannel.receiveAsFlow()
+
+    private val toastsChannel = Channel<String>(Channel.UNLIMITED)
+    val toasts: Flow<String> = toastsChannel.receiveAsFlow()
 
     val wallpaperState: MutableStateFlow<WallpaperResult> = MutableStateFlow(WallpaperResult.None)
     val showSpacesIntroduction: MutableStateFlow<Account?> = MutableStateFlow(null)
@@ -151,7 +165,7 @@ class MainViewModel(
             interceptAccountStatus.build().collect { status ->
                 when (status) {
                     is AccountStatus.PendingDeletion -> {
-                        commands.emit(
+                        commandsChannel.send(
                             ShowDeletedAccountScreen(
                                 deadline = status.deadline
                             )
@@ -255,12 +269,12 @@ class MainViewModel(
             if (notification.payload is NotificationPayload.GalleryImport) {
                 // TODO migrate to system notifications
                 delay(DELAY_BEFORE_SHOWING_NOTIFICATION_SCREEN)
-                commands.emit(Command.Notifications)
+                commandsChannel.send(Command.Notifications)
             } else if (notification.status == NotificationStatus.CREATED) {
                 if (notificator.areNotificationsEnabled) {
                     notificator.notify(notification)
                 } else {
-                    commands.emit(Command.RequestNotificationPermission).also {
+                    commandsChannel.send(Command.RequestNotificationPermission).also {
                         notificator.setPendingNotification(notification)
                     }
                 }
@@ -285,16 +299,16 @@ class MainViewModel(
             logout(Logout.Params(clearLocalRepositoryData = false)).collect { status ->
                 when (status) {
                     is Interactor.Status.Error -> {
-                        toasts.emit("Error while logging out due to account deletion")
+                        toastsChannel.send("Error while logging out due to account deletion")
                     }
 
                     is Interactor.Status.Started -> {
-                        toasts.emit("Your account is deleted. Logging out...")
+                        toastsChannel.send("Your account is deleted. Logging out...")
                     }
 
                     is Interactor.Status.Success -> {
                         unsubscribeFromGlobalSubscriptions()
-                        commands.emit(Command.LogoutDueToAccountDeletion)
+                        commandsChannel.send(Command.LogoutDueToAccountDeletion)
                     }
                 }
             }
@@ -363,7 +377,7 @@ class MainViewModel(
                 failure = { error ->
                     when (error) {
                         is NeedToUpdateApplicationException -> {
-                            commands.emit(Command.Error(SplashViewModel.ERROR_NEED_UPDATE))
+                            commandsChannel.send(Command.Error(SplashViewModel.ERROR_NEED_UPDATE))
                             Timber.e(error, "Error while launching account after activity recreation")
                         }
 
@@ -372,11 +386,11 @@ class MainViewModel(
                             // transient prefs read failure). Logout is destructive, so ask
                             // the user before wiping local state.
                             Timber.w("onRestore: mnemonic empty, asking user to confirm logout")
-                            commands.emit(Command.ConfirmResumeAccountLogout)
+                            commandsChannel.send(Command.ConfirmResumeAccountLogout)
                         }
 
                         else -> {
-                            commands.emit(Command.Error(SplashViewModel.ERROR_MESSAGE))
+                            commandsChannel.send(Command.Error(SplashViewModel.ERROR_MESSAGE))
                             Timber.e(error, "Error while launching account after activity recreation")
                         }
                     }
@@ -401,7 +415,7 @@ class MainViewModel(
                 onFailure = { e -> Timber.e(e, "Error while checking auth status") },
                 onSuccess = { (status, account) ->
                     if (status == AuthStatus.AUTHORIZED) {
-                        commands.emit(Command.OpenCreateNewType(type))
+                        commandsChannel.send(Command.OpenCreateNewType(type))
                     }
                 }
             )
@@ -424,15 +438,15 @@ class MainViewModel(
                     .onSuccess { config ->
                         Timber.d("onCreateObjectFromWidget: switched to space $spaceId successfully, config=$config")
                         Timber.d("onCreateObjectFromWidget: emitting OpenCreateObjectFromOsWidget with typeKey=$typeKey")
-                        commands.emit(Command.Deeplink.OpenCreateObjectFromOsWidget(typeKey = typeKey))
+                        commandsChannel.send(Command.Deeplink.OpenCreateObjectFromOsWidget(typeKey = typeKey))
                     }
                     .onFailure { e ->
                         Timber.e(e, "onCreateObjectFromWidget: failed to switch space to $spaceId")
-                        toasts.emit("Failed to switch space")
+                        toastsChannel.send("Failed to switch space")
                     }
             } else {
                 Timber.d("onCreateObjectFromWidget: already in space $spaceId, emitting create command")
-                commands.emit(Command.Deeplink.OpenCreateObjectFromOsWidget(typeKey = typeKey))
+                commandsChannel.send(Command.Deeplink.OpenCreateObjectFromOsWidget(typeKey = typeKey))
             }
         }
     }
@@ -530,7 +544,7 @@ class MainViewModel(
         Timber.d("Proceeding with the new deep link, deeplink: $deeplink")
         when (deeplink) {
             is DeepLinkResolver.Action.Import.Experience -> {
-                commands.emit(
+                commandsChannel.send(
                     Command.Deeplink.GalleryInstallation(
                         deepLinkType = deeplink.type,
                         deepLinkSource = deeplink.source
@@ -539,7 +553,7 @@ class MainViewModel(
             }
 
             is DeepLinkResolver.Action.Invite -> {
-                commands.emit(Command.Deeplink.Invite(deeplink.link))
+                commandsChannel.send(Command.Deeplink.Invite(deeplink.link))
             }
 
             is DeepLinkResolver.Action.DeepLinkToObject -> {
@@ -561,7 +575,7 @@ class MainViewModel(
                                     )
                                 )
                             )
-                            commands.emit(
+                            commandsChannel.send(
                                 Command.Deeplink.Invite(
                                     spaceInviteResolver.createInviteLink(
                                         contentId = link.cid,
@@ -570,7 +584,7 @@ class MainViewModel(
                                 )
                             )
                         } else {
-                            commands.emit(Command.Deeplink.DeepLinkToObjectNotWorking)
+                            commandsChannel.send(Command.Deeplink.DeepLinkToObjectNotWorking)
                         }
                     }
 
@@ -609,7 +623,7 @@ class MainViewModel(
                                                 )
                                             )
                                         )
-                                        commands.emit(
+                                        commandsChannel.send(
                                             Command.Deeplink.DeepLinkToObject(
                                                 navigation = result.obj.navigation(),
                                                 sideEffect = null,
@@ -637,7 +651,7 @@ class MainViewModel(
                                                 )
                                             )
                                         )
-                                        commands.emit(
+                                        commandsChannel.send(
                                             Command.Deeplink.DeepLinkToObject(
                                                 navigation = result.obj.navigation(),
                                                 sideEffect = null,
@@ -654,7 +668,7 @@ class MainViewModel(
             }
 
             is DeepLinkResolver.Action.DeepLinkToMembership -> {
-                commands.emit(
+                commandsChannel.send(
                     Command.Deeplink.MembershipScreen(tierId = deeplink.tierId)
                 )
             }
@@ -663,7 +677,7 @@ class MainViewModel(
                 // Data was already stored immediately in processDeepLinkBasedOnAuth()
                 // to avoid race condition with VaultViewModel.processPendingDeeplink()
                 Timber.d("Emitting InitiateOneToOneChat command: ${deeplink.identity}")
-                commands.emit(
+                commandsChannel.send(
                     Command.Deeplink.InitiateOneToOneChat(
                         identity = deeplink.identity,
                         metadataKey = deeplink.metadataKey
@@ -678,7 +692,7 @@ class MainViewModel(
 
             is DeepLinkResolver.Action.OsWidgetDeepLink.DeepLinkToCreateObject -> {
                 Timber.d("Processing OS widget deep link to create object: appWidgetId=${deeplink.appWidgetId}")
-                commands.emit(
+                commandsChannel.send(
                     Command.Deeplink.DeepLinkToCreateObject(
                         appWidgetId = deeplink.appWidgetId,
                         token = deeplink.token
@@ -728,7 +742,7 @@ class MainViewModel(
                     // `OpenChat` with a toast.
                     when (val nav = homepageResult.navigation) {
                         is OpenObjectNavigation.OpenChat -> {
-                            commands.emit(
+                            commandsChannel.send(
                                 Command.Deeplink.DeepLinkToSpace(
                                     space = targetSpace,
                                     shouldNavigateDirectlyToChat = true,
@@ -737,7 +751,7 @@ class MainViewModel(
                             )
                         }
                         else -> {
-                            commands.emit(
+                            commandsChannel.send(
                                 Command.Deeplink.DeepLinkToObjectFromWidget(
                                     space = targetSpace,
                                     obj = spaceView?.homepage.orEmpty(),
@@ -751,7 +765,7 @@ class MainViewModel(
                 }
             }
 
-            commands.emit(
+            commandsChannel.send(
                 Command.Deeplink.DeepLinkToSpace(
                     space = targetSpace,
                     shouldNavigateDirectlyToChat = shouldNavigateDirectlyToChat,
@@ -795,7 +809,7 @@ class MainViewModel(
             is DeepLinkToObjectDelegate.Result.Success -> {
                 val navigation = result.obj.navigation()
                 Timber.d("OS widget object navigation determined: $navigation")
-                commands.emit(
+                commandsChannel.send(
                     Command.Deeplink.DeepLinkToObjectFromWidget(
                         space = targetSpace,
                         obj = objectId,
@@ -806,15 +820,15 @@ class MainViewModel(
             }
             is DeepLinkToObjectDelegate.Result.Error.ObjectNotFound -> {
                 Timber.w("OS widget: Object not found: $objectId")
-                toasts.emit("Object not found")
+                toastsChannel.send("Object not found")
             }
             is DeepLinkToObjectDelegate.Result.Error.PermissionNeeded -> {
                 Timber.w("OS widget: Permission needed to access object: $objectId")
-                toasts.emit("Permission needed")
+                toastsChannel.send("Permission needed")
             }
             is DeepLinkToObjectDelegate.Result.Error.CouldNotOpenSpace -> {
                 Timber.w("OS widget: Could not open space: $targetSpace")
-                toasts.emit("Could not open space")
+                toastsChannel.send("Could not open space")
             }
         }
     }
@@ -838,7 +852,7 @@ class MainViewModel(
                         )
                     )
                 )
-                commands.emit(
+                commandsChannel.send(
                     Command.Deeplink.DeepLinkToObject(
                         navigation = result.obj.navigation(),
                         sideEffect = sideEffect,
@@ -868,7 +882,7 @@ class MainViewModel(
                 spaceManager.set(spaceId)
                     .onSuccess {
                         monitorSpaceLocalStatus(spaceId)
-                        commands.emit(
+                        commandsChannel.send(
                             Command.LaunchChat(
                                 space = spaceId,
                                 chat = chatId,
@@ -884,7 +898,7 @@ class MainViewModel(
                     }
             } else {
                 monitorSpaceLocalStatus(spaceId)
-                commands.emit(
+                commandsChannel.send(
                     Command.LaunchChat(
                         space = spaceId,
                         chat = chatId,
@@ -1002,7 +1016,7 @@ class MainViewModel(
                     "PUSH_SPACE_STATUS: Space $spaceId local status still LOADING after ${PUSH_SPACE_STATUS_TIMEOUT / 1000}s"
                 )
                 if (BuildConfig.ENABLE_SPACE_PUSH_DIAGNOSTICS) {
-                    commands.emit(
+                    commandsChannel.send(
                         Command.Snackbar(
                             "Space local status is still LOADING after ${PUSH_SPACE_STATUS_TIMEOUT / 1000} seconds (push)"
                         )
@@ -1023,7 +1037,7 @@ class MainViewModel(
      * completes.
      */
     fun showSnackbarWithOk(msg: String) {
-        viewModelScope.launch { commands.emit(Command.SnackbarWithOk(msg)) }
+        viewModelScope.launch { commandsChannel.send(Command.SnackbarWithOk(msg)) }
     }
 
     /**
@@ -1035,7 +1049,7 @@ class MainViewModel(
      */
     fun showSnackbarWithOpenType(msg: String, typeId: Id, space: Id, actionLabel: String) {
         viewModelScope.launch {
-            commands.emit(
+            commandsChannel.send(
                 Command.SnackbarWithOpenType(
                     msg = msg,
                     typeId = typeId,

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/main/MainViewModel.kt
@@ -1074,6 +1074,10 @@ class MainViewModel(
         //     }
         // }
         Timber.d("onCleared called - appShutdown disabled for FD crash testing")
+        // viewModelScope is already cancelled here, so no send() can race these
+        // close() calls. Explicit about intent: nothing consumes them once we're gone.
+        commandsChannel.close()
+        toastsChannel.close()
         super.onCleared()
     }
 

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/navigation/SupportNavigation.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/navigation/SupportNavigation.kt
@@ -4,8 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.anytypeio.anytype.presentation.common.BaseViewModel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 
 interface SupportNavigation<Navigation> {
@@ -18,12 +19,20 @@ interface SupportNavigation<Navigation> {
 }
 
 open class NavigationViewModel<Navigation> : BaseViewModel() {
-    private val _navigation = MutableSharedFlow<Navigation>()
-    val navigation: Flow<Navigation> get() = _navigation
+    /**
+     * Backed by an unbounded [Channel] (not a `replay = 0` [MutableSharedFlow]) so a
+     * destination emitted while the screen is not collecting — e.g. a deeplink
+     * resolved during the activity stop -> resume gap on cold start — is buffered and
+     * delivered to the next subscriber instead of being silently dropped (DROID-4523).
+     * Each screen has a single collector, so [receiveAsFlow]'s single-consumer
+     * semantics are correct.
+     */
+    private val _navigation = Channel<Navigation>(Channel.UNLIMITED)
+    val navigation: Flow<Navigation> = _navigation.receiveAsFlow()
     fun navigate(destination: Navigation) = viewModelScope.launch {
-        _navigation.emit(destination)
+        _navigation.send(destination)
     }
     suspend fun navigation(destination: Navigation) {
-        _navigation.emit(destination)
+        _navigation.send(destination)
     }
 }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/navigation/SupportNavigation.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/navigation/SupportNavigation.kt
@@ -28,6 +28,14 @@ open class NavigationViewModel<Navigation> : BaseViewModel() {
      * semantics are correct.
      */
     private val _navigation = Channel<Navigation>(Channel.UNLIMITED)
+
+    /**
+     * Single-consumer invariant: collect this from exactly ONE place. The backing
+     * channel hands each destination to a single receiver, so a second concurrent
+     * collector would silently steal half the destinations. Re-collecting
+     * sequentially across lifecycle bounces (`onStart`/`onStop`,
+     * `repeatOnLifecycle(STARTED)`) is fine — that is one consumer at a time.
+     */
     val navigation: Flow<Navigation> = _navigation.receiveAsFlow()
     fun navigate(destination: Navigation) = viewModelScope.launch {
         _navigation.send(destination)

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/notifications/NotificationActionDelegate.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/notifications/NotificationActionDelegate.kt
@@ -8,13 +8,14 @@ import com.anytypeio.anytype.domain.spaces.ResolveSpaceHomepage
 import com.anytypeio.anytype.domain.spaces.SaveCurrentSpace
 import com.anytypeio.anytype.domain.workspace.SpaceManager
 import javax.inject.Inject
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
 import timber.log.Timber
 
 interface NotificationActionDelegate {
 
-    val dispatcher: SharedFlow<NotificationCommand>
+    val dispatcher: Flow<NotificationCommand>
 
     suspend fun proceedWithNotificationAction(action: NotificationAction)
 
@@ -27,7 +28,12 @@ interface NotificationActionDelegate {
         private val resolveSpaceHomepage: ResolveSpaceHomepage
     ) : NotificationActionDelegate {
 
-        override val dispatcher: MutableSharedFlow<NotificationCommand> = MutableSharedFlow()
+        // Unbounded Channel (not a `replay = 0` SharedFlow): a notification command
+        // emitted while MainActivity isn't collecting — e.g. a notification tap on
+        // cold start, before the STARTED-scoped collector attaches — is buffered and
+        // delivered to the next subscriber instead of being dropped (DROID-4523).
+        private val dispatcherChannel = Channel<NotificationCommand>(Channel.UNLIMITED)
+        override val dispatcher: Flow<NotificationCommand> = dispatcherChannel.receiveAsFlow()
 
         override suspend fun proceedWithNotificationAction(action: NotificationAction) {
             Timber.d("Proceeding with notification action: $action")
@@ -67,7 +73,7 @@ interface NotificationActionDelegate {
                                 }
                             )
                         }
-                        dispatcher.emit(
+                        dispatcherChannel.send(
                             NotificationCommand.ViewSpaceJoinRequest(
                                 space = action.space,
                                 member = member.id
@@ -97,7 +103,7 @@ interface NotificationActionDelegate {
                     Timber.e(it, "Error while replying notification")
                 }
             )
-            dispatcher.emit(NotificationCommand.ViewSpaceLeaveRequest(space = action.space,))
+            dispatcherChannel.send(NotificationCommand.ViewSpaceLeaveRequest(space = action.space,))
             systemNotificationService.cancel(action.notification)
         }
 
@@ -125,7 +131,7 @@ interface NotificationActionDelegate {
                             Timber.e(it, "Error while saving current space")
                         }
                     )
-                dispatcher.emit(resolveGoToSpaceCommand(action.space))
+                dispatcherChannel.send(resolveGoToSpaceCommand(action.space))
             } else {
                 // TODO show error msg
             }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/notifications/NotificationActionDelegate.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/notifications/NotificationActionDelegate.kt
@@ -15,6 +15,15 @@ import timber.log.Timber
 
 interface NotificationActionDelegate {
 
+    /**
+     * Buffered one-shot commands (see [Default] for the backing [Channel]).
+     *
+     * Single-consumer invariant: collect this from exactly ONE place. The backing
+     * channel hands each command to a single receiver, so a second concurrent
+     * collector would silently steal half the commands. Re-collecting sequentially
+     * across lifecycle bounces (e.g. `repeatOnLifecycle(STARTED)`) is fine — that is
+     * one consumer at a time, not two at once.
+     */
     val dispatcher: Flow<NotificationCommand>
 
     suspend fun proceedWithNotificationAction(action: NotificationAction)

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/object/ObjectValueViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/object/ObjectValueViewModel.kt
@@ -35,12 +35,15 @@ import com.anytypeio.anytype.presentation.relations.value.tagstatus.RelationCont
 import com.anytypeio.anytype.presentation.search.ObjectSearchConstants
 import com.anytypeio.anytype.presentation.sets.filterIdsById
 import com.anytypeio.anytype.presentation.util.Dispatcher
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -66,7 +69,16 @@ class ObjectValueViewModel(
     val viewState = MutableStateFlow<ObjectValueViewState>(ObjectValueViewState.Loading())
     private val query = MutableSharedFlow<String>(replay = 1)
     private var isEditableRelation = false
-    val commands = MutableSharedFlow<Command>(replay = 0)
+    /**
+     * One-shot commands. Backed by an unbounded [Channel] (not a `replay = 0`
+     * [MutableSharedFlow]) so the `Command.Expand` emitted from the `init` pipeline
+     * on first load — before the bottom sheet has attached its collector — is buffered
+     * and delivered to the next subscriber instead of being silently dropped, which
+     * left the sheet stuck unexpanded (DROID-4523). The single collecting fragment
+     * makes [receiveAsFlow]'s single-consumer semantics correct.
+     */
+    private val commandsChannel = Channel<Command>(Channel.UNLIMITED)
+    val commands: Flow<Command> = commandsChannel.receiveAsFlow()
 
     private val initialIds = mutableListOf<Id>()
     private var isInitialSortDone = false
@@ -162,7 +174,7 @@ class ObjectValueViewModel(
     private fun emitCommand(command: Command, delay: Long = 0L) {
         viewModelScope.launch {
             delay(delay)
-            commands.emit(command)
+            commandsChannel.send(command)
         }
     }
 

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/object/ObjectValueViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/object/ObjectValueViewModel.kt
@@ -80,6 +80,14 @@ class ObjectValueViewModel(
     private val commandsChannel = Channel<Command>(Channel.UNLIMITED)
     val commands: Flow<Command> = commandsChannel.receiveAsFlow()
 
+    override fun onCleared() {
+        // viewModelScope is already cancelled by the time onCleared() runs, so no
+        // send() can race this close(). Closing is explicit about intent: nothing
+        // will consume the channel once the ViewModel is gone.
+        commandsChannel.close()
+        super.onCleared()
+    }
+
     private val initialIds = mutableListOf<Id>()
     private var isInitialSortDone = false
 

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
@@ -79,6 +79,14 @@ class TagOrStatusValueViewModel(
     private val commandsChannel = Channel<Command>(Channel.UNLIMITED)
     val commands: Flow<Command> = commandsChannel.receiveAsFlow()
 
+    override fun onCleared() {
+        // viewModelScope is already cancelled by the time onCleared() runs, so no
+        // send() can race this close(). Closing is explicit about intent: nothing
+        // will consume the channel once the ViewModel is gone.
+        commandsChannel.close()
+        super.onCleared()
+    }
+
     private var isInitialExpandDone = false
 
     // Lock mechanism to prevent race conditions during DnD operations

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
@@ -25,12 +25,14 @@ import com.anytypeio.anytype.presentation.relations.providers.ObjectValueProvide
 import com.anytypeio.anytype.presentation.sets.filterIdsById
 import com.anytypeio.anytype.presentation.util.Dispatcher
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
@@ -66,7 +68,16 @@ class TagOrStatusValueViewModel(
         )
     }
     private var isEditableRelation = false
-    val commands = MutableSharedFlow<Command>(replay = 0)
+    /**
+     * One-shot commands. Backed by an unbounded [Channel] (not a `replay = 0`
+     * SharedFlow) so the `Command.Expand` emitted from the `init` pipeline on first
+     * load — before the bottom sheet has attached its collector — is buffered and
+     * delivered to the next subscriber instead of being silently dropped, which left
+     * the sheet stuck unexpanded (DROID-4523). The single collecting fragment makes
+     * [receiveAsFlow]'s single-consumer semantics correct.
+     */
+    private val commandsChannel = Channel<Command>(Channel.UNLIMITED)
+    val commands: Flow<Command> = commandsChannel.receiveAsFlow()
 
     private var isInitialExpandDone = false
 
@@ -242,13 +253,13 @@ class TagOrStatusValueViewModel(
     private fun emitCommand(command: Command, delay: Long = 0L) {
         viewModelScope.launch {
             delay(delay)
-            commands.emit(command)
+            commandsChannel.send(command)
         }
     }
 
     private fun openOptionScreen(command: Command.OpenOptionScreen) {
         viewModelScope.launch {
-            commands.emit(command)
+            commandsChannel.send(command)
         }
     }
 

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/splash/SplashViewModel.kt
@@ -96,6 +96,14 @@ class SplashViewModel(
     private val commandsChannel = Channel<Command>(Channel.UNLIMITED)
     val commands: Flow<Command> = commandsChannel.receiveAsFlow()
 
+    override fun onCleared() {
+        // viewModelScope is already cancelled by the time onCleared() runs, so no
+        // send() can race this close(). Closing is explicit about intent: nothing
+        // will consume the channel once the ViewModel is gone.
+        commandsChannel.close()
+        super.onCleared()
+    }
+
     private var migrationRetryCount: Int = 0
 
     init {

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/splash/SplashViewModel.kt
@@ -43,12 +43,14 @@ import com.anytypeio.anytype.presentation.auth.account.MigrationHelperDelegate
 import com.anytypeio.anytype.presentation.extension.proceedWithAccountEvent
 import com.anytypeio.anytype.presentation.extension.sendAnalyticsObjectCreateEvent
 import com.anytypeio.anytype.presentation.search.ObjectSearchConstants
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -82,7 +84,15 @@ class SplashViewModel(
     MigrationHelperDelegate by migration {
 
     val state = MutableStateFlow<State>(State.Init)
-    val commands = MutableSharedFlow<Command>(replay = 0)
+
+    /**
+     * One-shot navigation commands. Backed by an unbounded [Channel] (not a
+     * `replay = 0` SharedFlow) so a command emitted while [SplashFragment] is not
+     * collecting — e.g. during the activity stop -> resume gap on cold start — is
+     * buffered and delivered to the next subscriber instead of being silently dropped.
+     */
+    private val commandsChannel = Channel<Command>(Channel.UNLIMITED)
+    val commands: Flow<Command> = commandsChannel.receiveAsFlow()
 
     private var migrationRetryCount: Int = 0
 
@@ -144,7 +154,7 @@ class SplashViewModel(
                 onSuccess = { (status, account) ->
                     Timber.i("Authorization status: $status")
                     if (status == AuthStatus.UNAUTHORIZED) {
-                        commands.emit(Command.NavigateToAuthStart)
+                        commandsChannel.send(Command.NavigateToAuthStart)
                     } else {
                         proceedWithLaunchingWallet()
                     }
@@ -200,7 +210,7 @@ class SplashViewModel(
                         analyticsId = analyticsId
                     )
                     proceedWithGlobalSubscriptions()
-                    commands.emit(Command.CheckAppStartIntent)
+                    commandsChannel.send(Command.CheckAppStartIntent)
                 },
                 failure = { e ->
                     Timber.e(e, "Error while launching account")
@@ -244,7 +254,7 @@ class SplashViewModel(
             createObjectByTypeAndTemplate.async(params).fold(
                 onFailure = { e ->
                     Timber.e(e, "Error while creating a new object with type:$type")
-                    commands.emit(Command.Toast(e.message ?: "Error while creating object"))
+                    commandsChannel.send(Command.Toast(e.message ?: "Error while creating object"))
                     proceedWithNavigation()
                 },
                 onSuccess = { result ->
@@ -258,7 +268,7 @@ class SplashViewModel(
                     )
                     when (result) {
                         CreateObjectByTypeAndTemplate.Result.ObjectTypeNotFound -> {
-                            commands.emit(Command.Toast(ERROR_CREATE_OBJECT))
+                            commandsChannel.send(Command.Toast(ERROR_CREATE_OBJECT))
                             proceedWithVaultNavigation()
                         }
                         is CreateObjectByTypeAndTemplate.Result.Success -> {
@@ -270,7 +280,7 @@ class SplashViewModel(
                                     spaceView = view
                                 )
                                 // Layout may not be known here; open as an object and let UI resolve.
-                                commands.emit(
+                                commandsChannel.send(
                                     Command.NavigateToObject(
                                         id = target,
                                         space = spaceId,
@@ -292,7 +302,7 @@ class SplashViewModel(
             spaceManager.set(space = space)
                 .onSuccess {
                     pendingIntentStore.setPushSpaceEntry(space)
-                    commands.emit(
+                    commandsChannel.send(
                         Command.NavigateToChat(
                             space = space,
                             chat = chat
@@ -360,7 +370,7 @@ class SplashViewModel(
         when (layout) {
             ObjectType.Layout.SET,
             ObjectType.Layout.COLLECTION ->
-                commands.emit(
+                commandsChannel.send(
                     Command.NavigateToObjectSet(
                         id = id,
                         space = space,
@@ -368,7 +378,7 @@ class SplashViewModel(
                     )
                 )
             ObjectType.Layout.DATE -> {
-                commands.emit(
+                commandsChannel.send(
                     Command.NavigateToDateObject(
                         id = id,
                         space = space,
@@ -377,7 +387,7 @@ class SplashViewModel(
                 )
             }
             ObjectType.Layout.OBJECT_TYPE -> {
-                commands.emit(
+                commandsChannel.send(
                     Command.NavigateToObjectType(
                         id = id,
                         space = space,
@@ -386,7 +396,7 @@ class SplashViewModel(
                 )
             }
             else ->
-                commands.emit(
+                commandsChannel.send(
                     Command.NavigateToObject(
                         id = id,
                         space = space,
@@ -412,7 +422,7 @@ class SplashViewModel(
             val action = deepLinkResolver.resolve(deeplink)
             if (action is DeepLinkResolver.Action.InitiateOneToOneChat) {
                 Timber.d("One-to-one chat deeplink detected, navigating to Vault")
-                commands.emit(Command.NavigateToVault(deeplink))
+                commandsChannel.send(Command.NavigateToVault(deeplink))
                 return
             }
         }
@@ -429,7 +439,7 @@ class SplashViewModel(
                             spaceView = view
                         )
                         if (chat != null) {
-                            commands.emit(
+                            commandsChannel.send(
                                 Command.NavigateToChat(
                                     space = space.id,
                                     chat = chat,
@@ -438,7 +448,7 @@ class SplashViewModel(
                             )
                         } else {
                             Timber.w("Could not resolve chat ID for one-to-one space")
-                            commands.emit(
+                            commandsChannel.send(
                                 Command.NavigateToWidgets(
                                     space = space.id,
                                     deeplink = deeplink
@@ -458,11 +468,11 @@ class SplashViewModel(
                 }
             } else {
                 Timber.w("Timeout while waiting for active space view. Navigating to vault.")
-                commands.emit(Command.NavigateToVault(deeplink))
+                commandsChannel.send(Command.NavigateToVault(deeplink))
             }
         } else {
             Timber.w("No space found or space manager state is NoSpace. Navigating to vault.")
-            commands.emit(Command.NavigateToVault(deeplink))
+            commandsChannel.send(Command.NavigateToVault(deeplink))
         }
     }
 
@@ -483,7 +493,7 @@ class SplashViewModel(
         deeplink: String?
     ) {
         if (homepage.isNullOrEmpty() || homepage in HOMEPAGE_SPECIAL_CONSTANTS) {
-            commands.emit(Command.NavigateToWidgets(space = spaceId, deeplink = deeplink))
+            commandsChannel.send(Command.NavigateToWidgets(space = spaceId, deeplink = deeplink))
             return
         }
         // Homepage is an object ID — resolve and navigate
@@ -504,33 +514,33 @@ class SplashViewModel(
         val obj = results.getOrNull()?.firstOrNull()
         if (obj == null) {
             Timber.w("Homepage object $homepage not found, falling back to widgets")
-            commands.emit(Command.NavigateToWidgets(space = spaceId, deeplink = deeplink))
+            commandsChannel.send(Command.NavigateToWidgets(space = spaceId, deeplink = deeplink))
             return
         }
         when (obj.navigation()) {
             is OpenObjectNavigation.OpenEditor -> {
-                commands.emit(Command.NavigateToObject(id = homepage, space = spaceId, chat = null))
+                commandsChannel.send(Command.NavigateToObject(id = homepage, space = spaceId, chat = null))
             }
             is OpenObjectNavigation.OpenDataView -> {
-                commands.emit(Command.NavigateToObjectSet(id = homepage, space = spaceId, chat = null))
+                commandsChannel.send(Command.NavigateToObjectSet(id = homepage, space = spaceId, chat = null))
             }
             is OpenObjectNavigation.OpenChat -> {
-                commands.emit(Command.NavigateToChat(space = spaceId, chat = homepage, deeplink = deeplink))
+                commandsChannel.send(Command.NavigateToChat(space = spaceId, chat = homepage, deeplink = deeplink))
             }
             is OpenObjectNavigation.OpenType -> {
-                commands.emit(Command.NavigateToObjectType(id = homepage, space = spaceId, chat = null))
+                commandsChannel.send(Command.NavigateToObjectType(id = homepage, space = spaceId, chat = null))
             }
             is OpenObjectNavigation.OpenDateObject -> {
-                commands.emit(Command.NavigateToDateObject(id = homepage, space = spaceId, chat = null))
+                commandsChannel.send(Command.NavigateToDateObject(id = homepage, space = spaceId, chat = null))
             }
             is OpenObjectNavigation.OpenBookmarkUrl -> {
-                commands.emit(Command.NavigateToObject(id = homepage, space = spaceId, chat = null))
+                commandsChannel.send(Command.NavigateToObject(id = homepage, space = spaceId, chat = null))
             }
             is OpenObjectNavigation.OpenParticipant -> {
-                commands.emit(Command.NavigateToWidgets(space = spaceId, deeplink = deeplink))
+                commandsChannel.send(Command.NavigateToWidgets(space = spaceId, deeplink = deeplink))
             }
             else -> {
-                commands.emit(Command.NavigateToWidgets(space = spaceId, deeplink = deeplink))
+                commandsChannel.send(Command.NavigateToWidgets(space = spaceId, deeplink = deeplink))
             }
         }
     }

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/navigation/NavigationViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/navigation/NavigationViewModelTest.kt
@@ -1,0 +1,29 @@
+package com.anytypeio.anytype.presentation.navigation
+
+import app.cash.turbine.test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class NavigationViewModelTest {
+
+    private class TestNavigationViewModel : NavigationViewModel<String>()
+
+    @Test
+    fun `should buffer navigation destination emitted before a collector subscribes`() = runTest {
+        // GIVEN
+        val vm = TestNavigationViewModel()
+
+        // WHEN — a destination is emitted while NOBODY is collecting `navigation`.
+        // This reproduces a deeplink resolved during the activity stop -> resume gap
+        // on cold start, before the screen's navigation collector has attached.
+        vm.navigation("destination-1")
+
+        // THEN — a collector subscribing afterwards must still receive it. With a
+        // `replay = 0` SharedFlow the destination was silently dropped; the buffered
+        // Channel delivers it to the late subscriber (DROID-4523).
+        vm.navigation.test {
+            assertEquals("destination-1", awaitItem())
+        }
+    }
+}

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/notifications/NotificationActionDelegateTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/notifications/NotificationActionDelegateTest.kt
@@ -1,0 +1,59 @@
+package com.anytypeio.anytype.presentation.notifications
+
+import app.cash.turbine.test
+import com.anytypeio.anytype.core_models.primitives.SpaceId
+import com.anytypeio.anytype.domain.base.Resultat
+import com.anytypeio.anytype.domain.multiplayer.GetSpaceMemberByIdentity
+import com.anytypeio.anytype.domain.notifications.ReplyNotifications
+import com.anytypeio.anytype.domain.notifications.SystemNotificationService
+import com.anytypeio.anytype.domain.spaces.ResolveSpaceHomepage
+import com.anytypeio.anytype.domain.spaces.SaveCurrentSpace
+import com.anytypeio.anytype.domain.workspace.SpaceManager
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.stub
+
+class NotificationActionDelegateTest {
+
+    @Test
+    fun `should buffer notification command emitted before a collector subscribes`() = runTest {
+        // GIVEN — a delegate whose leave-request flow can run to completion.
+        val replyNotifications = mock<ReplyNotifications>().apply {
+            stub { onBlocking { async(any()) } doReturn Resultat.Success(Unit) }
+        }
+        val delegate = NotificationActionDelegate.Default(
+            getSpaceMemberByIdentity = mock<GetSpaceMemberByIdentity>(),
+            replyNotifications = replyNotifications,
+            systemNotificationService = mock<SystemNotificationService>(),
+            spaceManager = mock<SpaceManager>(),
+            saveCurrentSpace = mock<SaveCurrentSpace>(),
+            resolveSpaceHomepage = mock<ResolveSpaceHomepage>()
+        )
+
+        val space = SpaceId("space-1")
+        val action = NotificationAction.Multiplayer.ViewSpaceLeaveRequest(
+            notification = "notification-1",
+            space = space
+        )
+
+        // WHEN — the command is dispatched while NOBODY is collecting `dispatcher`.
+        // This reproduces a notification tap arriving during the cold-start
+        // activity stop -> resume gap, before MainActivity's STARTED-scoped collector
+        // has re-attached.
+        delegate.proceedWithNotificationAction(action)
+
+        // THEN — a collector subscribing afterwards must still receive the command.
+        // With a `replay = 0` SharedFlow the command was silently dropped; the
+        // buffered Channel delivers it to the late subscriber (DROID-4523).
+        delegate.dispatcher.test {
+            assertEquals(
+                NotificationCommand.ViewSpaceLeaveRequest(space = space),
+                awaitItem()
+            )
+        }
+    }
+}

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/splash/SplashViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/splash/SplashViewModelTest.kt
@@ -202,6 +202,34 @@ class SplashViewModelTest {
     }
 
     @Test
+    fun `should not lose CheckAppStartIntent when emitted before splash starts collecting`() = runTest {
+        // GIVEN — a normal authorized cold start that launches wallet + account.
+        val status = AuthStatus.AUTHORIZED
+        val response = Resultat.Success(Pair(status, Account(id = "id")))
+
+        stubCheckAuthStatus(response)
+        stubLaunchWallet()
+        stubLaunchAccount()
+        stubGetLastOpenedObject()
+
+        // WHEN — the cold-start flow runs to completion and emits CheckAppStartIntent
+        // while no collector is active. This reproduces the activity stop -> resume gap
+        // during cold start, where SplashFragment has cancelled its command collector
+        // (BaseFragment.onStop) yet the ViewModel's viewModelScope keeps running.
+        initViewModel()
+
+        // THEN — a collector subscribing afterwards must still receive the command.
+        // With a replay=0 SharedFlow the command was dropped and the app stuck on the
+        // splash screen; a buffered channel delivers it to the late subscriber.
+        vm.commands.test {
+            assertEquals(
+                expected = SplashViewModel.Command.CheckAppStartIntent,
+                actual = awaitItem()
+            )
+        }
+    }
+
+    @Test
     fun `should navigate to vault if space view loading times out`() = runTest {
         // GIVEN
 
@@ -237,6 +265,9 @@ class SplashViewModelTest {
         }
 
         vm.commands.test {
+            // The cold-start CheckAppStartIntent is buffered and delivered first.
+            assertEquals(SplashViewModel.Command.CheckAppStartIntent, awaitItem())
+
             // Act: manually trigger proceedWithVaultNavigation
             vm.onDeepLinkLaunch(deeplink)
 
@@ -295,6 +326,9 @@ class SplashViewModelTest {
         }
 
         vm.commands.test {
+            // The cold-start CheckAppStartIntent is buffered and delivered first.
+            assertEquals(SplashViewModel.Command.CheckAppStartIntent, awaitItem())
+
             // Act: manually trigger proceedWithVaultNavigation
             vm.onDeepLinkLaunch(deeplink)
 
@@ -347,6 +381,9 @@ class SplashViewModelTest {
         }
 
         vm.commands.test {
+            // The cold-start CheckAppStartIntent is buffered and delivered first.
+            assertEquals(SplashViewModel.Command.CheckAppStartIntent, awaitItem())
+
             // Act
             vm.onDeepLinkLaunch(deeplink)
 
@@ -400,6 +437,9 @@ class SplashViewModelTest {
         }
 
         vm.commands.test {
+            // The cold-start CheckAppStartIntent is buffered and delivered first.
+            assertEquals(SplashViewModel.Command.CheckAppStartIntent, awaitItem())
+
             // Act
             vm.onDeepLinkLaunch(deeplink)
 


### PR DESCRIPTION
## Problem

One-shot navigation/command flows were exposed as `MutableSharedFlow(replay = 0)`. Such a flow has no buffer: any `emit()` while no collector is attached is **silently dropped**. On cold start there is a window (the activity stop → resume gap, and `onRestore()`/`init` running before `repeatOnLifecycle(STARTED)` collectors attach) where the ViewModel keeps emitting from `viewModelScope` while the UI collector is detached. The result: a navigation command is lost and the app gets stuck (splash hangs, home stays put after a deeplink, a bottom sheet never expands).

This started as a splash-only fix and was extended after auditing every command/event `SharedFlow` in `presentation/` for the same hazard.

## Fix

Back each affected one-shot flow with an unbounded `Channel(Channel.UNLIMITED)` exposed via `receiveAsFlow()`, so an emit made while nobody is collecting is **buffered and delivered to the next subscriber**.

The hazard requires two conditions: no buffer **and** emission from lifecycle-independent code (init / automatic async / resume), not a foreground user tap. Only flows meeting both were converted. Each converted flow was verified to have a **single collector per ViewModel instance**, so `receiveAsFlow`'s single-consumer semantics are correct (no broadcast is lost).

### Areas fixed
- **SplashViewModel** — navigation commands during cold start.
- **MainViewModel** `commands` / `toasts` — emitted from `init` (account-status interception), `onRestore` (in `onCreate`), deeplink/push handling; collected under `repeatOnLifecycle(STARTED)`.
- **NotificationActionDelegate** `dispatcher` — notification-tap commands after async use-cases.
- **HomeScreenViewModel** `commands` + base **NavigationViewModel** `_navigation` — deeplink resume emits commands and navigation automatically (one path after `delay(1000)`).
- **ObjectValueViewModel** / **TagOrStatusValueViewModel** `commands` — `init` pipeline auto-emits `Command.Expand` before the bottom sheet collects.

## Tests

Regression tests added, each verified RED on the old `SharedFlow` and GREEN on the buffered `Channel`:
- `SplashViewModelTest` — command emitted before splash collects is still delivered.
- `NotificationActionDelegateTest` — notification command buffered before a collector subscribes.
- `NavigationViewModelTest` — navigation destination buffered before a collector subscribes.

These cover the shared buffering mechanism used by all of the above. `:app` and `:presentation` (main + unit-test sources) compile clean.

## Out of scope
MED-risk flows (commands emitted at the end of a long async chain that *started* from a user tap — Onboarding login/start, SpacesStorage, ParticipantViewModel, etc.) are strictly lower risk and left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)