### PR TITLE
DROID-4524 Reduce redundant vault cold-start work

### DIFF
--- a/domain/src/main/java/com/anytypeio/anytype/domain/chats/ChatPreviewContainer.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/chats/ChatPreviewContainer.kt
@@ -334,7 +334,12 @@ interface ChatPreviewContainer {
                             preview = preview,
                             attachments = attachmentsBySpace[preview.space].orEmpty()
                         )
-                        preview.copy(dependencies = deps)
+                        // combine() re-fires for every space whenever any single space's
+                        // attachment flow emits, so most previews are unchanged. Reuse the
+                        // existing instance when deps didn't change so the downstream
+                        // distinctUntilChanged() can drop the redundant emission instead of
+                        // forcing a full vault re-render.
+                        if (deps == preview.dependencies) preview else preview.copy(dependencies = deps)
                     }
                     PreviewState.Ready(enriched)
                 }

--- a/domain/src/main/java/com/anytypeio/anytype/domain/chats/PushKeySpaceViewChannel.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/chats/PushKeySpaceViewChannel.kt
@@ -19,12 +19,13 @@ class PushKeySpaceViewChannel @Inject constructor(
     override fun observe(): Flow<PushKeyUpdate> =
         spaceViewSubscriptionContainer.observe()
             // The space-view subscription amends many times on cold start, re-emitting the
-            // full list each time. Collapse to the distinct set of push keys so the expensive
-            // Base64 + SHA-256 id computation below only runs when the keys actually change.
+            // full list each time. Collapse to the distinct SET of push keys (order-insensitive,
+            // so reordering spaces is a no-op) and dedupe, so the expensive Base64 + SHA-256 id
+            // computation below only runs when the set of keys actually changes.
             .map { spaceViews ->
                 spaceViews
                     .mapNotNull { it.spacePushNotificationEncryptionKey?.takeIf(String::isNotEmpty) }
-                    .distinct()
+                    .toSet()
             }
             .distinctUntilChanged()
             .flatMapLatest { keys ->

--- a/domain/src/main/java/com/anytypeio/anytype/domain/chats/PushKeySpaceViewChannel.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/chats/PushKeySpaceViewChannel.kt
@@ -3,8 +3,10 @@ package com.anytypeio.anytype.domain.chats
 import com.anytypeio.anytype.core_models.chats.PushKeyUpdate
 import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import java.security.MessageDigest
 import java.util.Base64
 import javax.inject.Inject
@@ -15,17 +17,28 @@ class PushKeySpaceViewChannel @Inject constructor(
 ) : PushKeyChannel {
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun observe(): Flow<PushKeyUpdate> =
-        spaceViewSubscriptionContainer.observe().flatMapLatest { spaceViews ->
-            flow {
-                spaceViews.forEach { spaceView ->
-                    val key = spaceView.spacePushNotificationEncryptionKey
-                    if (!key.isNullOrEmpty()) {
-                        val id = key.computePushKeyId()
-                        emit(PushKeyUpdate(encryptionKeyId = id, encryptionKey = key))
+        spaceViewSubscriptionContainer.observe()
+            // The space-view subscription amends many times on cold start, re-emitting the
+            // full list each time. Collapse to the distinct set of push keys so the expensive
+            // Base64 + SHA-256 id computation below only runs when the keys actually change.
+            .map { spaceViews ->
+                spaceViews
+                    .mapNotNull { it.spacePushNotificationEncryptionKey?.takeIf(String::isNotEmpty) }
+                    .distinct()
+            }
+            .distinctUntilChanged()
+            .flatMapLatest { keys ->
+                flow {
+                    keys.forEach { key ->
+                        emit(
+                            PushKeyUpdate(
+                                encryptionKeyId = key.computePushKeyId(),
+                                encryptionKey = key
+                            )
+                        )
                     }
                 }
             }
-        }
 }
 
 @OptIn(ExperimentalStdlibApi::class)

--- a/domain/src/test/java/com/anytypeio/anytype/domain/chats/PushKeySpaceViewChannelTest.kt
+++ b/domain/src/test/java/com/anytypeio/anytype/domain/chats/PushKeySpaceViewChannelTest.kt
@@ -53,6 +53,28 @@ class PushKeySpaceViewChannelTest {
     }
 
     @Test
+    fun `does not re-emit when the same key set is re-published by the subscription`() = runTest {
+        val key = Base64.getEncoder().encodeToString("stable-key".toByteArray())
+        val spaceView = mock<ObjectWrapper.SpaceView> {
+            on { spacePushNotificationEncryptionKey } doReturn key
+        }
+        // The space-view subscription amends repeatedly with the same key set on cold start.
+        val source = MutableStateFlow(listOf(spaceView))
+        val container = mock<SpaceViewSubscriptionContainer> {
+            on { observe() } doReturn source
+        }
+        val channel = PushKeySpaceViewChannel(container)
+        channel.observe().test {
+            // First publication produces exactly one update...
+            assertEquals(PushKeyUpdate(key.computePushKeyId(), key), awaitItem())
+            // ...and re-publishing the identical key set must not emit again.
+            source.value = listOf(spaceView)
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `emits for multiple valid keys`() = runTest {
         val key1 = Base64.getEncoder().encodeToString("key1".toByteArray())
         val key2 = Base64.getEncoder().encodeToString("key2".toByteArray())

--- a/domain/src/test/java/com/anytypeio/anytype/domain/chats/PushKeySpaceViewChannelTest.kt
+++ b/domain/src/test/java/com/anytypeio/anytype/domain/chats/PushKeySpaceViewChannelTest.kt
@@ -75,6 +75,56 @@ class PushKeySpaceViewChannelTest {
     }
 
     @Test
+    fun `re-emits the key set when a new key is added (set grows)`() = runTest {
+        val keyA = Base64.getEncoder().encodeToString("keyA".toByteArray())
+        val keyB = Base64.getEncoder().encodeToString("keyB".toByteArray())
+        val spaceA = mock<ObjectWrapper.SpaceView> {
+            on { spacePushNotificationEncryptionKey } doReturn keyA
+        }
+        val spaceB = mock<ObjectWrapper.SpaceView> {
+            on { spacePushNotificationEncryptionKey } doReturn keyB
+        }
+        val source = MutableStateFlow(listOf(spaceA))
+        val container = mock<SpaceViewSubscriptionContainer> {
+            on { observe() } doReturn source
+        }
+        val channel = PushKeySpaceViewChannel(container)
+        channel.observe().test {
+            assertEquals(PushKeyUpdate(keyA.computePushKeyId(), keyA), awaitItem())
+            // A new space with a new key changes the set, so the keys are re-published.
+            source.value = listOf(spaceA, spaceB)
+            assertEquals(PushKeyUpdate(keyA.computePushKeyId(), keyA), awaitItem())
+            assertEquals(PushKeyUpdate(keyB.computePushKeyId(), keyB), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `does not re-emit when only the order of an unchanged key set changes`() = runTest {
+        val keyA = Base64.getEncoder().encodeToString("keyA".toByteArray())
+        val keyB = Base64.getEncoder().encodeToString("keyB".toByteArray())
+        val spaceA = mock<ObjectWrapper.SpaceView> {
+            on { spacePushNotificationEncryptionKey } doReturn keyA
+        }
+        val spaceB = mock<ObjectWrapper.SpaceView> {
+            on { spacePushNotificationEncryptionKey } doReturn keyB
+        }
+        val source = MutableStateFlow(listOf(spaceA, spaceB))
+        val container = mock<SpaceViewSubscriptionContainer> {
+            on { observe() } doReturn source
+        }
+        val channel = PushKeySpaceViewChannel(container)
+        channel.observe().test {
+            assertEquals(PushKeyUpdate(keyA.computePushKeyId(), keyA), awaitItem())
+            assertEquals(PushKeyUpdate(keyB.computePushKeyId(), keyB), awaitItem())
+            // Same set, different order -> set-based dedup suppresses, no new emissions.
+            source.value = listOf(spaceB, spaceA)
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `emits for multiple valid keys`() = runTest {
         val key1 = Base64.getEncoder().encodeToString("key1".toByteArray())
         val key2 = Base64.getEncoder().encodeToString("key2".toByteArray())

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/notifications/PushKeyProviderImpl.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/notifications/PushKeyProviderImpl.kt
@@ -45,14 +45,20 @@ class PushKeyProviderImpl @Inject constructor(
     }
 
     private fun savePushKey(id: String?, value: String?) {
-        val storedKeys = getStoredPushKeys().toMutableMap()
+        if (id.isNullOrEmpty() || value.isNullOrEmpty()) return
 
-        if (!value.isNullOrEmpty() && !id.isNullOrEmpty()) {
-            storedKeys[id] = PushKey(id = id, value = value)
+        val storedKeys = getStoredPushKeys()
+
+        // Skip redundant disk writes: the same key is re-emitted on every space-view
+        // amend during cold start. Only persist when the value actually changed.
+        if (storedKeys[id]?.value == value) return
+
+        val updated = storedKeys.toMutableMap().apply {
+            put(id, PushKey(id = id, value = value))
         }
 
         sharedPreferences.edit().apply {
-            putString(PREF_PUSH_KEYS, json.encodeToString(storedKeys))
+            putString(PREF_PUSH_KEYS, json.encodeToString(updated))
             apply()
         }
     }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/notifications/PushKeyProviderImpl.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/notifications/PushKeyProviderImpl.kt
@@ -44,6 +44,12 @@ class PushKeyProviderImpl @Inject constructor(
         Timber.d("PushKeyProvider stop called")
     }
 
+    /**
+     * Read-modify-write of [PREF_PUSH_KEYS]. Safe without synchronization because it is invoked
+     * only from the single sequential collector in [start] (which cancels any prior job before
+     * relaunching), and this class is the only writer of that pref. Calling it from another
+     * thread/coroutine concurrently could lose updates.
+     */
     private fun savePushKey(id: String?, value: String?) {
         if (id.isNullOrEmpty() || value.isNullOrEmpty()) return
 

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/notifications/PushKeyProviderImplTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/notifications/PushKeyProviderImplTest.kt
@@ -249,6 +249,50 @@ class PushKeyProviderImplTest {
             assertEquals(keyValue, storedKeys[keyId]?.value)
         }
 
+    @Test
+    fun `writes again when the value changes after a run of redundant duplicates`() =
+        runTest(dispatcher) {
+            val keyId = "id"
+            val v1 = "v1"
+            val v2 = "v2"
+
+            val spyPrefs = Mockito.spy(sharedPreferences)
+            val channelFlow = MutableSharedFlow<PushKeyUpdate>(replay = 0)
+            mockChannel.stub {
+                on { observe() } doReturn channelFlow
+            }
+
+            val provider = PushKeyProviderImpl(
+                sharedPreferences = spyPrefs,
+                channel = mockChannel,
+                dispatchers = AppCoroutineDispatchers(
+                    io = dispatcher,
+                    main = dispatcher,
+                    computation = dispatcher
+                ),
+                scope = testScope,
+                json = json
+            )
+            provider.start()
+            dispatcher.scheduler.advanceUntilIdle()
+
+            // Same value three times, then a real change.
+            repeat(3) {
+                channelFlow.emit(PushKeyUpdate(encryptionKey = v1, encryptionKeyId = keyId))
+                dispatcher.scheduler.advanceUntilIdle()
+            }
+            channelFlow.emit(PushKeyUpdate(encryptionKey = v2, encryptionKeyId = keyId))
+            dispatcher.scheduler.advanceUntilIdle()
+
+            // One write for v1, two duplicates skipped, one write for the real change to v2.
+            verify(spyPrefs, times(2)).edit()
+
+            val storedKeys: Map<String, PushKey> = json.decodeFromString(
+                spyPrefs.getString(PushKeyProviderImpl.PREF_PUSH_KEYS, "{}") ?: "{}"
+            )
+            assertEquals(v2, storedKeys[keyId]?.value)
+        }
+
     private fun createPushKeyProvider(): PushKeyProviderImpl {
         return PushKeyProviderImpl(
             sharedPreferences = sharedPreferences,

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/notifications/PushKeyProviderImplTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/notifications/PushKeyProviderImplTest.kt
@@ -21,9 +21,12 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.stub
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -203,6 +206,48 @@ class PushKeyProviderImplTest {
         // Ensure no other keys were affected
         assertEquals(1, storedKeys2.size) // Still only one key should be present
     }
+
+    @Test
+    fun `should skip redundant prefs write when the same key-value is emitted repeatedly`() =
+        runTest(dispatcher) {
+            val keyId = "dup_key_id"
+            val keyValue = "dup_key_value"
+
+            val spyPrefs = Mockito.spy(sharedPreferences)
+            val channelFlow = MutableSharedFlow<PushKeyUpdate>(replay = 0)
+            mockChannel.stub {
+                on { observe() } doReturn channelFlow
+            }
+
+            val provider = PushKeyProviderImpl(
+                sharedPreferences = spyPrefs,
+                channel = mockChannel,
+                dispatchers = AppCoroutineDispatchers(
+                    io = dispatcher,
+                    main = dispatcher,
+                    computation = dispatcher
+                ),
+                scope = testScope,
+                json = json
+            )
+            provider.start()
+            dispatcher.scheduler.advanceUntilIdle()
+
+            // The same push key arrives three times (as happens on every space-view amend)
+            repeat(3) {
+                channelFlow.emit(PushKeyUpdate(encryptionKey = keyValue, encryptionKeyId = keyId))
+                dispatcher.scheduler.advanceUntilIdle()
+            }
+
+            // Only the first emission should hit disk; the identical repeats are skipped
+            verify(spyPrefs, times(1)).edit()
+
+            // ...and the value is still correctly persisted
+            val storedKeys: Map<String, PushKey> = json.decodeFromString(
+                spyPrefs.getString(PushKeyProviderImpl.PREF_PUSH_KEYS, "{}") ?: "{}"
+            )
+            assertEquals(keyValue, storedKeys[keyId]?.value)
+        }
 
     private fun createPushKeyProvider(): PushKeyProviderImpl {
         return PushKeyProviderImpl(


### PR DESCRIPTION
## Summary
Reduces redundant per-event work on the vault cold-start path (large vault, ~74 spaces) that caused scroll jank during the first ~30s.

- **PushKeyProviderImpl**: skip the SharedPreferences write when the stored key value is unchanged.
- **PushKeySpaceViewChannel**: dedup the key set (map -> distinct -> distinctUntilChanged) so the push-key id (Base64 + SHA-256) is computed only when keys actually change.
- **ChatPreviewContainer.enrichWithAttachments**: reuse the existing `Chat.Preview` when dependencies are unchanged, letting the existing `distinctUntilChanged()` drop redundant emissions instead of forcing a vault re-render.

## Measured (cold start, ~74 spaces)
- Choreographer skipped frames: 5 (incl. 84-frame) -> 0; Davey long frames -> 0; scrolling smooth.
- Push-key re-saves: 935 -> 65 (-93%)
- buildUpdatedDependencies: 1923 -> 506 (-74%)
- Vault preview rebuilds: 1115 -> 120 (-89%)

## Tests
New unit tests for the push-key write-guard and channel dedup. PushKeyProvider 5/5, PushKeySpaceViewChannel 4/4, domain chats 23/23 green. (Build/test requires JDK 17.)

Linear: https://linear.app/anytype/issue/DROID-4524