### PR TITLE
DROID-4529 Enable Kanban (Board) layout by default

### DIFF
--- a/persistence/src/main/java/com/anytypeio/anytype/persistence/repo/DefaultUserSettingsCache.kt
+++ b/persistence/src/main/java/com/anytypeio/anytype/persistence/repo/DefaultUserSettingsCache.kt
@@ -59,7 +59,7 @@ class DefaultUserSettingsCache(
     )
 
     private val _kanbanFlow = MutableStateFlow(
-        prefs.getBoolean(KANBAN_ENABLED_KEY, false)
+        prefs.getBoolean(KANBAN_ENABLED_KEY, true)
     )
 
     private val _fileDownloadLimitFlow = MutableStateFlow(
@@ -785,7 +785,7 @@ class DefaultUserSettingsCache(
     override fun observeCompactModeEnabled(): Flow<Boolean> = _compactModeFlow.asStateFlow()
 
     override suspend fun getKanbanEnabled(): Boolean {
-        return prefs.getBoolean(KANBAN_ENABLED_KEY, false)
+        return prefs.getBoolean(KANBAN_ENABLED_KEY, true)
     }
 
     override suspend fun setKanbanEnabled(enabled: Boolean) {

--- a/persistence/src/test/java/com/anytypeio/anytype/persistence/UserSettingsCacheTest.kt
+++ b/persistence/src/test/java/com/anytypeio/anytype/persistence/UserSettingsCacheTest.kt
@@ -52,21 +52,21 @@ class UserSettingsCacheTest {
     }
 
     @Test
-    fun `kanban experimental flag defaults to false and round-trips`() = runTest {
+    fun `kanban experimental flag defaults to true and round-trips`() = runTest {
         val cache = DefaultUserSettingsCache(
             prefs = defaultPrefs,
             context = ApplicationProvider.getApplicationContext(),
             appDefaultDateFormatProvider = dateFormatProvider
         )
 
-        assertEquals(expected = false, actual = cache.getKanbanEnabled())
-
-        cache.setKanbanEnabled(true)
         assertEquals(expected = true, actual = cache.getKanbanEnabled())
-        assertEquals(expected = true, actual = cache.observeKanbanEnabled().first())
 
         cache.setKanbanEnabled(false)
         assertEquals(expected = false, actual = cache.getKanbanEnabled())
+        assertEquals(expected = false, actual = cache.observeKanbanEnabled().first())
+
+        cache.setKanbanEnabled(true)
+        assertEquals(expected = true, actual = cache.getKanbanEnabled())
     }
 
     @Test

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
@@ -302,7 +302,7 @@ class ObjectSetViewModel(
 
     /** Whether the experimental Kanban (Board) view is enabled; when off, BOARD views are unsupported. */
     private val isKanbanEnabled = userSettingsRepository.observeKanbanEnabled()
-        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
 
     /** Fires a board re-render whenever any board-specific flow changes. */
     private val boardRenderTrigger = combine(

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/settings/ExperimentalFeaturesViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/settings/ExperimentalFeaturesViewModel.kt
@@ -17,7 +17,7 @@ class ExperimentalFeaturesViewModel(
     private val _isCompactModeEnabled = MutableStateFlow(true)
     val isCompactModeEnabled: StateFlow<Boolean> = _isCompactModeEnabled.asStateFlow()
 
-    private val _isKanbanEnabled = MutableStateFlow(false)
+    private val _isKanbanEnabled = MutableStateFlow(true)
     val isKanbanEnabled: StateFlow<Boolean> = _isKanbanEnabled.asStateFlow()
 
     init {


### PR DESCRIPTION
## What

Flips the experimental Kanban flag default from `false` to `true`, so the Board layout is visible by default without opting in via Experimental Features.

## Changes

- `DefaultUserSettingsCache`: default for `KANBAN_ENABLED_KEY` is now `true` (both `getKanbanEnabled()` and the observed flow's initial value). The pref key is unchanged, so users who explicitly toggled the setting keep their saved choice.
- `ExperimentalFeaturesViewModel` / `ObjectSetViewModel`: pre-load initial state flipped to `true` to match the new default and avoid a brief "off" flash.
- `UserSettingsCacheTest`: default-value test updated to expect `true`.

## Testing

- `UserSettingsCacheTest`, `ObjectSetBoardSubscriptionTest`, `ObjectSetBoardLayoutMenuTest` pass.
- Presentation and app modules compile cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)