### PR TITLE
DROID-4538 Prevent concurrent text loss in empty blocks

### DIFF
--- a/core-models/src/main/java/com/anytypeio/anytype/core_models/Block.kt
+++ b/core-models/src/main/java/com/anytypeio/anytype/core_models/Block.kt
@@ -433,10 +433,27 @@ data class Block(
         /**
          * Prototype of the textual block.
          * @param style style for a block to create
+         * @param text optional initial text for a block to create
+         * @param marks optional initial marks for a block to create
+         * @param checked optional initial checked state (checkbox style)
+         * @param color optional initial text color
+         * @param iconEmoji optional initial icon emoji (callout style)
+         * @param iconImage optional initial icon image (callout style)
+         * @param align optional initial block alignment
+         * @param backgroundColor optional initial block background color
+         * @param fields optional initial block fields
          */
         data class Text(
             val style: Style,
-            val text: String? = null
+            val text: String? = null,
+            val marks: List<Content.Text.Mark> = emptyList(),
+            val checked: Boolean? = null,
+            val color: String? = null,
+            val iconEmoji: String? = null,
+            val iconImage: String? = null,
+            val align: Align? = null,
+            val backgroundColor: String? = null,
+            val fields: Fields? = null
         ) : Prototype()
 
         data class File(

--- a/middleware/src/main/java/com/anytypeio/anytype/middleware/interactor/MiddlewareFactory.kt
+++ b/middleware/src/main/java/com/anytypeio/anytype/middleware/interactor/MiddlewareFactory.kt
@@ -6,6 +6,7 @@ import com.anytypeio.anytype.middleware.mappers.MBDiv
 import com.anytypeio.anytype.middleware.mappers.MBDivStyle
 import com.anytypeio.anytype.middleware.mappers.MBFile
 import com.anytypeio.anytype.middleware.mappers.MBLink
+import com.anytypeio.anytype.middleware.mappers.MBMarks
 import com.anytypeio.anytype.middleware.mappers.MBRelation
 import com.anytypeio.anytype.middleware.mappers.MBTableOfContents
 import com.anytypeio.anytype.middleware.mappers.MBText
@@ -31,9 +32,25 @@ class MiddlewareFactory {
             is Block.Prototype.Text -> {
                 val text = MBText(
                     style = prototype.style.toMiddlewareModel(),
-                    text = prototype.text.orEmpty()
+                    text = prototype.text.orEmpty(),
+                    marks = if (prototype.marks.isEmpty()) {
+                        null
+                    } else {
+                        MBMarks(marks = prototype.marks.map { it.toMiddlewareModel() })
+                    },
+                    checked = prototype.checked ?: false,
+                    color = prototype.color.orEmpty(),
+                    iconEmoji = prototype.iconEmoji.orEmpty(),
+                    iconImage = prototype.iconImage.orEmpty()
                 )
-                MBlock(text = text)
+                MBlock(
+                    text = text,
+                    backgroundColor = prototype.backgroundColor.orEmpty(),
+                    align = prototype.align.toMiddlewareModel(),
+                    fields = prototype.fields
+                        ?.takeIf { it.map.isNotEmpty() }
+                        ?.toMiddlewareModel()
+                )
             }
             is Block.Prototype.DividerLine -> {
                 val divider = MBDiv(style = MBDivStyle.Line)

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/Editor.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/Editor.kt
@@ -116,7 +116,15 @@ interface Editor {
 
     class Memory(
         val selections: SelectionStateHolder
-    )
+    ) {
+        /**
+         * Ids of blocks created by this editor session (create, replace, split, duplicate).
+         * Used to decide whether an empty trailing block can be safely focus-reused
+         * on outside click: reusing a block created by another client can lead to
+         * concurrent typing into the same block and last-writer-wins data loss.
+         */
+        val sessionCreatedBlockIds: MutableSet<Id> = mutableSetOf()
+    }
 
     sealed class Restore {
         data class Selection(

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
@@ -300,7 +300,9 @@ import java.util.LinkedList
 import java.util.Queue
 import java.util.regex.Pattern
 import kotlinx.coroutines.Job
+import com.anytypeio.anytype.presentation.editor.editor.pattern.DefaultPatternMatcher
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.yield
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -876,11 +878,13 @@ class EditorViewModel(
                 footers.value = getFooterState(root, currentObj)
                 val flags = mutableListOf<BlockViewRenderer.RenderFlag>()
                 Timber.d("Rendering starting...")
-                val doc = models.asMap().render(
+                val (placeholderModels, placeholderFocus) = resolveTrailingPlaceholder(models, focus)
+                val (renderModels, renderFocus) = resolveIdentityFork(placeholderModels, placeholderFocus)
+                val doc = renderModels.asMap().render(
                     context = context,
                     mode = mode,
-                    root = root,
-                    focus = focus,
+                    root = renderModels.first { it.id == context },
+                    focus = renderFocus,
                     anchor = context,
                     indent = INITIAL_INDENT,
                     details = objectViewDetails,
@@ -1100,6 +1104,19 @@ class EditorViewModel(
             .saves
             .stream()
             .filterNotNull()
+            .filter { update ->
+                // No text write on mere cursor placement: focus/blur and
+                // shortcut-triggered save flushes re-emit the block's unchanged
+                // text, and each such set-text is a last-writer-wins write that
+                // can stomp a concurrent peer edit on merge. Only proceed when
+                // the text or marks actually differ from the locally known
+                // synced state.
+                !isTextSameAsSynced(
+                    target = update.target,
+                    text = update.text,
+                    marks = update.markup.filter { it.range.first != it.range.last }
+                )
+            }
             .onEach { update ->
                 val updated = blocks.map { block ->
                     if (block.id == update.target) {
@@ -1123,6 +1140,20 @@ class EditorViewModel(
             .launchIn(viewModelScope)
     }
 
+    /**
+     * True when [text] and [marks] are identical to the locally known synced
+     * state of [target] — in which case sending a set-text write is a no-op
+     * that only risks overwriting a concurrent peer edit.
+     */
+    private fun isTextSameAsSynced(
+        target: Id,
+        text: String,
+        marks: List<Content.Text.Mark>
+    ): Boolean {
+        val content = blocks.find { it.id == target }?.content as? Content.Text ?: return false
+        return content.text == text && content.marks == marks
+    }
+
     private fun proceedWithUpdatingText(intent: Intent.Text.UpdateText) {
         viewModelScope.launch {
             orchestrator.proxies.intents.send(intent)
@@ -1133,6 +1164,11 @@ class EditorViewModel(
         Timber.d("onStart, id:[$id]")
 
         this.context = id
+
+        trailingPlaceholder = null
+        lastMaterializedTrailingBlock = null
+        identityFork = null
+        lastForkedBlock = null
 
         stateData.postValue(ViewState.Loading)
 
@@ -1427,6 +1463,9 @@ class EditorViewModel(
         marks: List<Content.Text.Mark>
     ) {
         Timber.d("onTextChanged, id:[$id], text:[$text], marks:[$marks]")
+        if (proceedWithIdentityForkTextChange(id = id, text = text, marks = marks, syncViewsStore = {})) {
+            return
+        }
         val update = TextUpdate.Default(target = id, text = text, markup = marks)
         viewModelScope.launch { orchestrator.proxies.changes.send(update) }
     }
@@ -1468,6 +1507,24 @@ class EditorViewModel(
 
     fun onTextBlockTextChanged(view: BlockView.Text) {
         Timber.d("onTextBlockTextChanged, view:[$view]")
+
+        if (view.id == VIRTUAL_TRAILING_BLOCK_ID) {
+            proceedWithTrailingPlaceholderTextChange(view)
+            return
+        }
+
+        val consumedByFork = proceedWithIdentityForkTextChange(
+            id = view.id,
+            text = view.text,
+            marks = view.marks.map { it.mark() },
+            syncViewsStore = {
+                viewModelScope.launch {
+                    val store = orchestrator.stores.views
+                    store.update(store.current().map { if (it.id == view.id) view else it })
+                }
+            }
+        )
+        if (consumedByFork) return
 
         val update = TextUpdate.Pattern(
             target = view.id,
@@ -1544,6 +1601,9 @@ class EditorViewModel(
                 )
             }
         } else {
+            if (id == VIRTUAL_TRAILING_BLOCK_ID) {
+                proceedWithTrailingPlaceholderFocusLost()
+            }
             sendHideTypesWidgetEvent()
         }
     }
@@ -1577,6 +1637,26 @@ class EditorViewModel(
         range: IntRange
     ) {
         Timber.d("onEnterKeyClicked, target:[$target] text:[$text] marks:[$marks] range:[$range]")
+
+        if (target == VIRTUAL_TRAILING_BLOCK_ID) {
+            proceedWithTrailingPlaceholderEnter(text, marks, range)
+            return
+        }
+
+        val fork = identityFork
+        if (fork != null && target == fork.oldId) {
+            // Replace in flight — replay the enter against the forked block.
+            fork.text = text
+            fork.marks = marks
+            fork.onForked += { id -> proceedWithEnterEvent(id, range, text, marks) }
+            return
+        }
+        val redirected = lastForkedBlock
+        if (redirected != null && target == redirected.first) {
+            proceedWithEnterEvent(redirected.second, range, text, marks)
+            return
+        }
+
         val focus = orchestrator.stores.focus.current()
         if (!focus.isEmpty && focus.isTarget(target)) {
             proceedWithEnterEvent(focus.requireTarget(), range, text, marks)
@@ -1623,6 +1703,11 @@ class EditorViewModel(
         val block = blocks.first { it.id == target }
         val content = block.content<Content.Text>()
 
+        // Skip the pre-split save flush when nothing actually changed —
+        // a redundant set-text is a last-writer-wins write that can stomp
+        // a concurrent peer edit.
+        val isFlushRedundant = isTextSameAsSynced(target, text, marks)
+
         val update = blocks.updateTextContent(target, text, marks)
         orchestrator.stores.document.update(update)
 
@@ -1631,15 +1716,17 @@ class EditorViewModel(
             orchestrator.proxies.changes.send(null)
         }
 
-        viewModelScope.launch {
-            orchestrator.proxies.intents.send(
-                Intent.Text.UpdateText(
-                    context = context,
-                    target = target,
-                    marks = marks,
-                    text = text
+        if (!isFlushRedundant) {
+            viewModelScope.launch {
+                orchestrator.proxies.intents.send(
+                    Intent.Text.UpdateText(
+                        context = context,
+                        target = target,
+                        marks = marks,
+                        text = text
+                    )
                 )
-            )
+            }
         }
 
         viewModelScope.launch {
@@ -1741,6 +1828,20 @@ class EditorViewModel(
 
     fun onEmptyBlockBackspaceClicked(id: String) {
         Timber.d("onEmptyBlockBackspaceClicked, id:[$id]")
+        if (id == VIRTUAL_TRAILING_BLOCK_ID) {
+            proceedWithTrailingPlaceholderBackspace()
+            return
+        }
+        val fork = identityFork
+        if (fork != null && id == fork.oldId) {
+            fork.onForked += { newId -> onEmptyBlockBackspaceClicked(newId) }
+            return
+        }
+        val redirected = lastForkedBlock
+        if (redirected != null && id == redirected.first) {
+            onEmptyBlockBackspaceClicked(redirected.second)
+            return
+        }
         val position = views.indexOfFirst { it.id == id }
         if (position > 0) {
             val current = views[position]
@@ -1786,6 +1887,46 @@ class EditorViewModel(
     ) {
         Timber.d("onNonEmptyBlockBackspaceClicked, id:[$id] text:[$text] marks:[$marks]")
 
+        if (id == VIRTUAL_TRAILING_BLOCK_ID) {
+            val state = trailingPlaceholder
+            if (state != null) {
+                // The block is being created — replay the merge-backspace against it.
+                state.text = text
+                state.marks = marks
+                state.onMaterialized += { newId ->
+                    onNonEmptyBlockBackspaceClicked(id = newId, text = text, marks = marks)
+                }
+                materializeTrailingPlaceholder()
+            } else {
+                // The placeholder was already swapped — retarget to the created block.
+                lastMaterializedTrailingBlock?.let { target ->
+                    onNonEmptyBlockBackspaceClicked(id = target, text = text, marks = marks)
+                }
+            }
+            return
+        }
+
+        val fork = identityFork
+        if (fork != null && id == fork.oldId) {
+            // Replace in flight — replay the merge-backspace against the forked block.
+            fork.text = text
+            fork.marks = marks
+            fork.onForked += { newId ->
+                onNonEmptyBlockBackspaceClicked(id = newId, text = text, marks = marks)
+            }
+            return
+        }
+        val redirected = lastForkedBlock
+        if (redirected != null && id == redirected.first) {
+            onNonEmptyBlockBackspaceClicked(id = redirected.second, text = text, marks = marks)
+            return
+        }
+
+        // Skip the pre-merge save flush when nothing actually changed —
+        // a redundant set-text is a last-writer-wins write that can stomp
+        // a concurrent peer edit.
+        val isFlushRedundant = isTextSameAsSynced(id, text, marks)
+
         val update = blocks.map { block ->
             if (block.id == id) {
                 block.copy(
@@ -1806,15 +1947,17 @@ class EditorViewModel(
             orchestrator.proxies.changes.send(null)
         }
 
-        viewModelScope.launch {
-            orchestrator.proxies.intents.send(
-                Intent.Text.UpdateText(
-                    context = context,
-                    target = id,
-                    marks = marks,
-                    text = text
+        if (!isFlushRedundant) {
+            viewModelScope.launch {
+                orchestrator.proxies.intents.send(
+                    Intent.Text.UpdateText(
+                        context = context,
+                        target = id,
+                        marks = marks,
+                        text = text
+                    )
                 )
-            )
+            }
         }
 
         val index = views.indexOfFirst { it.id == id }
@@ -1900,6 +2043,7 @@ class EditorViewModel(
     }
 
     private fun proceedWithEnteringActionMode(target: Id, scrollTarget: Boolean = true) {
+        if (target == VIRTUAL_TRAILING_BLOCK_ID) return
         val views = orchestrator.stores.views.current()
         val view = views.find { it.id == target }
 
@@ -2481,6 +2625,20 @@ class EditorViewModel(
 
         val focused = orchestrator.stores.focus.current().targetOrNull()
 
+        val placeholder = trailingPlaceholder
+        if (focused == VIRTUAL_TRAILING_BLOCK_ID && placeholder != null) {
+            // Mirrors the empty-block behavior below (replace with the chosen style):
+            // the placeholder materializes directly with that style, or — when a
+            // create is already in flight — the style is applied after the swap.
+            if (placeholder.isMaterializing) {
+                placeholder.onMaterialized += { onAddTextBlockClicked(style) }
+            } else {
+                materializeTrailingPlaceholder(style = style)
+            }
+            controlPanelInteractor.onEvent(ControlPanelMachine.Event.OnAddBlockToolbarOptionSelected)
+            return
+        }
+
         val target = if (focused != null)
             blocks.find { it.id == focused }
         else
@@ -2552,6 +2710,7 @@ class EditorViewModel(
 
     fun onAddFileBlockClicked(type: Content.File.Type) {
         Timber.d("onAddFileBlockClicked, type:[$type]")
+        if (deferUntilTrailingPlaceholderMaterialized { onAddFileBlockClicked(type) }) return
         val focused = orchestrator.stores.focus.current().targetOrNull()
         val target = if (focused != null)
             blocks.find { it.id == focused }
@@ -2739,6 +2898,7 @@ class EditorViewModel(
 
     fun onBlockToolbarStyleClicked() {
         Timber.d("onBlockToolbarStyleClicked, ")
+        if (deferUntilTrailingPlaceholderMaterialized { onBlockToolbarStyleClicked() }) return
         val focus = orchestrator.stores.focus.current().targetOrNull()
         val targetId = focus.orEmpty()
         if (targetId.isNotEmpty()) {
@@ -2924,6 +3084,7 @@ class EditorViewModel(
 
     fun onBlockToolbarBlockActionsClicked() {
         Timber.d("onBlockToolbarBlockActionsClicked, ")
+        if (deferUntilTrailingPlaceholderMaterialized { onBlockToolbarBlockActionsClicked() }) return
         val target = orchestrator.stores.focus.current().targetOrNull()
         val view = if (target != null) views.find { it.id == target } else null
         if (view == null) {
@@ -3262,6 +3423,7 @@ class EditorViewModel(
 
     fun onAddDividerBlockClicked(style: Content.Divider.Style) {
         Timber.d("onAddDividerBlockClicked, style:[$style]")
+        if (deferUntilTrailingPlaceholderMaterialized { onAddDividerBlockClicked(style) }) return
         addDividerBlock(style)
         controlPanelInteractor.onEvent(ControlPanelMachine.Event.OnAddBlockToolbarOptionSelected)
     }
@@ -3276,6 +3438,11 @@ class EditorViewModel(
             return
         }
 
+        if (mode !is EditorMode.Edit) {
+            Timber.d("Outside click is ignored in mode: $mode")
+            return
+        }
+
         val restrictions = orchestrator.stores.objectRestrictions.current()
         if (restrictions.contains(ObjectRestriction.BLOCKS)) {
             Timber.d("Object contains restriction BLOCKS, can't create blocks")
@@ -3285,54 +3452,62 @@ class EditorViewModel(
         val root = blocks.find { it.id == context } ?: return
 
         if (root.children.isEmpty()) {
-            addNewBlockAtTheEnd()
+            proceedWithShowingTrailingPlaceholder()
         } else {
             val last = blocks.find { it.id == root.children.last() }
             when (val content = last?.content) {
                 is Content.Text -> {
                     when {
-                        content.style == Content.Text.Style.TITLE -> addNewBlockAtTheEnd()
-                        content.style == Content.Text.Style.CODE_SNIPPET -> addNewBlockAtTheEnd()
-                        content.text.isNotEmpty() -> addNewBlockAtTheEnd()
+                        content.style == Content.Text.Style.TITLE -> proceedWithShowingTrailingPlaceholder()
+                        content.style == Content.Text.Style.CODE_SNIPPET -> proceedWithShowingTrailingPlaceholder()
+                        content.text.isNotEmpty() -> proceedWithShowingTrailingPlaceholder()
                         content.text.isEmpty() -> {
-                            val stores = orchestrator.stores
-                            if (stores.focus.current().isEmpty) {
-                                val focus = Editor.Focus(
-                                    target = Editor.Focus.Target.Block(last.id),
-                                    cursor = null
-                                )
-                                viewModelScope.launch { orchestrator.stores.focus.update(focus) }
-                                viewModelScope.launch { refresh() }
+                            if (orchestrator.memory.sessionCreatedBlockIds.contains(last.id)) {
+                                // Focus-reuse is safe only for blocks created by this session.
+                                // An empty trailing block from another client may be typed into
+                                // concurrently, and block text is last-writer-wins — so a foreign
+                                // empty block gets the virtual placeholder below it instead.
+                                val stores = orchestrator.stores
+                                if (stores.focus.current().isEmpty) {
+                                    val focus = Editor.Focus(
+                                        target = Editor.Focus.Target.Block(last.id),
+                                        cursor = null
+                                    )
+                                    viewModelScope.launch { orchestrator.stores.focus.update(focus) }
+                                    viewModelScope.launch { refresh() }
+                                } else {
+                                    Timber.d("Outside click is ignored because focus is not empty")
+                                }
                             } else {
-                                Timber.d("Outside click is ignored because focus is not empty")
+                                proceedWithShowingTrailingPlaceholder()
                             }
                         }
                         else -> Timber.d("Outside-click has been ignored.")
                     }
                 }
                 is Content.Link -> {
-                    addNewBlockAtTheEnd()
+                    proceedWithShowingTrailingPlaceholder()
                 }
                 is Content.Bookmark -> {
-                    addNewBlockAtTheEnd()
+                    proceedWithShowingTrailingPlaceholder()
                 }
                 is Content.File -> {
-                    addNewBlockAtTheEnd()
+                    proceedWithShowingTrailingPlaceholder()
                 }
                 is Content.Divider -> {
-                    addNewBlockAtTheEnd()
+                    proceedWithShowingTrailingPlaceholder()
                 }
                 is Content.Layout -> {
-                    addNewBlockAtTheEnd()
+                    proceedWithShowingTrailingPlaceholder()
                 }
                 is Content.RelationBlock -> {
-                    addNewBlockAtTheEnd()
+                    proceedWithShowingTrailingPlaceholder()
                 }
                 is Content.Table -> {
-                    addNewBlockAtTheEnd()
+                    proceedWithShowingTrailingPlaceholder()
                 }
                 is Content.TableOfContents -> {
-                    addNewBlockAtTheEnd()
+                    proceedWithShowingTrailingPlaceholder()
                 }
                 else -> {
                     Timber.d("Outside-click has been ignored.")
@@ -3341,12 +3516,615 @@ class EditorViewModel(
         }
     }
 
+    //region TRAILING PLACEHOLDER
+
+    /**
+     * State of the virtual trailing block ("click-to-type" placeholder).
+     *
+     * Clicking the empty area below the document content must not create a block:
+     * an empty block synced to peers makes every client's "click below content"
+     * logic focus-reuse the same block id, and concurrent typing into it is
+     * silently destroyed by last-writer-wins text sync. Instead, a purely
+     * presentational paragraph is appended to the rendered document. The real
+     * block is created only on first input — already carrying that input — and
+     * the placeholder is then swapped for the created block, preserving the caret.
+     */
+    private var trailingPlaceholder: TrailingPlaceholderState? = null
+
+    /**
+     * Id of the block most recently created from the placeholder. Events the UI
+     * dispatches against [VIRTUAL_TRAILING_BLOCK_ID] after the swap are redirected here.
+     */
+    private var lastMaterializedTrailingBlock: Id? = null
+
+    private class TrailingPlaceholderState(
+        var text: String = EMPTY_TEXT,
+        var marks: List<Content.Text.Mark> = emptyList(),
+        var isMaterializing: Boolean = false,
+        var materialized: Id? = null,
+        /** Text/marks last known to be synced to the middleware for the created block. */
+        var syncedText: String = EMPTY_TEXT,
+        var syncedMarks: List<Content.Text.Mark> = emptyList(),
+        /**
+         * Actions deferred until the created block is swapped in, replayed in
+         * the order the user performed them.
+         */
+        val onMaterialized: MutableList<(Id) -> Unit> = mutableListOf()
+    )
+
+    private fun proceedWithShowingTrailingPlaceholder() {
+        val state = trailingPlaceholder
+        if (state != null && orchestrator.stores.focus.current().isTarget(VIRTUAL_TRAILING_BLOCK_ID)) {
+            // Already shown and focused. In particular, repeated taps must never
+            // produce more than one placeholder — or any block at all.
+            return
+        }
+        if (state == null) {
+            trailingPlaceholder = TrailingPlaceholderState()
+        }
+        viewModelScope.launch {
+            orchestrator.stores.focus.update(
+                Editor.Focus(
+                    target = Editor.Focus.Target.Block(VIRTUAL_TRAILING_BLOCK_ID),
+                    cursor = null
+                )
+            )
+            refresh()
+        }
+    }
+
+    /**
+     * Creates the real block for the placeholder, carrying its current content.
+     * No-op if a create request is already in flight.
+     */
+    private fun materializeTrailingPlaceholder(style: Content.Text.Style = Content.Text.Style.P) {
+        val state = trailingPlaceholder ?: return
+        if (state.isMaterializing) return
+        state.isMaterializing = true
+        viewModelScope.launch {
+            val text = state.text
+            val marks = state.marks
+            state.syncedText = text
+            state.syncedMarks = marks
+            orchestrator.proxies.intents.send(
+                Intent.CRUD.Create(
+                    context = context,
+                    target = EMPTY_TEXT,
+                    position = Position.INNER,
+                    prototype = Prototype.Text(
+                        style = style,
+                        text = text,
+                        marks = marks
+                    ),
+                    onSuccess = { id ->
+                        // Invoked before the payload is dispatched, so the swap
+                        // render below is guaranteed to see the materialized id.
+                        state.materialized = id
+                        lastMaterializedTrailingBlock = id
+                        // Input that arrived while the create was in flight must
+                        // not wait for the swap render — the editor may be closed
+                        // before it happens. Sync it to the middleware now.
+                        flushTrailingPlaceholderDivergence(state, id)
+                    },
+                    onFailure = {
+                        // Keep the typed text in the placeholder; the next input
+                        // (keystroke, enter, paste) retries the create. Deferred
+                        // actions are dropped: replaying them against a later,
+                        // unrelated materialization would act on the wrong block.
+                        state.isMaterializing = false
+                        state.onMaterialized.clear()
+                        sendToast("Error while creating a new block")
+                    }
+                )
+            )
+        }
+    }
+
+    /**
+     * Syncs input buffered while the create was in flight straight to the
+     * middleware, bypassing the render pipeline: waiting for the swap render
+     * would lose the tail when the editor is closed before it happens.
+     */
+    private fun flushTrailingPlaceholderDivergence(state: TrailingPlaceholderState, target: Id) {
+        if (state.text == state.syncedText && state.marks == state.syncedMarks) return
+        val text = state.text
+        val marks = state.marks
+        state.syncedText = text
+        state.syncedMarks = marks
+        viewModelScope.launch {
+            orchestrator.proxies.intents.send(
+                Intent.Text.UpdateText(
+                    context = context,
+                    target = target,
+                    text = text,
+                    marks = marks
+                )
+            )
+        }
+    }
+
+    /**
+     * When the focused block is the trailing placeholder, creates the real block
+     * (carrying the current placeholder content) and re-dispatches [action] after
+     * the swap, when the created block holds focus. Returns true when deferred —
+     * callers must not proceed with the virtual id.
+     */
+    private fun deferUntilTrailingPlaceholderMaterialized(action: () -> Unit): Boolean {
+        val state = trailingPlaceholder ?: return false
+        if (!orchestrator.stores.focus.current().isTarget(VIRTUAL_TRAILING_BLOCK_ID)) return false
+        state.onMaterialized += { action() }
+        materializeTrailingPlaceholder()
+        return true
+    }
+
+    /**
+     * Called from the render pipeline: appends the virtual paragraph while the
+     * placeholder is active, and performs the swap once the created block has
+     * arrived in the document.
+     */
+    private suspend fun resolveTrailingPlaceholder(
+        models: List<Block>,
+        focus: Editor.Focus
+    ): Pair<List<Block>, Editor.Focus> {
+        val state = trailingPlaceholder ?: return models to focus
+        val materialized = state.materialized
+        if (materialized == null || models.none { it.id == materialized }) {
+            // Placeholder is visible: render it as a regular trailing paragraph.
+            // It exists only in the render input, never in the document store.
+            val virtual = Block(
+                id = VIRTUAL_TRAILING_BLOCK_ID,
+                children = emptyList(),
+                content = Content.Text(
+                    text = state.text,
+                    style = Content.Text.Style.P,
+                    marks = state.marks
+                ),
+                fields = Block.Fields.empty()
+            )
+            val appended = models.map { block ->
+                if (block.id == context) {
+                    block.copy(children = block.children + VIRTUAL_TRAILING_BLOCK_ID)
+                } else {
+                    block
+                }
+            } + virtual
+            return appended to focus
+        }
+        // The created block has arrived — swap the placeholder for it.
+        trailingPlaceholder = null
+        var result = models
+        var effectiveFocus = focus
+        if (focus.isTarget(VIRTUAL_TRAILING_BLOCK_ID) || focus.isTarget(materialized)) {
+            val selection = orchestrator.stores.textSelection.current()
+                .takeIf { it.id == VIRTUAL_TRAILING_BLOCK_ID }
+                ?.selection?.last
+                ?.coerceIn(0, state.text.length)
+                ?: state.text.length
+            effectiveFocus = Editor.Focus(
+                target = Editor.Focus.Target.Block(materialized),
+                cursor = Editor.Cursor.Range(selection..selection)
+            )
+            orchestrator.stores.focus.update(effectiveFocus)
+        }
+        val content = models.first { it.id == materialized }.content
+        if (content is Content.Text && content.text != state.text) {
+            // Text typed while the create request was in flight: patch this render's
+            // input and the local document.
+            result = models.map { block ->
+                if (block.id == materialized) {
+                    block.copy(content = content.copy(text = state.text, marks = state.marks))
+                } else {
+                    block
+                }
+            }
+            // Patch the live store rather than writing the render snapshot back:
+            // the snapshot may predate events applied while this render was queued.
+            orchestrator.stores.document.update(
+                blocks.map { block ->
+                    val current = block.content
+                    if (block.id == materialized && current is Content.Text) {
+                        block.copy(content = current.copy(text = state.text, marks = state.marks))
+                    } else {
+                        block
+                    }
+                }
+            )
+            flushTrailingPlaceholderDivergence(state, materialized)
+            // Re-render from the live store so any stale render queued with a
+            // pre-patch snapshot is superseded.
+            viewModelScope.launch { refresh() }
+        }
+        if (state.onMaterialized.isNotEmpty()) {
+            val actions = state.onMaterialized.toList()
+            viewModelScope.launch {
+                // This mapping runs on Main.immediate, so an immediate launch would
+                // execute before the pipeline stores this render's views. Yield past
+                // it: replays must observe the post-swap views store.
+                yield()
+                actions.forEach { action -> action(materialized) }
+            }
+        }
+        return result to effectiveFocus
+    }
+
+    private fun proceedWithTrailingPlaceholderTextChange(view: BlockView.Text) {
+        val state = trailingPlaceholder
+        if (state == null) {
+            // The placeholder has already been swapped for a real block, but this
+            // change was dispatched against the old id — redirect to the created block.
+            val target = lastMaterializedTrailingBlock ?: return
+            val update = TextUpdate.Pattern(
+                target = target,
+                text = view.text,
+                markup = view.marks.map { it.mark() }
+            )
+            viewModelScope.launch {
+                val store = orchestrator.stores.views
+                store.update(
+                    store.current().map { current ->
+                        if (current.id == target && current is BlockView.Text) {
+                            current.apply {
+                                text = view.text
+                                marks = view.marks
+                            }
+                        } else {
+                            current
+                        }
+                    }
+                )
+            }
+            viewModelScope.launch { orchestrator.proxies.changes.send(update) }
+            return
+        }
+        state.text = view.text
+        state.marks = view.marks.map { it.mark() }
+        viewModelScope.launch {
+            val store = orchestrator.stores.views
+            store.update(store.current().map { if (it.id == view.id) view else it })
+        }
+        if (!state.isMaterializing && view.text.isNotEmpty()) {
+            // First real input: create the block already carrying it.
+            materializeTrailingPlaceholder()
+        }
+    }
+
+    private fun proceedWithTrailingPlaceholderEnter(
+        text: String,
+        marks: List<Content.Text.Mark>,
+        range: IntRange
+    ) {
+        val state = trailingPlaceholder
+        if (state == null) {
+            val target = lastMaterializedTrailingBlock ?: return
+            proceedWithEnterEvent(target, range, text, marks)
+            return
+        }
+        state.text = text
+        state.marks = marks
+        // Replay the enter against the created block, mirroring enter behavior
+        // on a real empty trailing block.
+        state.onMaterialized += { id -> proceedWithEnterEvent(id, range, text, marks) }
+        materializeTrailingPlaceholder()
+    }
+
+    private fun proceedWithTrailingPlaceholderBackspace() {
+        val state = trailingPlaceholder
+        if (state == null) {
+            // Already swapped: give the created block the standard empty-backspace
+            // treatment (unlink + focus previous).
+            lastMaterializedTrailingBlock?.let { onEmptyBlockBackspaceClicked(it) }
+            return
+        }
+        if (state.isMaterializing) {
+            // The block is being created — replay the backspace against it after the swap.
+            state.onMaterialized += { id -> onEmptyBlockBackspaceClicked(id) }
+            return
+        }
+        // Nothing was created — just dismiss the placeholder and move the caret
+        // to the last focusable text block above it.
+        trailingPlaceholder = null
+        val previous = views.lastOrNull { view ->
+            view.id != VIRTUAL_TRAILING_BLOCK_ID
+                    && (view is BlockView.Text || view is BlockView.Title || view is BlockView.Description)
+        }
+        viewModelScope.launch {
+            if (previous != null) {
+                orchestrator.stores.focus.update(
+                    Editor.Focus(
+                        target = Editor.Focus.Target.Block(previous.id),
+                        cursor = Editor.Cursor.End
+                    )
+                )
+            } else {
+                orchestrator.stores.focus.update(Editor.Focus.empty())
+            }
+            refresh()
+        }
+    }
+
+    private fun proceedWithTrailingPlaceholderFocusLost() {
+        val state = trailingPlaceholder ?: return
+        if (state.isMaterializing || state.text.isNotEmpty()) return
+        // Focus left the placeholder with nothing typed: it simply goes away.
+        // Nothing was created, nothing to clean up, nothing synced.
+        trailingPlaceholder = null
+        viewModelScope.launch { refresh() }
+    }
+
+    //endregion
+
+    //region IDENTITY FORK
+
+    /**
+     * First content into an existing EMPTY text block forks the block identity.
+     *
+     * Block text is whole-value last-writer-wins keyed by block id, so any empty
+     * block is a shared register: two users filling the same empty block
+     * concurrently lose one text on merge. Instead of BlockTextSetText, the first
+     * real input replaces the block via BlockReplace with a model carrying the
+     * new content plus everything the empty block already had (style, checked,
+     * colors, align, fields). Replace is remove+create in one atomic change, so
+     * two concurrent fills produce two blocks — both texts survive.
+     */
+    private var identityFork: IdentityForkState? = null
+
+    /**
+     * Old id → new id of the most recent fork. Events the UI dispatches against
+     * the old id after the swap are redirected to the created block.
+     */
+    private var lastForkedBlock: Pair<Id, Id>? = null
+
+    private val forkPatternMatcher = DefaultPatternMatcher()
+
+    private class IdentityForkState(
+        val oldId: Id,
+        var text: String,
+        var marks: List<Content.Text.Mark>,
+        var forked: Id? = null,
+        /** Text/marks last known to be synced to the middleware for the new block. */
+        var syncedText: String = text,
+        var syncedMarks: List<Content.Text.Mark> = marks,
+        /** Actions deferred until the replacement block is swapped in. */
+        val onForked: MutableList<(Id) -> Unit> = mutableListOf()
+    )
+
+    /**
+     * True when first content into [target] must fork the block identity instead
+     * of writing text into the existing (empty) block.
+     */
+    private fun shouldForkBlockIdentity(target: Block, newText: String): Boolean {
+        if (newText.isEmpty()) return false
+        if (identityFork != null) return false
+        val content = target.content
+        if (content !is Content.Text) return false
+        if (content.text.isNotEmpty()) return false
+        // Replacing a block with children would orphan them (e.g. toggle header).
+        if (target.children.isNotEmpty()) return false
+        // Detail-backed blocks — the middleware rejects replacing them.
+        if (content.style == Content.Text.Style.TITLE) return false
+        if (content.style == Content.Text.Style.DESCRIPTION) return false
+        // Table cell ids are structural (row-column composites) — never replace.
+        val parent = blocks.find { it.children.contains(target.id) }
+        if (parent?.content is Content.TableRow) return false
+        // Markdown shortcuts are handled by the pattern matcher, whose Replace
+        // already allocates a new id — let that flow proceed unchanged.
+        if (forkPatternMatcher.match(newText).isNotEmpty()) return false
+        // Slash-menu input is a command, not content: the chosen slash action
+        // itself replaces or restyles the empty block — keep that flow unchanged.
+        if (newText.first() == SLASH_CHAR) return false
+        return true
+    }
+
+    private fun proceedWithForkingBlockIdentity(
+        target: Block,
+        text: String,
+        marks: List<Content.Text.Mark>
+    ) {
+        val content = target.content<Content.Text>()
+        val state = IdentityForkState(oldId = target.id, text = text, marks = marks)
+        identityFork = state
+        viewModelScope.launch {
+            orchestrator.proxies.intents.send(
+                Intent.CRUD.Replace(
+                    context = context,
+                    target = target.id,
+                    prototype = Prototype.Text(
+                        style = content.style,
+                        text = text,
+                        marks = marks,
+                        checked = content.isChecked,
+                        color = content.color,
+                        iconEmoji = content.iconEmoji,
+                        iconImage = content.iconImage,
+                        align = content.align,
+                        backgroundColor = target.backgroundColor,
+                        fields = target.fields
+                    ),
+                    onSuccess = { id ->
+                        // Invoked before the payload is dispatched, so the swap
+                        // render below is guaranteed to see the forked id.
+                        state.forked = id
+                        lastForkedBlock = target.id to id
+                        // Input that arrived while the replace was in flight must
+                        // not wait for the swap render — the editor may be closed
+                        // before it happens. Sync it to the middleware now.
+                        flushIdentityForkDivergence(state, id)
+                    },
+                    onFailure = {
+                        // The old block still exists — fall back to the regular
+                        // set-text flow so no typed text is lost.
+                        identityFork = null
+                        viewModelScope.launch {
+                            orchestrator.proxies.changes.send(
+                                TextUpdate.Pattern(
+                                    target = state.oldId,
+                                    text = state.text,
+                                    markup = state.marks
+                                )
+                            )
+                        }
+                    }
+                )
+            )
+        }
+    }
+
+    /**
+     * Syncs input buffered while a block-identity request was in flight straight
+     * to the middleware, bypassing the render pipeline: waiting for the swap
+     * render would lose the tail when the editor is closed before it happens.
+     */
+    private fun flushIdentityForkDivergence(state: IdentityForkState, target: Id) {
+        if (state.text == state.syncedText && state.marks == state.syncedMarks) return
+        val text = state.text
+        val marks = state.marks
+        state.syncedText = text
+        state.syncedMarks = marks
+        viewModelScope.launch {
+            orchestrator.proxies.intents.send(
+                Intent.Text.UpdateText(
+                    context = context,
+                    target = target,
+                    text = text,
+                    marks = marks
+                )
+            )
+        }
+    }
+
+    /**
+     * Called from the render pipeline: keeps the old block rendered with the
+     * buffered text while the replace is in flight, and swaps all local
+     * references to the new id once the replacement block has arrived.
+     */
+    private suspend fun resolveIdentityFork(
+        models: List<Block>,
+        focus: Editor.Focus
+    ): Pair<List<Block>, Editor.Focus> {
+        val state = identityFork ?: return models to focus
+        val forked = state.forked
+        if (forked == null || models.none { it.id == forked }) {
+            // Replace still in flight: render the old block with the buffered
+            // input so a concurrent re-render doesn't clobber what the user typed.
+            val patched = models.map { block ->
+                val content = block.content
+                if (block.id == state.oldId && content is Content.Text) {
+                    block.copy(content = content.copy(text = state.text, marks = state.marks))
+                } else {
+                    block
+                }
+            }
+            return patched to focus
+        }
+        // The replacement block has arrived — swap local references to it.
+        identityFork = null
+        var result = models
+        var effectiveFocus = focus
+        if (focus.isTarget(state.oldId) || focus.isTarget(forked)) {
+            val selection = orchestrator.stores.textSelection.current()
+                .takeIf { it.id == state.oldId || it.id == forked }
+                ?.selection?.last
+                ?.coerceIn(0, state.text.length)
+                ?: state.text.length
+            effectiveFocus = Editor.Focus(
+                target = Editor.Focus.Target.Block(forked),
+                cursor = Editor.Cursor.Range(selection..selection)
+            )
+            orchestrator.stores.focus.update(effectiveFocus)
+        }
+        val content = models.first { it.id == forked }.content
+        if (content is Content.Text && (content.text != state.text || content.marks != state.marks)) {
+            // Input arrived while the replace was in flight: patch this render's
+            // input and the local document.
+            result = models.map { block ->
+                if (block.id == forked) {
+                    block.copy(content = content.copy(text = state.text, marks = state.marks))
+                } else {
+                    block
+                }
+            }
+            // Patch the live store rather than writing the render snapshot back.
+            orchestrator.stores.document.update(
+                blocks.map { block ->
+                    val current = block.content
+                    if (block.id == forked && current is Content.Text) {
+                        block.copy(content = current.copy(text = state.text, marks = state.marks))
+                    } else {
+                        block
+                    }
+                }
+            )
+            flushIdentityForkDivergence(state, forked)
+            viewModelScope.launch { refresh() }
+        }
+        if (state.onForked.isNotEmpty()) {
+            val actions = state.onForked.toList()
+            viewModelScope.launch {
+                // Replays must observe the post-swap views store — yield past the
+                // pipeline's views.update (this mapping runs on Main.immediate).
+                yield()
+                actions.forEach { action -> action(forked) }
+            }
+        }
+        return result to effectiveFocus
+    }
+
+    /**
+     * Routes a text change for a block involved in an identity fork.
+     * Returns true when the change was consumed.
+     */
+    private fun proceedWithIdentityForkTextChange(
+        id: Id,
+        text: String,
+        marks: List<Content.Text.Mark>,
+        syncViewsStore: () -> Unit
+    ): Boolean {
+        val state = identityFork
+        if (state != null && id == state.oldId) {
+            // Replace in flight: buffer the input; it is synced at the swap.
+            state.text = text
+            state.marks = marks
+            syncViewsStore()
+            return true
+        }
+        val redirect = lastForkedBlock
+        if (redirect != null && id == redirect.first) {
+            // Dispatched against the pre-fork id after the swap — retarget.
+            val update = TextUpdate.Pattern(target = redirect.second, text = text, markup = marks)
+            viewModelScope.launch {
+                val store = orchestrator.stores.views
+                store.update(
+                    store.current().map { current ->
+                        if (current.id == redirect.second && current is BlockView.Text) {
+                            current.apply {
+                                this.text = text
+                            }
+                        } else {
+                            current
+                        }
+                    }
+                )
+            }
+            viewModelScope.launch { orchestrator.proxies.changes.send(update) }
+            return true
+        }
+        // Not part of a fork: check whether this change must start one.
+        val target = blocks.find { it.id == id } ?: return false
+        if (!shouldForkBlockIdentity(target, text)) return false
+        syncViewsStore()
+        proceedWithForkingBlockIdentity(target, text, marks)
+        return true
+    }
+
+    //endregion
+
     //Todo this method need refactoring
     fun onHideKeyboardClicked() {
         Timber.d("onHideKeyboardClicked, ")
         controlPanelInteractor.onEvent(ControlPanelMachine.Event.OnClearFocusClicked)
         viewModelScope.launch { orchestrator.stores.focus.update(Editor.Focus.empty()) }
         views.onEach { if (it is Focusable) it.isFocused = false }
+        proceedWithTrailingPlaceholderFocusLost()
         viewModelScope.launch { renderCommand.send(Unit) }
         viewModelScope.launch { analytics.sendHideKeyboardEvent() }
     }
@@ -3546,6 +4324,11 @@ class EditorViewModel(
         objectTypeView: ObjectTypeView,
         fromSlashMenu: Boolean = false
     ) {
+        if (deferUntilTrailingPlaceholderMaterialized {
+                onAddNewObjectClicked(objectTypeView, fromSlashMenu)
+            }
+        ) return
+
         val position: Position
 
         val focused = blocks.find { it.id == orchestrator.stores.focus.current().targetOrNull() }
@@ -3694,6 +4477,8 @@ class EditorViewModel(
     fun onAddBookmarkBlockClicked() {
         Timber.d("onAddBookmarkBlockClicked, ")
 
+        if (deferUntilTrailingPlaceholderMaterialized { onAddBookmarkBlockClicked() }) return
+
         val focus = orchestrator.stores.focus.current().targetOrNull() ?: return
         val focused = blocks.find { it.id == focus } ?: return
 
@@ -3803,6 +4588,7 @@ class EditorViewModel(
     }
 
     private fun onBlockMultiSelectClicked(target: Id) {
+        if (target == VIRTUAL_TRAILING_BLOCK_ID) return
         proceedWithTogglingSelection(target)
         proceedWithUpdatingActionsForCurrentSelection()
     }
@@ -3852,11 +4638,23 @@ class EditorViewModel(
         range: IntRange
     ) {
         Timber.d("onPaste, range:[$range]")
+        var focused = orchestrator.stores.focus.current().targetOrNull()
+        if (focused == VIRTUAL_TRAILING_BLOCK_ID) {
+            val state = trailingPlaceholder
+            if (state != null) {
+                // Paste is the first real input: create the block first, then
+                // replay the paste against the created block.
+                state.onMaterialized += { onPaste(range) }
+                materializeTrailingPlaceholder()
+                return
+            }
+            focused = lastMaterializedTrailingBlock ?: return
+        }
         viewModelScope.launch {
             orchestrator.proxies.intents.send(
                 Intent.Clipboard.Paste(
                     context = context,
-                    focus = orchestrator.stores.focus.current().targetOrNull().orEmpty(),
+                    focus = focused.orEmpty(),
                     range = range,
                     selected = emptyList()
                 )
@@ -3870,6 +4668,15 @@ class EditorViewModel(
     ) {
 
         Timber.d("onApplyScrollAndMove, target:[$target] ratio:[$ratio]")
+
+        if (target == VIRTUAL_TRAILING_BLOCK_ID) {
+            // Dropping on the placeholder row means "move to the end of the document".
+            val lastReal = blocks.find { it.id == context }?.children?.lastOrNull()
+            if (lastReal != null) {
+                onApplyScrollAndMove(target = lastReal, ratio = 2f)
+            }
+            return
+        }
 
         val ordering = views.mapIndexed { index, view -> view.id to index }.toMap()
 
@@ -4199,6 +5006,7 @@ class EditorViewModel(
                 dispatch(Command.OpenDocumentImagePicker(Mimetype.MIME_IMAGE_ALL))
             }
             is ListenerType.LongClick -> {
+                if (clicked.target == VIRTUAL_TRAILING_BLOCK_ID) return
                 when (mode) {
                     EditorMode.Edit -> proceedWithEnteringActionMode(clicked.target)
                     EditorMode.Select -> onBlockMultiSelectClicked(target = clicked.target)
@@ -4765,14 +5573,6 @@ class EditorViewModel(
         )
     }
 
-    private fun addNewBlockAtTheEnd() {
-        proceedWithCreatingNewTextBlock(
-            target = "",
-            position = Position.INNER,
-            style = Content.Text.Style.P
-        )
-    }
-
     fun proceedWithOpeningObject(target: Id) {
         viewModelScope.launch {
             closePage.async(
@@ -5149,6 +5949,12 @@ class EditorViewModel(
         const val EMPTY_TEXT = ""
         const val EMPTY_CONTEXT = ""
         const val EMPTY_FOCUS_ID = ""
+
+        /**
+         * Id of the client-side virtual trailing block ("click-to-type" placeholder).
+         * Never sent to the middleware: the real block is created on first input.
+         */
+        const val VIRTUAL_TRAILING_BLOCK_ID = "virtual-trailing-block"
         const val TEXT_CHANGES_DEBOUNCE_DURATION = 500L
         const val DELAY_REFRESH_DOCUMENT_TO_ENTER_MULTI_SELECT_MODE = 150L
         const val DELAY_REFRESH_DOCUMENT_ON_EXIT_MULTI_SELECT_MODE = 300L
@@ -5218,6 +6024,7 @@ class EditorViewModel(
 
     fun onSlashItemClicked(item: SlashItem) {
         Timber.v("onSlashItemClicked, item:[$item]")
+        if (deferUntilTrailingPlaceholderMaterialized { onSlashItemClicked(item) }) return
         val target = orchestrator.stores.focus.current()
         if (!target.isEmpty) {
             proceedWithSlashItem(item, target.requireTarget())
@@ -6796,6 +7603,18 @@ class EditorViewModel(
         target: Id,
         position: Position
     ) {
+        if (dragged == VIRTUAL_TRAILING_BLOCK_ID) {
+            // The placeholder is not a real block and cannot be moved.
+            return
+        }
+        if (target == VIRTUAL_TRAILING_BLOCK_ID) {
+            // Dropping onto the placeholder row means "move to the end of the document".
+            val lastReal = blocks.find { it.id == context }?.children?.lastOrNull()
+            if (lastReal != null && lastReal != dragged) {
+                onDragAndDrop(dragged = dragged, target = lastReal, position = Position.BOTTOM)
+            }
+            return
+        }
         val descendants = blocks.asMap().descendants(parent = dragged)
 
         if (descendants.contains(target)) {

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
@@ -1517,6 +1517,7 @@ class EditorViewModel(
             id = view.id,
             text = view.text,
             marks = view.marks.map { it.mark() },
+            viewMarks = view.marks,
             syncViewsStore = {
                 viewModelScope.launch {
                     val store = orchestrator.stores.views
@@ -1595,6 +1596,18 @@ class EditorViewModel(
         Timber.d("onBlockFocusChanged, id:[$id] hasFocus:[$hasFocus]")
         if (hasFocus) {
             isUndoRedoToolbarIsVisible.value = false
+            // Remember where the user moved the caret while a block-identity
+            // request is in flight, so the swap doesn't steal focus back.
+            identityFork?.let { fork ->
+                fork.userFocus = id.takeIf { it != fork.oldId && it != fork.forked }
+            }
+            trailingPlaceholder?.let { state ->
+                if (state.isMaterializing) {
+                    state.userFocus = id.takeIf {
+                        it != VIRTUAL_TRAILING_BLOCK_ID && it != state.materialized
+                    }
+                }
+            }
             viewModelScope.launch {
                 orchestrator.stores.focus.update(
                     Editor.Focus.id(id = id, isPending = false)
@@ -1651,9 +1664,8 @@ class EditorViewModel(
             fork.onForked += { id -> proceedWithEnterEvent(id, range, text, marks) }
             return
         }
-        val redirected = lastForkedBlock
-        if (redirected != null && target == redirected.first) {
-            proceedWithEnterEvent(redirected.second, range, text, marks)
+        forkRedirectOrNull(target)?.let { redirected ->
+            proceedWithEnterEvent(redirected, range, text, marks)
             return
         }
 
@@ -1837,9 +1849,8 @@ class EditorViewModel(
             fork.onForked += { newId -> onEmptyBlockBackspaceClicked(newId) }
             return
         }
-        val redirected = lastForkedBlock
-        if (redirected != null && id == redirected.first) {
-            onEmptyBlockBackspaceClicked(redirected.second)
+        forkRedirectOrNull(id)?.let { redirected ->
+            onEmptyBlockBackspaceClicked(redirected)
             return
         }
         val position = views.indexOfFirst { it.id == id }
@@ -1916,9 +1927,8 @@ class EditorViewModel(
             }
             return
         }
-        val redirected = lastForkedBlock
-        if (redirected != null && id == redirected.first) {
-            onNonEmptyBlockBackspaceClicked(id = redirected.second, text = text, marks = marks)
+        forkRedirectOrNull(id)?.let { redirected ->
+            onNonEmptyBlockBackspaceClicked(id = redirected, text = text, marks = marks)
             return
         }
 
@@ -2639,6 +2649,14 @@ class EditorViewModel(
             return
         }
 
+        val fork = identityFork
+        if (focused != null && focused == fork?.oldId) {
+            // Identity-fork replace in flight — apply the chosen style after the swap.
+            fork.onForked += { onAddTextBlockClicked(style) }
+            controlPanelInteractor.onEvent(ControlPanelMachine.Event.OnAddBlockToolbarOptionSelected)
+            return
+        }
+
         val target = if (focused != null)
             blocks.find { it.id == focused }
         else
@@ -2710,7 +2728,7 @@ class EditorViewModel(
 
     fun onAddFileBlockClicked(type: Content.File.Type) {
         Timber.d("onAddFileBlockClicked, type:[$type]")
-        if (deferUntilTrailingPlaceholderMaterialized { onAddFileBlockClicked(type) }) return
+        if (deferUntilBlockIdentitySettled { onAddFileBlockClicked(type) }) return
         val focused = orchestrator.stores.focus.current().targetOrNull()
         val target = if (focused != null)
             blocks.find { it.id == focused }
@@ -2898,7 +2916,7 @@ class EditorViewModel(
 
     fun onBlockToolbarStyleClicked() {
         Timber.d("onBlockToolbarStyleClicked, ")
-        if (deferUntilTrailingPlaceholderMaterialized { onBlockToolbarStyleClicked() }) return
+        if (deferUntilBlockIdentitySettled { onBlockToolbarStyleClicked() }) return
         val focus = orchestrator.stores.focus.current().targetOrNull()
         val targetId = focus.orEmpty()
         if (targetId.isNotEmpty()) {
@@ -3084,7 +3102,7 @@ class EditorViewModel(
 
     fun onBlockToolbarBlockActionsClicked() {
         Timber.d("onBlockToolbarBlockActionsClicked, ")
-        if (deferUntilTrailingPlaceholderMaterialized { onBlockToolbarBlockActionsClicked() }) return
+        if (deferUntilBlockIdentitySettled { onBlockToolbarBlockActionsClicked() }) return
         val target = orchestrator.stores.focus.current().targetOrNull()
         val view = if (target != null) views.find { it.id == target } else null
         if (view == null) {
@@ -3423,7 +3441,7 @@ class EditorViewModel(
 
     fun onAddDividerBlockClicked(style: Content.Divider.Style) {
         Timber.d("onAddDividerBlockClicked, style:[$style]")
-        if (deferUntilTrailingPlaceholderMaterialized { onAddDividerBlockClicked(style) }) return
+        if (deferUntilBlockIdentitySettled { onAddDividerBlockClicked(style) }) return
         addDividerBlock(style)
         controlPanelInteractor.onEvent(ControlPanelMachine.Event.OnAddBlockToolbarOptionSelected)
     }
@@ -3545,6 +3563,8 @@ class EditorViewModel(
         /** Text/marks last known to be synced to the middleware for the created block. */
         var syncedText: String = EMPTY_TEXT,
         var syncedMarks: List<Content.Text.Mark> = emptyList(),
+        /** Block the user moved focus to while the create was in flight. */
+        var userFocus: Id? = null,
         /**
          * Actions deferred until the created block is swapped in, replayed in
          * the order the user performed them.
@@ -3631,16 +3651,7 @@ class EditorViewModel(
         val marks = state.marks
         state.syncedText = text
         state.syncedMarks = marks
-        viewModelScope.launch {
-            orchestrator.proxies.intents.send(
-                Intent.Text.UpdateText(
-                    context = context,
-                    target = target,
-                    text = text,
-                    marks = marks
-                )
-            )
-        }
+        flushBufferedTextDivergence(target = target, text = text, marks = marks)
     }
 
     /**
@@ -3654,6 +3665,20 @@ class EditorViewModel(
         if (!orchestrator.stores.focus.current().isTarget(VIRTUAL_TRAILING_BLOCK_ID)) return false
         state.onMaterialized += { action() }
         materializeTrailingPlaceholder()
+        return true
+    }
+
+    /**
+     * Defers [action] while the focused block's identity is unsettled — either
+     * the trailing placeholder hasn't materialized yet, or an identity-fork
+     * replace is in flight. The action is re-dispatched once the real block
+     * holds focus. Returns true when deferred.
+     */
+    private fun deferUntilBlockIdentitySettled(action: () -> Unit): Boolean {
+        if (deferUntilTrailingPlaceholderMaterialized(action)) return true
+        val fork = identityFork ?: return false
+        if (!orchestrator.stores.focus.current().isTarget(fork.oldId)) return false
+        fork.onForked += { action() }
         return true
     }
 
@@ -3694,7 +3719,17 @@ class EditorViewModel(
         trailingPlaceholder = null
         var result = models
         var effectiveFocus = focus
-        if (focus.isTarget(VIRTUAL_TRAILING_BLOCK_ID) || focus.isTarget(materialized)) {
+        val userFocus = state.userFocus
+        if (userFocus != null) {
+            // The user moved the caret elsewhere while the create was in flight —
+            // don't steal it back into the created block.
+            effectiveFocus = Editor.Focus(
+                target = Editor.Focus.Target.Block(userFocus),
+                cursor = null,
+                isPending = false
+            )
+            orchestrator.stores.focus.update(effectiveFocus)
+        } else if (focus.isTarget(VIRTUAL_TRAILING_BLOCK_ID) || focus.isTarget(materialized)) {
             val selection = orchestrator.stores.textSelection.current()
                 .takeIf { it.id == VIRTUAL_TRAILING_BLOCK_ID }
                 ?.selection?.last
@@ -3884,9 +3919,27 @@ class EditorViewModel(
         /** Text/marks last known to be synced to the middleware for the new block. */
         var syncedText: String = text,
         var syncedMarks: List<Content.Text.Mark> = marks,
+        /** Block the user moved focus to while the replace was in flight. */
+        var userFocus: Id? = null,
         /** Actions deferred until the replacement block is swapped in. */
         val onForked: MutableList<(Id) -> Unit> = mutableListOf()
     )
+
+    /**
+     * Resolves the forked id for an event dispatched against the pre-fork id
+     * after the swap. Returns null — clearing the stale mapping — when the old
+     * block has reappeared in the document (undo of the BlockReplace): events
+     * must then target the restored block again, not the removed forked one.
+     */
+    private fun forkRedirectOrNull(id: Id): Id? {
+        val redirect = lastForkedBlock ?: return null
+        if (id != redirect.first) return null
+        if (blocks.any { it.id == redirect.first }) {
+            lastForkedBlock = null
+            return null
+        }
+        return redirect.second
+    }
 
     /**
      * True when first content into [target] must fork the block identity instead
@@ -3952,8 +4005,11 @@ class EditorViewModel(
                     },
                     onFailure = {
                         // The old block still exists — fall back to the regular
-                        // set-text flow so no typed text is lost.
+                        // set-text flow so no typed text is lost, and replay any
+                        // deferred actions (enter, backspace, toolbar) against it.
                         identityFork = null
+                        val pending = state.onForked.toList()
+                        state.onForked.clear()
                         viewModelScope.launch {
                             orchestrator.proxies.changes.send(
                                 TextUpdate.Pattern(
@@ -3962,6 +4018,12 @@ class EditorViewModel(
                                     markup = state.marks
                                 )
                             )
+                        }
+                        if (pending.isNotEmpty()) {
+                            viewModelScope.launch {
+                                yield()
+                                pending.forEach { action -> action(state.oldId) }
+                            }
                         }
                     }
                 )
@@ -3980,15 +4042,38 @@ class EditorViewModel(
         val marks = state.marks
         state.syncedText = text
         state.syncedMarks = marks
-        viewModelScope.launch {
-            orchestrator.proxies.intents.send(
-                Intent.Text.UpdateText(
-                    context = context,
-                    target = target,
-                    text = text,
-                    marks = marks
+        flushBufferedTextDivergence(target = target, text = text, marks = marks)
+    }
+
+    /**
+     * A markdown shortcut completed while the request was in flight must still
+     * convert: route it through the pattern pipeline (whose match ends in a
+     * style Replace, not a save). Anything else is synced with a direct
+     * set-text — the saves pipeline would drop it as a no-op once the local
+     * document has been patched with the buffered text.
+     */
+    private fun flushBufferedTextDivergence(
+        target: Id,
+        text: String,
+        marks: List<Content.Text.Mark>
+    ) {
+        if (forkPatternMatcher.match(text).isNotEmpty()) {
+            viewModelScope.launch {
+                orchestrator.proxies.changes.send(
+                    TextUpdate.Pattern(target = target, text = text, markup = marks)
                 )
-            )
+            }
+        } else {
+            viewModelScope.launch {
+                orchestrator.proxies.intents.send(
+                    Intent.Text.UpdateText(
+                        context = context,
+                        target = target,
+                        text = text,
+                        marks = marks
+                    )
+                )
+            }
         }
     }
 
@@ -4020,7 +4105,21 @@ class EditorViewModel(
         identityFork = null
         var result = models
         var effectiveFocus = focus
-        if (focus.isTarget(state.oldId) || focus.isTarget(forked)) {
+        // Preserve the expansion state of an (empty) toggle across the id swap.
+        if (renderer.isToggled(state.oldId) && !renderer.isToggled(forked)) {
+            renderer.onToggleChanged(forked)
+        }
+        val userFocus = state.userFocus
+        if (userFocus != null) {
+            // The user moved the caret elsewhere while the replace was in flight —
+            // don't steal it back into the forked block.
+            effectiveFocus = Editor.Focus(
+                target = Editor.Focus.Target.Block(userFocus),
+                cursor = null,
+                isPending = false
+            )
+            orchestrator.stores.focus.update(effectiveFocus)
+        } else if (focus.isTarget(state.oldId) || focus.isTarget(forked)) {
             val selection = orchestrator.stores.textSelection.current()
                 .takeIf { it.id == state.oldId || it.id == forked }
                 ?.selection?.last
@@ -4077,6 +4176,7 @@ class EditorViewModel(
         id: Id,
         text: String,
         marks: List<Content.Text.Mark>,
+        viewMarks: List<Markup.Mark>? = null,
         syncViewsStore: () -> Unit
     ): Boolean {
         val state = identityFork
@@ -4087,17 +4187,18 @@ class EditorViewModel(
             syncViewsStore()
             return true
         }
-        val redirect = lastForkedBlock
-        if (redirect != null && id == redirect.first) {
+        val redirected = forkRedirectOrNull(id)
+        if (redirected != null) {
             // Dispatched against the pre-fork id after the swap — retarget.
-            val update = TextUpdate.Pattern(target = redirect.second, text = text, markup = marks)
+            val update = TextUpdate.Pattern(target = redirected, text = text, markup = marks)
             viewModelScope.launch {
                 val store = orchestrator.stores.views
                 store.update(
                     store.current().map { current ->
-                        if (current.id == redirect.second && current is BlockView.Text) {
+                        if (current.id == redirected && current is BlockView.Text) {
                             current.apply {
                                 this.text = text
+                                if (viewMarks != null) this.marks = viewMarks
                             }
                         } else {
                             current
@@ -4324,7 +4425,7 @@ class EditorViewModel(
         objectTypeView: ObjectTypeView,
         fromSlashMenu: Boolean = false
     ) {
-        if (deferUntilTrailingPlaceholderMaterialized {
+        if (deferUntilBlockIdentitySettled {
                 onAddNewObjectClicked(objectTypeView, fromSlashMenu)
             }
         ) return
@@ -4477,7 +4578,7 @@ class EditorViewModel(
     fun onAddBookmarkBlockClicked() {
         Timber.d("onAddBookmarkBlockClicked, ")
 
-        if (deferUntilTrailingPlaceholderMaterialized { onAddBookmarkBlockClicked() }) return
+        if (deferUntilBlockIdentitySettled { onAddBookmarkBlockClicked() }) return
 
         val focus = orchestrator.stores.focus.current().targetOrNull() ?: return
         val focused = blocks.find { it.id == focus } ?: return
@@ -6024,7 +6125,7 @@ class EditorViewModel(
 
     fun onSlashItemClicked(item: SlashItem) {
         Timber.v("onSlashItemClicked, item:[$item]")
-        if (deferUntilTrailingPlaceholderMaterialized { onSlashItemClicked(item) }) return
+        if (deferUntilBlockIdentitySettled { onSlashItemClicked(item) }) return
         val target = orchestrator.stores.focus.current()
         if (!target.isEmpty) {
             proceedWithSlashItem(item, target.requireTarget())

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/editor/Intent.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/editor/Intent.kt
@@ -51,6 +51,7 @@ sealed class Intent {
             val target: Id,
             val prototype: Block.Prototype,
             val onSuccess: ((Id) -> Unit)? = null,
+            val onFailure: (() -> Unit)? = null,
             val route: String? = null
         ) : CRUD()
 
@@ -60,6 +61,7 @@ sealed class Intent {
             val position: Position,
             val prototype: Block.Prototype,
             val onSuccess: ((Id) -> Unit)? = null,
+            val onFailure: (() -> Unit)? = null,
             val isDate: Boolean = false,
             val route: String? = null
         ) : CRUD()

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/editor/Orchestrator.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/editor/Orchestrator.kt
@@ -119,9 +119,12 @@ class Orchestrator(
                     ).suspendFold(
                         onSuccess = { (id, payload) ->
                             val middlewareTime = System.currentTimeMillis()
+                            memory.sessionCreatedBlockIds.add(id)
                             stores.focus.update(Focus.id(id = id))
-                            proxies.payloads.send(payload)
+                            // Invoked before dispatching the payload, so that callers can
+                            // record the new id before the payload-triggered re-render.
                             intent.onSuccess?.invoke(id)
+                            proxies.payloads.send(payload)
                             analytics.sendAnalyticsCreateBlockEvent(
                                 prototype = intent.prototype,
                                 startTime = startTime,
@@ -131,7 +134,10 @@ class Orchestrator(
                                 route = intent.route
                             )
                         },
-                        onFailure = defaultOnError
+                        onFailure = {
+                            intent.onFailure?.invoke()
+                            defaultOnError(it)
+                        }
                     )
                 }
                 is Intent.CRUD.Replace -> {
@@ -143,12 +149,18 @@ class Orchestrator(
                             prototype = intent.prototype
                         )
                     ).proceed(
-                        failure = defaultOnError,
+                        failure = {
+                            intent.onFailure?.invoke()
+                            defaultOnError(it)
+                        },
                         success = { (id, payload) ->
                             val middlewareTime = System.currentTimeMillis()
+                            memory.sessionCreatedBlockIds.add(id)
                             stores.focus.update(Focus.id(id = id))
-                            proxies.payloads.send(payload)
+                            // Invoked before dispatching the payload, so that callers can
+                            // record the new id before the payload-triggered re-render.
                             intent.onSuccess?.invoke(id)
+                            proxies.payloads.send(payload)
                             analytics.sendAnalyticsCreateBlockEvent(
                                 prototype = intent.prototype,
                                 startTime = startTime,
@@ -169,6 +181,7 @@ class Orchestrator(
                     ).proceed(
                         failure = defaultOnError,
                         success = { (ids, payload) ->
+                            memory.sessionCreatedBlockIds.addAll(ids)
                             stores.focus.update(
                                 Focus(
                                     target = Focus.Target.Block(ids.last()),
@@ -230,6 +243,7 @@ class Orchestrator(
                         failure = defaultOnError,
                         success = { (id, payload) ->
                             val middlewareTime = System.currentTimeMillis()
+                            memory.sessionCreatedBlockIds.add(id)
                             stores.focus.update(
                                 Focus(
                                     target = Focus.Target.Block(id),

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/EditorViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/EditorViewModelTest.kt
@@ -1385,7 +1385,7 @@ open class EditorViewModelTest {
 
         val root = MockDataFactory.randomUuid()
         val child = MockDataFactory.randomUuid()
-        val initialText = ""
+        val initialText = MockDataFactory.randomString()
 
         val initialContent = Block.Content.Text(
             text = initialText,
@@ -1467,7 +1467,7 @@ open class EditorViewModelTest {
 
         val root = MockDataFactory.randomUuid()
         val child = MockDataFactory.randomUuid()
-        val initialText = ""
+        val initialText = MockDataFactory.randomString()
 
         val initialContent = Block.Content.Text(
             text = initialText,
@@ -2315,7 +2315,7 @@ open class EditorViewModelTest {
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
         runBlockingTest {
-            verify(updateText, times(2)).invoke(
+            verify(updateText, times(1)).invoke(
                 params = eq(
                     UpdateText.Params(
                         context = root,
@@ -2409,7 +2409,7 @@ open class EditorViewModelTest {
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
         runBlockingTest {
-            verify(updateText, times(2)).invoke(
+            verify(updateText, times(1)).invoke(
                 params = eq(
                     UpdateText.Params(
                         context = root,

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorEmptySpaceInteractionTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorEmptySpaceInteractionTest.kt
@@ -2,18 +2,26 @@ package com.anytypeio.anytype.presentation.editor.editor
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.anytypeio.anytype.core_models.Block
+import com.anytypeio.anytype.core_models.Event
+import com.anytypeio.anytype.core_models.Payload
 import com.anytypeio.anytype.core_models.Position
 import com.anytypeio.anytype.core_models.StubCodeSnippet
 import com.anytypeio.anytype.core_models.StubHeader
 import com.anytypeio.anytype.core_models.StubLinkToObjectBlock
+import com.anytypeio.anytype.core_models.StubParagraph
 import com.anytypeio.anytype.core_models.StubSmartBlock
 import com.anytypeio.anytype.core_models.StubTable
 import com.anytypeio.anytype.core_models.StubTitle
 import com.anytypeio.anytype.core_models.restrictions.ObjectRestriction
+import com.anytypeio.anytype.domain.base.Resultat
 import com.anytypeio.anytype.domain.block.interactor.CreateBlock
 import com.anytypeio.anytype.presentation.MockBlockFactory
+import com.anytypeio.anytype.presentation.editor.EditorViewModel.Companion.VIRTUAL_TRAILING_BLOCK_ID
+import com.anytypeio.anytype.presentation.editor.editor.model.BlockView
 import com.anytypeio.anytype.presentation.util.DefaultCoroutineTestRule
 import com.anytypeio.anytype.test_utils.MockDataFactory
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -21,7 +29,10 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.stub
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.verifyNoInteractions
@@ -61,6 +72,9 @@ class EditorEmptySpaceInteractionTest : EditorPresentationTestSetup() {
         proceedWithDefaultBeforeTestStubbing()
     }
 
+    private fun trailingPlaceholderOrNull(vm: com.anytypeio.anytype.presentation.editor.EditorViewModel): BlockView.Text.Paragraph? =
+        vm.views.lastOrNull()?.takeIf { it.id == VIRTUAL_TRAILING_BLOCK_ID } as? BlockView.Text.Paragraph
+
     @Test
     fun `should ignore outside click if document isn't started yet`() = runTest {
         val vm = buildViewModel()
@@ -70,7 +84,7 @@ class EditorEmptySpaceInteractionTest : EditorPresentationTestSetup() {
     }
 
     @Test
-    fun `should create a new paragraph on outside-clicked event if page contains only title with icon`() = runTest {
+    fun `should show focused trailing placeholder without any middleware calls on outside click if page contains only title with icon`() = runTest {
 
         // SETUP
 
@@ -85,7 +99,6 @@ class EditorEmptySpaceInteractionTest : EditorPresentationTestSetup() {
 
         stubInterceptEvents()
         stubOpenDocument(doc)
-        stubCreateBlock(root)
 
         val vm = buildViewModel()
 
@@ -99,37 +112,244 @@ class EditorEmptySpaceInteractionTest : EditorPresentationTestSetup() {
 
         advanceUntilIdle()
 
-        verifyBlocking(createBlock, times(1)) {
-            async(
-                params = eq(
-                    CreateBlock.Params(
-                        context = root,
-                        target = "",
-                        position = Position.INNER,
-                        prototype = Block.Prototype.Text(
-                            style = Block.Content.Text.Style.P
-                        )
-                    )
-                )
-            )
-        }
+        // Clicking the empty area must produce zero middleware calls.
+        verifyNoInteractions(createBlock)
+        verifyNoInteractions(updateText)
+
+        val placeholder = trailingPlaceholderOrNull(vm)
+        assertTrue(
+            placeholder != null && placeholder.isFocused,
+            "Expected a focused virtual trailing placeholder as the last view"
+        )
     }
 
     @Test
-    fun `should create a new paragraph on outside-clicked event if page contains only title with icon and one non-empty paragraph`() = runTest {
+    fun `should show trailing placeholder instead of creating a block if the last block is a non-empty paragraph`() = runTest {
 
         // SETUP
 
-        val block = Block(
-            id = MockDataFactory.randomUuid(),
-            content = Block.Content.Text(
-                text = MockDataFactory.randomString(),
-                style = Block.Content.Text.Style.P,
-                marks = emptyList()
-            ),
-            children = emptyList(),
-            fields = Block.Fields.empty()
+        val block = StubParagraph(text = MockDataFactory.randomString())
+
+        val page = Block(
+            id = root,
+            fields = Block.Fields(emptyMap()),
+            content = Block.Content.Smart,
+            children = listOf(header.id, block.id)
         )
+
+        val doc = listOf(page, header, title, block)
+
+        stubInterceptEvents()
+        stubOpenDocument(doc)
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onOutsideClicked()
+
+        advanceUntilIdle()
+
+        verifyNoInteractions(createBlock)
+        assertTrue(trailingPlaceholderOrNull(vm) != null)
+    }
+
+    @Test
+    fun `should show trailing placeholder instead of creating a block if the last block is a link block`() = runTest {
+
+        // SETUP
+
+        val link = StubLinkToObjectBlock()
+
+        val root = StubSmartBlock(
+            id = root,
+            children = listOf(
+                header.id,
+                link.id
+            )
+        )
+
+        val doc = listOf(
+            root, header, title, link
+        )
+
+        stubInterceptEvents()
+        stubInterceptThreadStatus()
+        stubOpenDocument(doc)
+        stubGetNetworkMode()
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root.id, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onOutsideClicked()
+
+        advanceUntilIdle()
+
+        verifyNoInteractions(createBlock)
+        assertTrue(trailingPlaceholderOrNull(vm) != null)
+    }
+
+    @Test
+    fun `should not show trailing placeholder on outside-clicked event if object has restriction BLOCKS`() = runTest {
+
+        // SETUP
+
+        val firstChild = MockDataFactory.randomUuid()
+        val secondChild = MockDataFactory.randomUuid()
+
+        val page = MockBlockFactory.makeOnePageWithTitleAndOnePageLinkBlock(
+            rootId = root,
+            titleBlockId = firstChild,
+            pageBlockId = secondChild
+        )
+
+        stubInterceptEvents()
+        stubOpenDocument(document = page, objectRestrictions = listOf(ObjectRestriction.BLOCKS))
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onOutsideClicked()
+
+        advanceUntilIdle()
+
+        verifyNoInteractions(createBlock)
+        assertTrue(trailingPlaceholderOrNull(vm) == null)
+    }
+
+    @Test
+    fun `should show trailing placeholder instead of creating a block if the last block is a table block`() = runTest {
+
+        // SETUP
+
+        val table = StubTable(children = listOf())
+        val title = StubTitle()
+        val header = StubHeader(children = listOf(title.id))
+        val page = Block(
+            id = root,
+            children = listOf(header.id) + listOf(table.id),
+            fields = Block.Fields.empty(),
+            content = Block.Content.Smart
+        )
+
+        val document = listOf(page, header, title, table)
+
+        stubInterceptEvents()
+        stubOpenDocument(document)
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onOutsideClicked()
+
+        advanceUntilIdle()
+
+        verifyNoInteractions(createBlock)
+        assertTrue(trailingPlaceholderOrNull(vm) != null)
+    }
+
+    @Test
+    fun `should show trailing placeholder instead of creating a block if the last block is a code snippet block`() = runTest {
+
+        // SETUP
+
+        val snippet = StubCodeSnippet(children = listOf())
+        val title = StubTitle()
+        val header = StubHeader(children = listOf(title.id))
+        val page = Block(
+            id = root,
+            children = listOf(header.id) + listOf(snippet.id),
+            fields = Block.Fields.empty(),
+            content = Block.Content.Smart
+        )
+
+        val document = listOf(page, header, title, snippet)
+
+        stubInterceptEvents()
+        stubOpenDocument(document)
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onOutsideClicked()
+
+        advanceUntilIdle()
+
+        verifyNoInteractions(createBlock)
+        assertTrue(trailingPlaceholderOrNull(vm) != null)
+    }
+
+    @Test
+    fun `should never create blocks or duplicate the placeholder on repeated outside clicks`() = runTest {
+
+        // SETUP
+
+        val block = StubParagraph(text = MockDataFactory.randomString())
+
+        val page = Block(
+            id = root,
+            fields = Block.Fields(emptyMap()),
+            content = Block.Content.Smart,
+            children = listOf(header.id, block.id)
+        )
+
+        val doc = listOf(page, header, title, block)
+
+        stubInterceptEvents()
+        stubOpenDocument(doc)
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        repeat(3) {
+            vm.onOutsideClicked()
+            advanceUntilIdle()
+        }
+
+        verifyNoInteractions(createBlock)
+
+        assertEquals(
+            expected = 1,
+            actual = vm.views.count { it.id == VIRTUAL_TRAILING_BLOCK_ID },
+            message = "Repeated taps must never produce more than one placeholder"
+        )
+    }
+
+    @Test
+    fun `should create exactly one block carrying the first input when typing into the placeholder`() = runTest {
+
+        // SETUP
+
+        val block = StubParagraph(text = MockDataFactory.randomString())
 
         val page = Block(
             id = root,
@@ -156,6 +376,12 @@ class EditorEmptySpaceInteractionTest : EditorPresentationTestSetup() {
 
         advanceUntilIdle()
 
+        val placeholder = trailingPlaceholderOrNull(vm)!!
+
+        vm.onTextBlockTextChanged(placeholder.copy(text = "h"))
+
+        advanceUntilIdle()
+
         verifyBlocking(createBlock, times(1)) {
             async(
                 params = eq(
@@ -164,7 +390,8 @@ class EditorEmptySpaceInteractionTest : EditorPresentationTestSetup() {
                         target = "",
                         position = Position.INNER,
                         prototype = Block.Prototype.Text(
-                            style = Block.Content.Text.Style.P
+                            style = Block.Content.Text.Style.P,
+                            text = "h"
                         )
                     )
                 )
@@ -173,33 +400,51 @@ class EditorEmptySpaceInteractionTest : EditorPresentationTestSetup() {
     }
 
     @Test
-    fun `should create a new paragraph on outside-clicked event if the last block is a link block`() = runTest {
+    fun `should swap the placeholder for the created block preserving text and focus`() = runTest {
 
         // SETUP
 
-        val link = StubLinkToObjectBlock()
+        val block = StubParagraph(text = MockDataFactory.randomString())
 
-        val root = StubSmartBlock(
+        val page = Block(
             id = root,
-            children = listOf(
-                header.id,
-                link.id
-            )
+            fields = Block.Fields(emptyMap()),
+            content = Block.Content.Smart,
+            children = listOf(header.id, block.id)
         )
 
-        val doc = listOf(
-            root, header, title, link
-        )
+        val doc = listOf(page, header, title, block)
+
+        val created = StubParagraph(text = "h")
 
         stubInterceptEvents()
-        stubInterceptThreadStatus()
         stubOpenDocument(doc)
-        stubCreateBlock(root.id)
-        stubGetNetworkMode()
+
+        createBlock.stub {
+            onBlocking { async(any()) } doReturn Resultat.success(
+                Pair(
+                    created.id,
+                    Payload(
+                        context = root,
+                        events = listOf(
+                            Event.Command.AddBlock(
+                                context = root,
+                                blocks = listOf(created)
+                            ),
+                            Event.Command.UpdateStructure(
+                                context = root,
+                                id = root,
+                                children = listOf(header.id, block.id, created.id)
+                            )
+                        )
+                    )
+                )
+            )
+        }
 
         val vm = buildViewModel()
 
-        vm.onStart(id = root.id, space = defaultSpace)
+        vm.onStart(id = root, space = defaultSpace)
 
         advanceUntilIdle()
 
@@ -209,39 +454,42 @@ class EditorEmptySpaceInteractionTest : EditorPresentationTestSetup() {
 
         advanceUntilIdle()
 
-        verifyBlocking(createBlock, times(1)) {
-            async(
-                params = eq(
-                    CreateBlock.Params(
-                        target = "",
-                        context = root.id,
-                        position = Position.INNER,
-                        prototype = Block.Prototype.Text(
-                            style = Block.Content.Text.Style.P
-                        )
-                    )
-                )
-            )
-        }
+        val placeholder = trailingPlaceholderOrNull(vm)!!
+
+        vm.onTextBlockTextChanged(placeholder.copy(text = "h"))
+
+        advanceUntilIdle()
+
+        // The placeholder is gone, replaced by the created block carrying the input.
+        assertTrue(vm.views.none { it.id == VIRTUAL_TRAILING_BLOCK_ID })
+
+        val last = vm.views.last() as BlockView.Text.Paragraph
+        assertEquals(expected = created.id, actual = last.id)
+        assertEquals(expected = "h", actual = last.text)
+        assertTrue(last.isFocused, "Focus must move to the created block")
+
+        // The block was created already carrying the text — no follow-up set-text needed.
+        verifyNoInteractions(updateText)
     }
 
     @Test
-    fun `should not create a new paragraph on outside-clicked event if object has restriction BLOCKS`() = runTest {
+    fun `should show placeholder below a foreign empty trailing paragraph instead of focus-reusing it`() = runTest {
 
         // SETUP
 
-        val firstChild = MockDataFactory.randomUuid()
-        val secondChild = MockDataFactory.randomUuid()
+        val foreign = StubParagraph(text = "")
 
-        val page = MockBlockFactory.makeOnePageWithTitleAndOnePageLinkBlock(
-            rootId = root,
-            titleBlockId = firstChild,
-            pageBlockId = secondChild
+        val page = Block(
+            id = root,
+            fields = Block.Fields(emptyMap()),
+            content = Block.Content.Smart,
+            children = listOf(header.id, foreign.id)
         )
 
+        val doc = listOf(page, header, title, foreign)
+
         stubInterceptEvents()
-        stubOpenDocument(document = page, objectRestrictions = listOf(ObjectRestriction.BLOCKS))
-        stubCreateBlock(root)
+        stubOpenDocument(doc)
 
         val vm = buildViewModel()
 
@@ -256,27 +504,121 @@ class EditorEmptySpaceInteractionTest : EditorPresentationTestSetup() {
         advanceUntilIdle()
 
         verifyNoInteractions(createBlock)
+        // The foreign empty block is not deleted and not reused.
+        verifyNoInteractions(unlinkBlocks)
+
+        val placeholder = trailingPlaceholderOrNull(vm)
+        assertTrue(placeholder != null && placeholder.isFocused)
+
+        val foreignView = vm.views.first { it.id == foreign.id } as BlockView.Text.Paragraph
+        assertTrue(
+            !foreignView.isFocused,
+            "A foreign empty trailing block must not be focus-reused"
+        )
     }
 
     @Test
-    fun `should create a new paragraph on outside-clicked event if the last block is a table block`() = runTest {
+    fun `should focus-reuse an empty trailing paragraph created by this session`() = runTest {
 
         // SETUP
 
-        val table = StubTable(children = listOf())
-        val title = StubTitle()
-        val header = StubHeader(children = listOf(title.id))
+        val own = StubParagraph(text = "")
+
         val page = Block(
             id = root,
-            children = listOf(header.id) + listOf(table.id),
-            fields = Block.Fields.empty(),
-            content = Block.Content.Smart
+            fields = Block.Fields(emptyMap()),
+            content = Block.Content.Smart,
+            children = listOf(header.id, own.id)
         )
 
-        val document = listOf(page, header, title, table)
+        val doc = listOf(page, header, title, own)
 
         stubInterceptEvents()
-        stubOpenDocument(document)
+        stubOpenDocument(doc)
+
+        val vm = buildViewModel()
+
+        orchestrator.memory.sessionCreatedBlockIds.add(own.id)
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onOutsideClicked()
+
+        advanceUntilIdle()
+
+        verifyNoInteractions(createBlock)
+        assertTrue(trailingPlaceholderOrNull(vm) == null)
+
+        val ownView = vm.views.first { it.id == own.id } as BlockView.Text.Paragraph
+        assertTrue(ownView.isFocused, "An empty trailing block created by this session is focus-reused")
+    }
+
+    @Test
+    fun `should remove the placeholder when focus is lost with nothing typed`() = runTest {
+
+        // SETUP
+
+        val block = StubParagraph(text = MockDataFactory.randomString())
+
+        val page = Block(
+            id = root,
+            fields = Block.Fields(emptyMap()),
+            content = Block.Content.Smart,
+            children = listOf(header.id, block.id)
+        )
+
+        val doc = listOf(page, header, title, block)
+
+        stubInterceptEvents()
+        stubOpenDocument(doc)
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onOutsideClicked()
+
+        advanceUntilIdle()
+
+        assertTrue(trailingPlaceholderOrNull(vm) != null)
+
+        vm.onBlockFocusChanged(id = VIRTUAL_TRAILING_BLOCK_ID, hasFocus = false)
+
+        advanceUntilIdle()
+
+        verifyNoInteractions(createBlock)
+        assertTrue(
+            vm.views.none { it.id == VIRTUAL_TRAILING_BLOCK_ID },
+            "Nothing typed: the placeholder simply goes away, nothing is created"
+        )
+    }
+
+    @Test
+    fun `should create a block on enter pressed inside the empty placeholder`() = runTest {
+
+        // SETUP
+
+        val block = StubParagraph(text = MockDataFactory.randomString())
+
+        val page = Block(
+            id = root,
+            fields = Block.Fields(emptyMap()),
+            content = Block.Content.Smart,
+            children = listOf(header.id, block.id)
+        )
+
+        val doc = listOf(page, header, title, block)
+
+        stubInterceptEvents()
+        stubOpenDocument(doc)
         stubCreateBlock(root)
 
         val vm = buildViewModel()
@@ -291,64 +633,25 @@ class EditorEmptySpaceInteractionTest : EditorPresentationTestSetup() {
 
         advanceUntilIdle()
 
-        verifyBlocking(createBlock, times(1)) {
-            async(
-                params = eq(
-                    CreateBlock.Params(
-                        target = "",
-                        context = root,
-                        position = Position.INNER,
-                        prototype = Block.Prototype.Text(
-                            style = Block.Content.Text.Style.P
-                        )
-                    )
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `should create a new paragraph on outside-clicked event if the last block is a code snippet block`() = runTest {
-
-        // SETUP
-
-        val snippet = StubCodeSnippet(children = listOf())
-        val title = StubTitle()
-        val header = StubHeader(children = listOf(title.id))
-        val page = Block(
-            id = root,
-            children = listOf(header.id) + listOf(snippet.id),
-            fields = Block.Fields.empty(),
-            content = Block.Content.Smart
+        vm.onEnterKeyClicked(
+            target = VIRTUAL_TRAILING_BLOCK_ID,
+            text = "",
+            marks = emptyList(),
+            range = 0..0
         )
 
-        val document = listOf(page, header, title, snippet)
-
-        stubInterceptEvents()
-        stubOpenDocument(document)
-        stubCreateBlock(root)
-
-        val vm = buildViewModel()
-
-        vm.onStart(id = root, space = defaultSpace)
-
-        advanceUntilIdle()
-
-        // TESTING
-
-        vm.onOutsideClicked()
-
         advanceUntilIdle()
 
         verifyBlocking(createBlock, times(1)) {
             async(
                 params = eq(
                     CreateBlock.Params(
-                        target = "",
                         context = root,
+                        target = "",
                         position = Position.INNER,
                         prototype = Block.Prototype.Text(
-                            style = Block.Content.Text.Style.P
+                            style = Block.Content.Text.Style.P,
+                            text = ""
                         )
                     )
                 )

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorIdentityForkTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorIdentityForkTest.kt
@@ -1,0 +1,381 @@
+package com.anytypeio.anytype.presentation.editor.editor
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.anytypeio.anytype.core_models.Block
+import com.anytypeio.anytype.core_models.Event
+import com.anytypeio.anytype.core_models.Payload
+import com.anytypeio.anytype.core_models.StubParagraph
+import com.anytypeio.anytype.core_models.StubTitle
+import com.anytypeio.anytype.core_models.StubHeader
+import com.anytypeio.anytype.domain.base.Either
+import com.anytypeio.anytype.domain.block.interactor.ReplaceBlock
+import com.anytypeio.anytype.presentation.editor.editor.model.BlockView
+import com.anytypeio.anytype.presentation.util.DefaultCoroutineTestRule
+import com.anytypeio.anytype.test_utils.MockDataFactory
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.verifyNoInteractions
+
+/**
+ * Filling any existing EMPTY text block forks the block identity: the first
+ * real input is sent as a single BlockReplace carrying the input plus
+ * everything the empty block already had, so two clients filling the same
+ * empty block concurrently end up with two blocks — both texts intact.
+ */
+class EditorIdentityForkTest : EditorPresentationTestSetup() {
+
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @get:Rule
+    val coroutineTestRule = DefaultCoroutineTestRule()
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        proceedWithDefaultBeforeTestStubbing()
+    }
+
+    val title = StubTitle()
+    val header = StubHeader(children = listOf(title.id))
+
+    private fun givenDocument(vararg blocks: Block): List<Block> {
+        val page = Block(
+            id = root,
+            fields = Block.Fields(emptyMap()),
+            content = Block.Content.Smart,
+            children = listOf(header.id) + blocks.map { it.id }
+        )
+        return listOf(page, header, title) + blocks
+    }
+
+    @Test
+    fun `should preserve style and formatting of the empty block in the replace prototype`() = runTest {
+
+        // SETUP
+
+        val checkbox = Block(
+            id = MockDataFactory.randomUuid(),
+            fields = Block.Fields(mapOf("key" to "value")),
+            children = emptyList(),
+            backgroundColor = "yellow",
+            content = Block.Content.Text(
+                text = "",
+                marks = emptyList(),
+                style = Block.Content.Text.Style.CHECKBOX,
+                isChecked = true,
+                color = "red",
+                align = Block.Align.AlignCenter
+            )
+        )
+
+        stubInterceptEvents()
+        stubOpenDocument(givenDocument(checkbox))
+        stubReplaceBlock()
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onTextBlockTextChanged(
+            BlockView.Text.Checkbox(
+                id = checkbox.id,
+                text = "h",
+                isChecked = true
+            )
+        )
+
+        advanceUntilIdle()
+
+        verifyBlocking(replaceBlock, times(1)) {
+            invoke(
+                params = eq(
+                    ReplaceBlock.Params(
+                        context = root,
+                        target = checkbox.id,
+                        prototype = Block.Prototype.Text(
+                            style = Block.Content.Text.Style.CHECKBOX,
+                            text = "h",
+                            marks = emptyList(),
+                            checked = true,
+                            color = "red",
+                            align = Block.Align.AlignCenter,
+                            backgroundColor = "yellow",
+                            fields = Block.Fields(mapOf("key" to "value"))
+                        )
+                    )
+                )
+            )
+        }
+        verifyNoInteractions(updateText)
+    }
+
+    @Test
+    fun `should not fork an empty toggle with children - regular set-text flow`() = runTest {
+
+        // SETUP
+
+        val child = StubParagraph()
+        val toggle = Block(
+            id = MockDataFactory.randomUuid(),
+            fields = Block.Fields.empty(),
+            children = listOf(child.id),
+            content = Block.Content.Text(
+                text = "",
+                marks = emptyList(),
+                style = Block.Content.Text.Style.TOGGLE
+            )
+        )
+
+        val page = Block(
+            id = root,
+            fields = Block.Fields(emptyMap()),
+            content = Block.Content.Smart,
+            children = listOf(header.id, toggle.id)
+        )
+
+        stubInterceptEvents()
+        stubOpenDocument(listOf(page, header, title, toggle, child))
+        stubUpdateText()
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onTextBlockTextChanged(
+            BlockView.Text.Toggle(
+                id = toggle.id,
+                text = "h"
+            )
+        )
+
+        advanceUntilIdle()
+
+        // Replacing a toggle with children would orphan them — text is set
+        // on the existing block instead.
+        verifyNoInteractions(replaceBlock)
+        verifyBlocking(updateText, times(1)) {
+            invoke(any())
+        }
+    }
+
+    @Test
+    fun `should not fork a table cell`() = runTest {
+
+        // SETUP
+
+        val cell = StubParagraph(text = "")
+        val row = Block(
+            id = MockDataFactory.randomUuid(),
+            fields = Block.Fields.empty(),
+            children = listOf(cell.id),
+            content = Block.Content.TableRow(isHeader = false)
+        )
+
+        val block = StubParagraph()
+
+        val page = Block(
+            id = root,
+            fields = Block.Fields(emptyMap()),
+            content = Block.Content.Smart,
+            children = listOf(header.id, block.id)
+        )
+
+        // The row/cell pair exists in the document but is deliberately not
+        // rendered — only the parent lookup matters for this test.
+        stubInterceptEvents()
+        stubOpenDocument(listOf(page, header, title, block, row, cell))
+        stubUpdateText()
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onTextBlockTextChanged(
+            BlockView.Text.Paragraph(
+                id = cell.id,
+                text = "h"
+            )
+        )
+
+        advanceUntilIdle()
+
+        // Table cell ids are structural (row-column composites) — never replaced.
+        verifyNoInteractions(replaceBlock)
+        verifyBlocking(updateText, times(1)) {
+            invoke(any())
+        }
+    }
+
+    @Test
+    fun `should keep markdown shortcut flow for empty blocks - style replace without text`() = runTest {
+
+        // SETUP
+
+        val block = StubParagraph(text = "")
+
+        stubInterceptEvents()
+        stubOpenDocument(givenDocument(block))
+        stubReplaceBlock()
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onTextBlockTextChanged(
+            BlockView.Text.Paragraph(
+                id = block.id,
+                text = "# "
+            )
+        )
+
+        advanceUntilIdle()
+
+        // The markdown pattern already allocates a new id via BlockReplace.
+        verifyBlocking(replaceBlock, times(1)) {
+            invoke(
+                params = eq(
+                    ReplaceBlock.Params(
+                        context = root,
+                        target = block.id,
+                        prototype = Block.Prototype.Text(
+                            style = Block.Content.Text.Style.H1
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `should swap the empty block for the forked block preserving text and focus`() = runTest {
+
+        // SETUP
+
+        val empty = StubParagraph(text = "")
+        val forked = StubParagraph(text = "h")
+
+        stubInterceptEvents()
+        stubOpenDocument(givenDocument(empty))
+
+        replaceBlock.stub {
+            onBlocking { invoke(any()) } doReturn Either.Right(
+                Pair(
+                    forked.id,
+                    Payload(
+                        context = root,
+                        events = listOf(
+                            Event.Command.UpdateStructure(
+                                context = root,
+                                id = root,
+                                children = listOf(header.id, forked.id)
+                            ),
+                            Event.Command.AddBlock(
+                                context = root,
+                                blocks = listOf(forked)
+                            ),
+                            Event.Command.DeleteBlock(
+                                context = root,
+                                targets = listOf(empty.id)
+                            )
+                        )
+                    )
+                )
+            )
+        }
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onBlockFocusChanged(id = empty.id, hasFocus = true)
+
+        vm.onTextBlockTextChanged(
+            BlockView.Text.Paragraph(
+                id = empty.id,
+                text = "h"
+            )
+        )
+
+        advanceUntilIdle()
+
+        // The old id is gone; the forked block carries the text and the focus.
+        assertTrue(vm.views.none { it.id == empty.id })
+
+        val last = vm.views.last() as BlockView.Text.Paragraph
+        assertEquals(expected = forked.id, actual = last.id)
+        assertEquals(expected = "h", actual = last.text)
+        assertTrue(last.isFocused, "Focus must move to the forked block")
+
+        // The block was replaced already carrying the text — no set-text needed.
+        verifyNoInteractions(updateText)
+    }
+
+    @Test
+    fun `should not send any text write when text and marks are unchanged`() = runTest {
+
+        // SETUP
+
+        val block = StubParagraph()
+
+        stubInterceptEvents()
+        stubOpenDocument(givenDocument(block))
+        stubUpdateText()
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        // Cursor placement / focus-blur flushes re-emit the unchanged text.
+        vm.onTextBlockTextChanged(
+            BlockView.Text.Paragraph(
+                id = block.id,
+                text = block.content.asText().text
+            )
+        )
+
+        advanceUntilIdle()
+
+        // No change — no last-writer-wins write that could stomp a peer edit.
+        verifyNoInteractions(updateText)
+        verifyNoInteractions(replaceBlock)
+    }
+}

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorMergeTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorMergeTest.kt
@@ -105,7 +105,9 @@ class EditorMergeTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(2)) {
+        // The pre-merge save flush is skipped when text is unchanged, so only
+        // the actual edit produces a set-text write.
+        verifyBlocking(updateText, times(1)) {
             invoke(
                 params = eq(
                     UpdateText.Params(

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorSplitTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorSplitTest.kt
@@ -328,18 +328,10 @@ class EditorSplitTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(1)) {
-            invoke(
-                params = eq(
-                    UpdateText.Params(
-                        context = root,
-                        text = title.content<Block.Content.Text>().text,
-                        marks = emptyList(),
-                        target = title.id
-                    )
-                )
-            )
-        }
+        // The pre-split save flush is skipped when text is unchanged:
+        // a redundant set-text is a last-writer-wins write that can stomp
+        // a concurrent peer edit.
+        verifyNoInteractions(updateText)
 
         verifyBlocking(splitBlock, times(1)) {
             invoke(
@@ -389,18 +381,10 @@ class EditorSplitTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(1)) {
-            invoke(
-                params = eq(
-                    UpdateText.Params(
-                        context = root,
-                        text = title.content<Block.Content.Text>().text,
-                        marks = emptyList(),
-                        target = title.id
-                    )
-                )
-            )
-        }
+        // The pre-split save flush is skipped when text is unchanged:
+        // a redundant set-text is a last-writer-wins write that can stomp
+        // a concurrent peer edit.
+        verifyNoInteractions(updateText)
 
         verifyBlocking(splitBlock, times(1)) {
             invoke(
@@ -500,18 +484,10 @@ class EditorSplitTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(1)) {
-            invoke(
-                params = eq(
-                    UpdateText.Params(
-                        context = root,
-                        text = title.content<Block.Content.Text>().text,
-                        marks = emptyList(),
-                        target = title.id
-                    )
-                )
-            )
-        }
+        // The pre-split save flush is skipped when text is unchanged:
+        // a redundant set-text is a last-writer-wins write that can stomp
+        // a concurrent peer edit.
+        verifyNoInteractions(updateText)
 
         verifyBlocking(splitBlock, times(1)) {
             invoke(
@@ -560,18 +536,10 @@ class EditorSplitTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(1)) {
-            invoke(
-                params = eq(
-                    UpdateText.Params(
-                        context = root,
-                        text = title.content<Block.Content.Text>().text,
-                        marks = emptyList(),
-                        target = title.id
-                    )
-                )
-            )
-        }
+        // The pre-split save flush is skipped when text is unchanged:
+        // a redundant set-text is a last-writer-wins write that can stomp
+        // a concurrent peer edit.
+        verifyNoInteractions(updateText)
 
         verifyBlocking(splitBlock, times(1)) {
             invoke(
@@ -689,18 +657,10 @@ class EditorSplitTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(1)) {
-            invoke(
-                params = eq(
-                    UpdateText.Params(
-                        context = root,
-                        text = title.content<Block.Content.Text>().text,
-                        marks = emptyList(),
-                        target = title.id
-                    )
-                )
-            )
-        }
+        // The pre-split save flush is skipped when text is unchanged:
+        // a redundant set-text is a last-writer-wins write that can stomp
+        // a concurrent peer edit.
+        verifyNoInteractions(updateText)
 
         verifyBlocking(splitBlock, times(1)) {
             invoke(
@@ -852,18 +812,10 @@ class EditorSplitTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(1)) {
-            invoke(
-                params = eq(
-                    UpdateText.Params(
-                        context = root,
-                        text = title.content<Block.Content.Text>().text,
-                        marks = emptyList(),
-                        target = title.id
-                    )
-                )
-            )
-        }
+        // The pre-split save flush is skipped when text is unchanged:
+        // a redundant set-text is a last-writer-wins write that can stomp
+        // a concurrent peer edit.
+        verifyNoInteractions(updateText)
 
         verifyBlocking(splitBlock, times(1)) {
             invoke(
@@ -1094,18 +1046,10 @@ class EditorSplitTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(1)) {
-            invoke(
-                params = eq(
-                    UpdateText.Params(
-                        context = root,
-                        text = title.content<Block.Content.Text>().text,
-                        marks = emptyList(),
-                        target = title.id
-                    )
-                )
-            )
-        }
+        // The pre-split save flush is skipped when text is unchanged:
+        // a redundant set-text is a last-writer-wins write that can stomp
+        // a concurrent peer edit.
+        verifyNoInteractions(updateText)
 
         verifyBlocking(splitBlock, times(1)) {
             invoke(
@@ -1275,18 +1219,10 @@ class EditorSplitTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(1)) {
-            invoke(
-                params = eq(
-                    UpdateText.Params(
-                        context = root,
-                        text = title.content<Block.Content.Text>().text,
-                        marks = emptyList(),
-                        target = title.id
-                    )
-                )
-            )
-        }
+        // The pre-split save flush is skipped when text is unchanged:
+        // a redundant set-text is a last-writer-wins write that can stomp
+        // a concurrent peer edit.
+        verifyNoInteractions(updateText)
 
         verifyBlocking(splitBlock, times(1)) {
             invoke(
@@ -1401,18 +1337,10 @@ class EditorSplitTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(1)) {
-            invoke(
-                params = eq(
-                    UpdateText.Params(
-                        context = root,
-                        text = description.content<Block.Content.Text>().text,
-                        marks = emptyList(),
-                        target = description.id
-                    )
-                )
-            )
-        }
+        // The pre-split save flush is skipped when text is unchanged:
+        // a redundant set-text is a last-writer-wins write that can stomp
+        // a concurrent peer edit.
+        verifyNoInteractions(updateText)
 
         verifyBlocking(splitBlock, times(1)) {
             invoke(
@@ -1475,18 +1403,10 @@ class EditorSplitTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(1)) {
-            invoke(
-                params = eq(
-                    UpdateText.Params(
-                        context = root,
-                        text = description.content<Block.Content.Text>().text,
-                        marks = emptyList(),
-                        target = description.id
-                    )
-                )
-            )
-        }
+        // The pre-split save flush is skipped when text is unchanged:
+        // a redundant set-text is a last-writer-wins write that can stomp
+        // a concurrent peer edit.
+        verifyNoInteractions(updateText)
 
         verifyBlocking(splitBlock, times(1)) {
             invoke(
@@ -1549,18 +1469,10 @@ class EditorSplitTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(1)) {
-            invoke(
-                params = eq(
-                    UpdateText.Params(
-                        context = root,
-                        text = description.content<Block.Content.Text>().text,
-                        marks = emptyList(),
-                        target = description.id
-                    )
-                )
-            )
-        }
+        // The pre-split save flush is skipped when text is unchanged:
+        // a redundant set-text is a last-writer-wins write that can stomp
+        // a concurrent peer edit.
+        verifyNoInteractions(updateText)
 
         verifyBlocking(splitBlock, times(1)) {
             invoke(
@@ -1625,18 +1537,10 @@ class EditorSplitTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(1)) {
-            invoke(
-                params = eq(
-                    UpdateText.Params(
-                        context = root,
-                        text = description.content<Block.Content.Text>().text,
-                        marks = emptyList(),
-                        target = description.id
-                    )
-                )
-            )
-        }
+        // The pre-split save flush is skipped when text is unchanged:
+        // a redundant set-text is a last-writer-wins write that can stomp
+        // a concurrent peer edit.
+        verifyNoInteractions(updateText)
 
         verifyBlocking(splitBlock, times(1)) {
             invoke(
@@ -1698,18 +1602,10 @@ class EditorSplitTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(1)) {
-            invoke(
-                params = eq(
-                    UpdateText.Params(
-                        context = root,
-                        text = description.content<Block.Content.Text>().text,
-                        marks = emptyList(),
-                        target = description.id
-                    )
-                )
-            )
-        }
+        // The pre-split save flush is skipped when text is unchanged:
+        // a redundant set-text is a last-writer-wins write that can stomp
+        // a concurrent peer edit.
+        verifyNoInteractions(updateText)
 
         verifyBlocking(splitBlock, times(1)) {
             invoke(
@@ -1771,18 +1667,10 @@ class EditorSplitTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(1)) {
-            invoke(
-                params = eq(
-                    UpdateText.Params(
-                        context = root,
-                        text = description.content<Block.Content.Text>().text,
-                        marks = emptyList(),
-                        target = description.id
-                    )
-                )
-            )
-        }
+        // The pre-split save flush is skipped when text is unchanged:
+        // a redundant set-text is a last-writer-wins write that can stomp
+        // a concurrent peer edit.
+        verifyNoInteractions(updateText)
 
         verifyBlocking(splitBlock, times(1)) {
             invoke(

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorTableOfContentsBlockTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorTableOfContentsBlockTest.kt
@@ -450,7 +450,9 @@ class EditorTableOfContentsBlockTest : EditorPresentationTestSetup() {
             id = MockDataFactory.randomUuid(),
             fields = Block.Fields(emptyMap()),
             content = Block.Content.Text(
-                text = "",
+                // Non-empty: filling an empty block forks its identity via
+                // BlockReplace; this test covers the regular text-change flow.
+                text = MockDataFactory.randomString(),
                 marks = emptyList(),
                 style = Block.Content.Text.Style.H2
             ),

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorTextUpdateTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorTextUpdateTest.kt
@@ -4,7 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.anytypeio.anytype.core_models.Block
 import com.anytypeio.anytype.core_models.ext.content
 import com.anytypeio.anytype.core_models.primitives.SpaceId
-import com.anytypeio.anytype.domain.block.interactor.UpdateText
+import com.anytypeio.anytype.domain.block.interactor.ReplaceBlock
 import com.anytypeio.anytype.domain.page.CloseObject
 import com.anytypeio.anytype.presentation.editor.EditorViewModel
 import com.anytypeio.anytype.presentation.editor.editor.model.BlockView
@@ -21,8 +21,13 @@ import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyBlocking
-import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.verifyNoInteractions
 
+/**
+ * First content into an existing empty text block forks the block identity:
+ * the text reaches the middleware through a single BlockReplace carrying the
+ * input — never through BlockTextSetText on the old (shared) block id.
+ */
 class EditorTextUpdateTest : EditorPresentationTestSetup() {
 
     @get:Rule
@@ -58,21 +63,34 @@ class EditorTextUpdateTest : EditorPresentationTestSetup() {
         children = listOf(title.id)
     )
 
+    private fun givenEmptyParagraph(): Block = Block(
+        id = MockDataFactory.randomUuid(),
+        fields = Block.Fields.empty(),
+        children = emptyList(),
+        content = Block.Content.Text(
+            text = "",
+            marks = emptyList(),
+            style = Block.Content.Text.Style.P
+        )
+    )
+
+    private fun expectedForkParams(target: Block, text: String) = ReplaceBlock.Params(
+        context = root,
+        target = target.id,
+        prototype = Block.Prototype.Text(
+            style = Block.Content.Text.Style.P,
+            text = text,
+            marks = emptyList(),
+            fields = Block.Fields.empty()
+        )
+    )
+
     @Test
     fun `should send paragraph's text update before closing page when bottom sheet is hidden`() {
 
         // SETUP
 
-        val block = Block(
-            id = MockDataFactory.randomUuid(),
-            fields = Block.Fields.empty(),
-            children = emptyList(),
-            content = Block.Content.Text(
-                text = "",
-                marks = emptyList(),
-                style = Block.Content.Text.Style.P
-            )
-        )
+        val block = givenEmptyParagraph()
 
         val page = Block(
             id = root,
@@ -85,7 +103,7 @@ class EditorTextUpdateTest : EditorPresentationTestSetup() {
 
         stubOpenDocument(document)
         stubInterceptEvents()
-        stubUpdateText()
+        stubReplaceBlock()
         stubClosePage()
 
         val vm = buildViewModel()
@@ -111,19 +129,17 @@ class EditorTextUpdateTest : EditorPresentationTestSetup() {
 
         vm.onHomeButtonClicked()
 
-        val inOrder = inOrder(updateText, closePage)
+        val inOrder = inOrder(replaceBlock, closePage)
 
         runBlockingTest {
-            inOrder.verify(updateText, times(1)).invoke(
-                UpdateText.Params(
-                    context = root,
-                    text = updated.text,
-                    marks = emptyList(),
-                    target = block.id
-                )
+            inOrder.verify(replaceBlock, times(1)).invoke(
+                expectedForkParams(target = block, text = updated.text)
             )
             inOrder.verify(closePage, times(1)).async(CloseObject.Params(root, SpaceId(defaultSpace)))
         }
+
+        // Filling an empty block must never set text on the old (shared) id.
+        verifyNoInteractions(updateText)
 
         // RELEASING PENDING COROUTINES
 
@@ -135,16 +151,7 @@ class EditorTextUpdateTest : EditorPresentationTestSetup() {
 
         // SETUP
 
-        val block = Block(
-            id = MockDataFactory.randomUuid(),
-            fields = Block.Fields.empty(),
-            children = emptyList(),
-            content = Block.Content.Text(
-                text = "",
-                marks = emptyList(),
-                style = Block.Content.Text.Style.P
-            )
-        )
+        val block = givenEmptyParagraph()
 
         val page = Block(
             id = root,
@@ -157,7 +164,7 @@ class EditorTextUpdateTest : EditorPresentationTestSetup() {
 
         stubOpenDocument(document)
         stubInterceptEvents()
-        stubUpdateText()
+        stubReplaceBlock()
         stubClosePage()
 
         val vm = buildViewModel()
@@ -183,15 +190,8 @@ class EditorTextUpdateTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(1)) {
-            invoke(
-                UpdateText.Params(
-                    context = root,
-                    text = updated.text,
-                    marks = emptyList(),
-                    target = block.id
-                )
-            )
+        verifyBlocking(replaceBlock, times(1)) {
+            invoke(expectedForkParams(target = block, text = updated.text))
         }
 
         vm.onHomeButtonClicked()
@@ -200,7 +200,7 @@ class EditorTextUpdateTest : EditorPresentationTestSetup() {
             async(CloseObject.Params(root, SpaceId(defaultSpace)))
         }
 
-        verifyNoMoreInteractions(updateText)
+        verifyNoInteractions(updateText)
     }
 
     @Test
@@ -208,16 +208,7 @@ class EditorTextUpdateTest : EditorPresentationTestSetup() {
 
         // SETUP
 
-        val block = Block(
-            id = MockDataFactory.randomUuid(),
-            fields = Block.Fields.empty(),
-            children = emptyList(),
-            content = Block.Content.Text(
-                text = "",
-                marks = emptyList(),
-                style = Block.Content.Text.Style.P
-            )
-        )
+        val block = givenEmptyParagraph()
 
         val page = Block(
             id = root,
@@ -230,7 +221,7 @@ class EditorTextUpdateTest : EditorPresentationTestSetup() {
 
         stubOpenDocument(document)
         stubInterceptEvents()
-        stubUpdateText()
+        stubReplaceBlock()
         stubClosePage()
 
         val vm = buildViewModel()
@@ -256,21 +247,18 @@ class EditorTextUpdateTest : EditorPresentationTestSetup() {
 
         vm.onSystemBackPressed(false)
 
-        val inOrder = inOrder(updateText, closePage)
+        val inOrder = inOrder(replaceBlock, closePage)
 
         runBlockingTest {
-            inOrder.verify(updateText, times(1)).invoke(
-                UpdateText.Params(
-                    context = root,
-                    text = updated.text,
-                    marks = emptyList(),
-                    target = block.id
-                )
+            inOrder.verify(replaceBlock, times(1)).invoke(
+                expectedForkParams(target = block, text = updated.text)
             )
             inOrder.verify(closePage, times(1)).async(
-               CloseObject.Params(root, SpaceId(defaultSpace))
+                CloseObject.Params(root, SpaceId(defaultSpace))
             )
         }
+
+        verifyNoInteractions(updateText)
 
         // RELEASING PENDING COROUTINES
 
@@ -282,16 +270,7 @@ class EditorTextUpdateTest : EditorPresentationTestSetup() {
 
         // SETUP
 
-        val block = Block(
-            id = MockDataFactory.randomUuid(),
-            fields = Block.Fields.empty(),
-            children = emptyList(),
-            content = Block.Content.Text(
-                text = "",
-                marks = emptyList(),
-                style = Block.Content.Text.Style.P
-            )
-        )
+        val block = givenEmptyParagraph()
 
         val page = Block(
             id = root,
@@ -304,7 +283,7 @@ class EditorTextUpdateTest : EditorPresentationTestSetup() {
 
         stubOpenDocument(document)
         stubInterceptEvents()
-        stubUpdateText()
+        stubReplaceBlock()
         stubClosePage()
 
         val vm = buildViewModel()
@@ -330,15 +309,8 @@ class EditorTextUpdateTest : EditorPresentationTestSetup() {
 
         coroutineTestRule.advanceTime(EditorViewModel.TEXT_CHANGES_DEBOUNCE_DURATION)
 
-        verifyBlocking(updateText, times(1)) {
-            invoke(
-                UpdateText.Params(
-                    context = root,
-                    text = updated.text,
-                    marks = emptyList(),
-                    target = block.id
-                )
-            )
+        verifyBlocking(replaceBlock, times(1)) {
+            invoke(expectedForkParams(target = block, text = updated.text))
         }
 
         vm.onSystemBackPressed(false)
@@ -347,6 +319,6 @@ class EditorTextUpdateTest : EditorPresentationTestSetup() {
             async(CloseObject.Params(root, SpaceId(defaultSpace)))
         }
 
-        verifyNoMoreInteractions(updateText)
+        verifyNoInteractions(updateText)
     }
 }


### PR DESCRIPTION
## Problem

Block text is whole-value last-writer-wins in the CRDT, keyed by block id. Any empty text block is a shared register: when two users put text into the same empty block concurrently (very common with offline usage), one user's text is silently destroyed on merge. This was our most frequent data-loss conflict, fed by three client behaviors: clicking below the content created an empty block that all clients' cursors converged on; filling any existing empty block wrote text into the shared id; and mere cursor placement (focus/blur, pre-split/pre-merge flushes) issued redundant SetText writes that could stomp peer edits.

## Changes

**1. Virtual trailing "click to type" block.** Clicking the empty area below the document content no longer calls the middleware. A purely presentational paragraph (client-side virtual id) is injected into the render input only — never the document store. On first real input (keystroke, IME, paste, Enter, slash, toolbar action) the block is created via one `BlockCreate` already carrying the content, then swapped in preserving the caret. Focus-reuse of an existing empty trailing block happens only if this session created it; a foreign empty trailing block gets the placeholder rendered below it (and is never auto-deleted). Repeated taps can never create blocks.

**2. Identity fork on filling any empty block (`BlockReplace`).** First content into an existing empty text block sends a single `BlockReplace` carrying the input plus everything the block had (style, checked, color, icon, align, background, fields) instead of `BlockTextSetText`. Replace = remove+create in one atomic change, so two users filling the same empty block end up with two blocks — both texts intact. Exclusions: blocks with children (toggles), title/description, table cells, markdown patterns (their existing Replace already forks), slash-menu input, paste (middleware-side later). Undo restores the empty block; a stale old→new redirect is invalidated when the old block reappears.

**3. No text writes on mere cursor placement.** The saves pipeline drops any update whose text and marks equal the locally known synced state, and the explicit pre-split/pre-merge flushes skip when redundant — for both empty and non-empty blocks.

Both in-flight flows share the same machinery: input buffering with render-time patching, deterministic swap in the render pipeline (`onSuccess` invoked before payload dispatch), divergence flushed immediately on success (editor may close before the swap render), deferred replay of enter/backspace/toolbar/slash actions performed mid-flight, focus-steal protection when the user moves the caret away, and toggle expansion transfer across the id swap.

## Acceptance criteria covered

- Clicking the empty area produces zero middleware calls; typing "h" produces exactly one `BlockCreate` whose model contains "h".
- Typing "h" into an existing empty paragraph sends exactly one `BlockReplace` (no `BlockTextSetText` for the old id); prior style/checked/formatting preserved; caret survives the id swap.
- Two clients typing into the same empty block (or at the doc bottom) while offline end with two blocks — both texts present.
- Empty toggle-with-children, title, description: behavior unchanged. A document is never left with a trailing empty block from mere clicking.

## Testing

- `EditorEmptySpaceInteractionTest` rewritten (12 tests) + new `EditorIdentityForkTest` (6 tests) covering the acceptance criteria; `EditorTextUpdateTest` rewritten for fork semantics.
- Full presentation suite: 1275 tests, 0 failures; middleware/domain/data/core-models suites green.
- Two adversarial review passes on the diff; all confirmed findings fixed.
- Manually tested on device.