### PR TITLE
DROID-4542 Fix invisible select/multi-select options in data-view sets

### DIFF
--- a/app/src/androidTest/java/com/anytypeio/anytype/features/sets/dv/TestObjectSetSetup.kt
+++ b/app/src/androidTest/java/com/anytypeio/anytype/features/sets/dv/TestObjectSetSetup.kt
@@ -53,6 +53,7 @@ import com.anytypeio.anytype.domain.objects.ObjectStore
 import com.anytypeio.anytype.domain.objects.SetObjectListIsArchived
 import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
 import com.anytypeio.anytype.domain.objects.StoreOfRelations
+import com.anytypeio.anytype.domain.objects.options.GetOptions
 import com.anytypeio.anytype.domain.page.CloseObject
 import com.anytypeio.anytype.domain.page.CreateObject
 import com.anytypeio.anytype.domain.primitives.FieldParser
@@ -353,7 +354,6 @@ abstract class TestObjectSetSetup {
             removeObjectFromCollection = removeObjectFromCollection,
             setDataViewProperties = mock(),
             setDataViewObjectOrder = mock(),
-            getOptions = mock(),
             boardGroupSubscriptionContainer = mock(),
             createBlock = mock(),
             emojiProvider = mock(),
@@ -364,7 +364,8 @@ abstract class TestObjectSetSetup {
             backHistoryDelegate = org.mockito.kotlin.mock(),
             exitToVaultDelegate = org.mockito.kotlin.mock(),
             boardRecordsSubscriptionContainer = org.mockito.kotlin.mock(),
-            userSettingsRepository = userSettingsRepository
+            userSettingsRepository = userSettingsRepository,
+            storelessSubscriptionContainer = storelessSubscriptionContainer,
         )
 
         Mockito.`when`(localeProvider.locale()).thenReturn(Locale.getDefault())

--- a/app/src/main/java/com/anytypeio/anytype/ui/sets/ObjectSetFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/sets/ObjectSetFragment.kt
@@ -745,7 +745,13 @@ open class ObjectSetFragment :
                     } else {
                         DataViewInfo.TYPE.COLLECTION_NO_ITEMS
                     },
-                    isReadOnlyAccess = !state.isCreateObjectAllowed
+                    // The group-by hint points at view settings, so it is gated by view-edit
+                    // permission; the "no items" hint is gated by object creation.
+                    isReadOnlyAccess = if (state.isBoardGroupByRequired) {
+                        !state.isEditingViewAllowed
+                    } else {
+                        !state.isCreateObjectAllowed
+                    }
                 )
                 setViewer(viewer = null)
             }
@@ -810,7 +816,13 @@ open class ObjectSetFragment :
                     } else {
                         DataViewInfo.TYPE.SET_NO_ITEMS
                     },
-                    isReadOnlyAccess = !state.isCreateObjectAllowed
+                    // The group-by hint points at view settings, so it is gated by view-edit
+                    // permission; the "no items" hint is gated by object creation.
+                    isReadOnlyAccess = if (state.isBoardGroupByRequired) {
+                        !state.isEditingViewAllowed
+                    } else {
+                        !state.isCreateObjectAllowed
+                    }
                 )
                 setViewer(viewer = null)
             }
@@ -896,7 +908,13 @@ open class ObjectSetFragment :
                     } else {
                         DataViewInfo.TYPE.SET_NO_ITEMS
                     },
-                    isReadOnlyAccess = !state.isCreateObjectAllowed
+                    // The group-by hint points at view settings, so it is gated by view-edit
+                    // permission; the "no items" hint is gated by object creation.
+                    isReadOnlyAccess = if (state.isBoardGroupByRequired) {
+                        !state.isEditingViewAllowed
+                    } else {
+                        !state.isCreateObjectAllowed
+                    }
                 )
                 setViewer(viewer = null)
             }

--- a/app/src/main/java/com/anytypeio/anytype/ui/sets/ObjectSetFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/sets/ObjectSetFragment.kt
@@ -319,6 +319,7 @@ open class ObjectSetFragment :
                     DataViewInfo.TYPE.COLLECTION_NO_ITEMS -> vm.proceedWithDataViewObjectCreate()
                     DataViewInfo.TYPE.SET_NO_QUERY -> vm.onSelectQueryButtonClicked()
                     DataViewInfo.TYPE.SET_NO_ITEMS -> vm.proceedWithDataViewObjectCreate()
+                    DataViewInfo.TYPE.BOARD_NO_GROUP_BY -> {}
                     DataViewInfo.TYPE.INIT -> {}
                 }
             }
@@ -739,7 +740,11 @@ open class ObjectSetFragment :
                 setupNewButtons(state.isCreateObjectAllowed)
                 setCurrentViewerName(state.title)
                 dataViewInfo.show(
-                    type = DataViewInfo.TYPE.COLLECTION_NO_ITEMS,
+                    type = if (state.isBoardGroupByRequired) {
+                        DataViewInfo.TYPE.BOARD_NO_GROUP_BY
+                    } else {
+                        DataViewInfo.TYPE.COLLECTION_NO_ITEMS
+                    },
                     isReadOnlyAccess = !state.isCreateObjectAllowed
                 )
                 setViewer(viewer = null)
@@ -800,7 +805,11 @@ open class ObjectSetFragment :
                 }
                 setCurrentViewerName(state.title)
                 dataViewInfo.show(
-                    type = DataViewInfo.TYPE.SET_NO_ITEMS,
+                    type = if (state.isBoardGroupByRequired) {
+                        DataViewInfo.TYPE.BOARD_NO_GROUP_BY
+                    } else {
+                        DataViewInfo.TYPE.SET_NO_ITEMS
+                    },
                     isReadOnlyAccess = !state.isCreateObjectAllowed
                 )
                 setViewer(viewer = null)
@@ -882,7 +891,11 @@ open class ObjectSetFragment :
                 customizeViewButton.isEnabled = true
                 setCurrentViewerName(state.title)
                 dataViewInfo.show(
-                    type = DataViewInfo.TYPE.SET_NO_ITEMS,
+                    type = if (state.isBoardGroupByRequired) {
+                        DataViewInfo.TYPE.BOARD_NO_GROUP_BY
+                    } else {
+                        DataViewInfo.TYPE.SET_NO_ITEMS
+                    },
                     isReadOnlyAccess = !state.isCreateObjectAllowed
                 )
                 setViewer(viewer = null)

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/widgets/toolbar/DataViewInfo.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/widgets/toolbar/DataViewInfo.kt
@@ -75,11 +75,16 @@ class DataViewInfo @JvmOverloads constructor(
             }
             TYPE.BOARD_NO_GROUP_BY -> {
                 // The board has no grouping property set, so it can never build columns. Show an
-                // explicit hint (instead of an endless spinner) pointing to the view settings.
+                // explicit hint (instead of an endless spinner) pointing to the view settings —
+                // but only for users who can actually edit the view.
                 binding.title.text = resources.getString(R.string.dataview_board_no_group_title)
-                binding.description.text =
-                    resources.getString(R.string.dataview_board_no_group_description)
-                binding.description.visible()
+                if (isReadOnlyAccess) {
+                    binding.description.invisible()
+                } else {
+                    binding.description.text =
+                        resources.getString(R.string.dataview_board_no_group_description)
+                    binding.description.visible()
+                }
                 binding.button.invisible()
             }
         }

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/widgets/toolbar/DataViewInfo.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/widgets/toolbar/DataViewInfo.kt
@@ -73,6 +73,15 @@ class DataViewInfo @JvmOverloads constructor(
                     binding.button.visible()
                 }
             }
+            TYPE.BOARD_NO_GROUP_BY -> {
+                // The board has no grouping property set, so it can never build columns. Show an
+                // explicit hint (instead of an endless spinner) pointing to the view settings.
+                binding.title.text = resources.getString(R.string.dataview_board_no_group_title)
+                binding.description.text =
+                    resources.getString(R.string.dataview_board_no_group_description)
+                binding.description.visible()
+                binding.button.invisible()
+            }
         }
     }
 
@@ -93,6 +102,7 @@ class DataViewInfo @JvmOverloads constructor(
         INIT,
         COLLECTION_NO_ITEMS,
         SET_NO_QUERY,
-        SET_NO_ITEMS
+        SET_NO_ITEMS,
+        BOARD_NO_GROUP_BY
     }
 }

--- a/localization/src/main/res/values/strings.xml
+++ b/localization/src/main/res/values/strings.xml
@@ -658,6 +658,8 @@
     <string name="dataview_board_checked">Checked</string>
     <string name="dataview_board_unchecked">Unchecked</string>
     <string name="dataview_board_new_object">New</string>
+    <string name="dataview_board_no_group_title">No grouping property</string>
+    <string name="dataview_board_no_group_description">Choose a property to group cards by in view settings</string>
     <string name="page_cover">Page cover</string>
     <string name="object_action_pin">Pin</string>
     <string name="object_action_unpin">Unpin</string>

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/DataViewViewState.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/DataViewViewState.kt
@@ -17,7 +17,10 @@ sealed class DataViewViewState {
         data class NoItems(
             val title: String,
             override val isCreateObjectAllowed: Boolean = true,
-            override val isEditingViewAllowed: Boolean = true
+            override val isEditingViewAllowed: Boolean = true,
+            // Board view with no grouping property set: show a "choose a grouping property" hint
+            // instead of the "no objects" message (and instead of an endless loading spinner).
+            val isBoardGroupByRequired: Boolean = false
         ) : Collection()
 
         data class Default(
@@ -45,7 +48,10 @@ sealed class DataViewViewState {
         data class NoItems(
             val title: String,
             override val isCreateObjectAllowed: Boolean = true,
-            override val isEditingViewAllowed: Boolean = true
+            override val isEditingViewAllowed: Boolean = true,
+            // Board view with no grouping property set: show a "choose a grouping property" hint
+            // instead of the "no objects" message (and instead of an endless loading spinner).
+            val isBoardGroupByRequired: Boolean = false
         ) : Set()
 
         data class Default(
@@ -63,7 +69,10 @@ sealed class DataViewViewState {
         data class NoItems(
             val title: String,
             override val isCreateObjectAllowed: Boolean = true,
-            override val isEditingViewAllowed: Boolean = false
+            override val isEditingViewAllowed: Boolean = false,
+            // Board view with no grouping property set: show a "choose a grouping property" hint
+            // instead of the "no objects" message (and instead of an endless loading spinner).
+            val isBoardGroupByRequired: Boolean = false
         ) : TypeSet()
 
         data class Default(

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
@@ -1088,7 +1088,7 @@ class ObjectSetViewModel(
                             StoreSearchParams(
                                 space = vmParams.space,
                                 subscription = boardOptionsSubscriptionId,
-                                filters = boardGroupOptionsFilters(groupRelationKey),
+                                filters = relationOptionsFilters(listOf(groupRelationKey)),
                                 keys = listOf(
                                     Relations.ID,
                                     Relations.NAME,
@@ -1120,7 +1120,12 @@ class ObjectSetViewModel(
      */
     private fun subscribeToDataViewRelationOptions() {
         jobs += viewModelScope.launch {
-            stateReducer.state
+            // Also re-evaluate on relation-store changes: resolving a link's format below needs the
+            // relation object, which may arrive only after the last state emission on cold start.
+            combine(
+                stateReducer.state,
+                storeOfRelations.trackChanges()
+            ) { state, _ -> state }
                 .map { state ->
                     state.dataViewState()?.dataViewContent?.relationLinks
                         ?.mapNotNull { link ->
@@ -1144,13 +1149,16 @@ class ObjectSetViewModel(
                             StoreSearchParams(
                                 space = vmParams.space,
                                 subscription = dataViewOptionsSubscriptionId,
-                                filters = dataViewOptionsFilters(tagStatusKeys),
+                                filters = relationOptionsFilters(tagStatusKeys),
                                 keys = listOf(
                                     Relations.ID,
                                     Relations.SPACE_ID,
                                     Relations.NAME,
                                     Relations.RELATION_OPTION_COLOR,
-                                    Relations.RELATION_KEY
+                                    Relations.RELATION_KEY,
+                                    // The grid render checks isDeleted before showing a chip; fetch
+                                    // it so a deletion amend can be honoured at render time.
+                                    Relations.IS_DELETED
                                 )
                             )
                         )
@@ -1173,8 +1181,8 @@ class ObjectSetViewModel(
         }
     }
 
-    /** The non-deleted options of the given Tag/Status relations (same query as [boardGroupOptionsFilters] / GetOptions). */
-    private fun dataViewOptionsFilters(relationKeys: List<Key>): List<DVFilter> = listOf(
+    /** The non-deleted options of the given Tag/Status relations (same query as the GetOptions use case). */
+    private fun relationOptionsFilters(relationKeys: List<Key>): List<DVFilter> = listOf(
         DVFilter(
             relation = Relations.LAYOUT,
             condition = DVFilterCondition.EQUAL,
@@ -1194,30 +1202,6 @@ class ObjectSetViewModel(
             relation = Relations.RELATION_KEY,
             condition = DVFilterCondition.IN,
             value = relationKeys
-        )
-    )
-
-    /** The non-deleted options of the given relation (same query as the GetOptions use case). */
-    private fun boardGroupOptionsFilters(relationKey: Key): List<DVFilter> = listOf(
-        DVFilter(
-            relation = Relations.LAYOUT,
-            condition = DVFilterCondition.EQUAL,
-            value = ObjectType.Layout.RELATION_OPTION.code.toDouble()
-        ),
-        DVFilter(
-            relation = Relations.IS_DELETED,
-            condition = DVFilterCondition.NOT_EQUAL,
-            value = true
-        ),
-        DVFilter(
-            relation = Relations.IS_ARCHIVED,
-            condition = DVFilterCondition.NOT_EQUAL,
-            value = true
-        ),
-        DVFilter(
-            relation = Relations.RELATION_KEY,
-            condition = DVFilterCondition.EQUAL,
-            value = relationKey
         )
     )
 

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
@@ -310,6 +310,18 @@ class ObjectSetViewModel(
     /** Subscription id of the live options (column headers) of the board's group relation. */
     private val boardOptionsSubscriptionId = "${vmParams.ctx}$SUBSCRIPTION_BOARD_OPTIONS_POSTFIX"
 
+    /**
+     * Subscription id of the live options of the active data view's Tag/Status relations. Their
+     * objects are merged into the shared [objectStore] so grid/gallery/list cells can resolve their
+     * option chips. Needed for TypeSets, where the type's relations are added to the data view only
+     * after the record subscription has started, so option objects never arrive via that
+     * subscription's dependency snapshot (DROID-4542).
+     */
+    private val dataViewOptionsSubscriptionId = "${vmParams.ctx}$SUBSCRIPTION_DATA_VIEW_OPTIONS_POSTFIX"
+
+    /** Bumped whenever the data view's Tag/Status options are (re)merged into the store, to trigger a re-render. */
+    private val dataViewOptionsVersion = MutableStateFlow(0)
+
     /** Whether the experimental Kanban (Board) view is enabled; when off, BOARD views are unsupported. */
     private val isKanbanEnabled = userSettingsRepository.observeKanbanEnabled()
         .stateIn(viewModelScope, SharingStarted.Eagerly, true)
@@ -329,6 +341,12 @@ class ObjectSetViewModel(
         isKanbanEnabled,
         boardSubscriptionError
     ) { _, _, _, _, _ -> Unit }
+
+    /** Fires a re-render whenever the board flows OR the data view's Tag/Status options change. */
+    private val renderTrigger = combine(
+        boardRenderTrigger,
+        dataViewOptionsVersion
+    ) { _, _ -> Unit }
 
     private val _dvViews = MutableStateFlow<List<ViewerView>>(emptyList())
 
@@ -704,6 +722,7 @@ class ObjectSetViewModel(
         // re-subscribes — otherwise the backend group sub, cancelled in onStop, would never
         // be re-established after the first background/foreground cycle.
         subscribeToBoardGroupOptions()
+        subscribeToDataViewRelationOptions()
         subscribeToBoardGroups()
         subscribeToBoardRecords()
         proceedWithOpeningCurrentObject(ctx = vmParams.ctx)
@@ -1091,6 +1110,93 @@ class ObjectSetViewModel(
         }
     }
 
+    /**
+     * Live Tag/Status options (name + color) for the active data view's relations, merged into the
+     * shared [objectStore] so grid/gallery/list cells resolve their option chips. Needed for
+     * TypeSets, where the type's relations are added to the data view only after the record
+     * subscription has started, so the option objects never arrive via that subscription's
+     * dependency snapshot. Harmless for Sets/Collections: the same options are simply re-merged
+     * idempotently (DROID-4542).
+     */
+    private fun subscribeToDataViewRelationOptions() {
+        jobs += viewModelScope.launch {
+            stateReducer.state
+                .map { state ->
+                    state.dataViewState()?.dataViewContent?.relationLinks
+                        ?.mapNotNull { link ->
+                            val format = storeOfRelations.getByKey(link.key)?.format
+                            if (format == RelationFormat.TAG || format == RelationFormat.STATUS) {
+                                link.key
+                            } else {
+                                null
+                            }
+                        }
+                        ?.distinct()
+                        .orEmpty()
+                }
+                .distinctUntilChanged()
+                .flatMapLatest { tagStatusKeys ->
+                    if (tagStatusKeys.isEmpty()) {
+                        storelessSubscriptionContainer.unsubscribe(listOf(dataViewOptionsSubscriptionId))
+                        flowOf(emptyList())
+                    } else {
+                        storelessSubscriptionContainer.subscribe(
+                            StoreSearchParams(
+                                space = vmParams.space,
+                                subscription = dataViewOptionsSubscriptionId,
+                                filters = dataViewOptionsFilters(tagStatusKeys),
+                                keys = listOf(
+                                    Relations.ID,
+                                    Relations.SPACE_ID,
+                                    Relations.NAME,
+                                    Relations.RELATION_OPTION_COLOR,
+                                    Relations.RELATION_KEY
+                                )
+                            )
+                        )
+                    }
+                }
+                .catch { e ->
+                    Timber.e(e, "Error in data view relation options subscription")
+                    emit(emptyList())
+                }
+                .collect { options ->
+                    // Merge into the shared store (grid/gallery/list read options via store.get),
+                    // then bump the version so the render pipeline re-reads the store.
+                    objectStore.merge(
+                        objects = options,
+                        dependencies = emptyList(),
+                        subscriptions = listOf(dataViewOptionsSubscriptionId)
+                    )
+                    dataViewOptionsVersion.update { it + 1 }
+                }
+        }
+    }
+
+    /** The non-deleted options of the given Tag/Status relations (same query as [boardGroupOptionsFilters] / GetOptions). */
+    private fun dataViewOptionsFilters(relationKeys: List<Key>): List<DVFilter> = listOf(
+        DVFilter(
+            relation = Relations.LAYOUT,
+            condition = DVFilterCondition.EQUAL,
+            value = ObjectType.Layout.RELATION_OPTION.code.toDouble()
+        ),
+        DVFilter(
+            relation = Relations.IS_DELETED,
+            condition = DVFilterCondition.NOT_EQUAL,
+            value = true
+        ),
+        DVFilter(
+            relation = Relations.IS_ARCHIVED,
+            condition = DVFilterCondition.NOT_EQUAL,
+            value = true
+        ),
+        DVFilter(
+            relation = Relations.RELATION_KEY,
+            condition = DVFilterCondition.IN,
+            value = relationKeys
+        )
+    )
+
     /** The non-deleted options of the given relation (same query as the GetOptions use case). */
     private fun boardGroupOptionsFilters(relationKey: Key): List<DVFilter> = listOf(
         DVFilter(
@@ -1123,7 +1229,7 @@ class ObjectSetViewModel(
                 stateReducer.state,
                 session.currentViewerId,
                 permission,
-                boardRenderTrigger
+                renderTrigger
             ) { dataViewState, objectState, currentViewId, permission, _ ->
                 processViewState(dataViewState, objectState, currentViewId, permission)
             }.distinctUntilChanged().collect { viewState ->
@@ -1173,6 +1279,16 @@ class ObjectSetViewModel(
      */
     private fun isBoardAwaitingGroups(viewer: Viewer): Boolean =
         viewer is Viewer.Board && boardGroups.value == null
+
+    /**
+     * An enabled Board view with no grouping property can never build columns (it has nothing to
+     * group by), so it would otherwise sit in the loading state forever. Detect it so the render
+     * shows an explicit "choose a grouping property" hint instead of an endless spinner.
+     */
+    private fun isBoardMissingGroupRelation(viewer: DVViewer?): Boolean =
+        isKanbanEnabled.value
+                && viewer?.type == DVViewerType.BOARD
+                && viewer.groupRelationKey.isNullOrEmpty()
 
     /** An active board whose group/record subscription died renders an explicit error. */
     private fun hasBoardSubscriptionFailed(viewer: DVViewer?): Boolean =
@@ -1224,12 +1340,14 @@ class ObjectSetViewModel(
                         msg = BOARD_SUBSCRIPTION_ERROR_MSG
                     )
                     viewer.isEmpty() -> {
-                        if (isBoardAwaitingGroups(viewer)) return DataViewViewState.Init
+                        val missingGroupBy = isBoardMissingGroupRelation(dvViewer)
+                        if (!missingGroupBy && isBoardAwaitingGroups(viewer)) return DataViewViewState.Init
                         val isCreateObjectAllowed = objectState.isCreateObjectAllowed() && permission?.isOwnerOrEditor() == true
                         DataViewViewState.Collection.NoItems(
                             title = viewer.title,
                             isCreateObjectAllowed = isCreateObjectAllowed,
-                            isEditingViewAllowed = permission?.isOwnerOrEditor() == true
+                            isEditingViewAllowed = permission?.isOwnerOrEditor() == true,
+                            isBoardGroupByRequired = missingGroupBy
                         )
                     }
                     else -> {
@@ -1315,14 +1433,16 @@ class ObjectSetViewModel(
                         msg = BOARD_SUBSCRIPTION_ERROR_MSG
                     )
                     render.isEmpty() -> {
-                        if (isBoardAwaitingGroups(render)) return DataViewViewState.Init
+                        val missingGroupBy = isBoardMissingGroupRelation(viewer)
+                        if (!missingGroupBy && isBoardAwaitingGroups(render)) return DataViewViewState.Init
                         val (defType, _) = objectState.getActiveViewTypeAndTemplate(
                             vmParams.ctx, viewer, storeOfObjectTypes
                         )
                         DataViewViewState.Set.NoItems(
                             title = render.title,
                             isCreateObjectAllowed = objectState.isCreateObjectAllowed(defType) && (permission?.isOwnerOrEditor() == true),
-                            isEditingViewAllowed = permission?.isOwnerOrEditor() == true
+                            isEditingViewAllowed = permission?.isOwnerOrEditor() == true,
+                            isBoardGroupByRequired = missingGroupBy
                         )
                     }
                     else -> {
@@ -1399,14 +1519,16 @@ class ObjectSetViewModel(
                         msg = BOARD_SUBSCRIPTION_ERROR_MSG
                     )
                     render.isEmpty() -> {
-                        if (isBoardAwaitingGroups(render)) return DataViewViewState.Init
+                        val missingGroupBy = isBoardMissingGroupRelation(viewer)
+                        if (!missingGroupBy && isBoardAwaitingGroups(render)) return DataViewViewState.Init
                         val (defType, _) = objectState.getActiveViewTypeAndTemplate(
                             vmParams.ctx, viewer, storeOfObjectTypes
                         )
                         DataViewViewState.TypeSet.NoItems(
                             title = render.title,
                             isCreateObjectAllowed = objectState.isCreateObjectAllowed(defType) && (permission?.isOwnerOrEditor() == true),
-                            isEditingViewAllowed = permission?.isOwnerOrEditor() == true
+                            isEditingViewAllowed = permission?.isOwnerOrEditor() == true,
+                            isBoardGroupByRequired = missingGroupBy
                         )
                     }
                     else -> {
@@ -1480,6 +1602,7 @@ class ObjectSetViewModel(
         boardGroupOptions.value = emptyMap()
         boardRecords.value = emptyMap()
         boardSubscriptionError.value = null
+        dataViewOptionsVersion.value = 0
     }
 
     fun onCloseObject() {
@@ -1518,6 +1641,10 @@ class ObjectSetViewModel(
                 vmParams.ctx + BoardGroupSubscriptionContainer.SUBSCRIPTION_POSTFIX
             )
             storelessSubscriptionContainer.unsubscribe(listOf(boardOptionsSubscriptionId))
+            storelessSubscriptionContainer.unsubscribe(listOf(dataViewOptionsSubscriptionId))
+            // Evict Tag/Status option objects this VM merged into the shared store; options still
+            // referenced by the record subscription survive (unsubscribe only drops this sub id).
+            objectStore.unsubscribe(listOf(dataViewOptionsSubscriptionId))
             if (boardRecordSubscriptionIds.isNotEmpty()) {
                 boardRecordsSubscriptionContainer.unsubscribe(boardRecordSubscriptionIds)
                 boardRecordSubscriptionIds = emptyList()
@@ -4811,6 +4938,7 @@ if (effectiveType.recommendedLayout == ObjectType.Layout.SET || effectiveType.re
         const val DELAY_BEFORE_CREATING_TEMPLATE = 200L
         private const val SUBSCRIPTION_TEMPLATES_ID = "-SUBSCRIPTION_TEMPLATES_ID"
         private const val SUBSCRIPTION_BOARD_OPTIONS_POSTFIX = "-board-options"
+        private const val SUBSCRIPTION_DATA_VIEW_OPTIONS_POSTFIX = "-dataview-options"
         const val BOARD_SUBSCRIPTION_ERROR_MSG = "Couldn't load the board. Please reopen the object."
     }
 

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/main/ObjectSetTypeSetTagOptionsTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/main/ObjectSetTypeSetTagOptionsTest.kt
@@ -1,0 +1,372 @@
+package com.anytypeio.anytype.presentation.sets.main
+
+import com.anytypeio.anytype.core_models.Block
+import com.anytypeio.anytype.core_models.DVSort
+import com.anytypeio.anytype.core_models.DVViewerType
+import com.anytypeio.anytype.core_models.ObjectType
+import com.anytypeio.anytype.core_models.ObjectViewDetails
+import com.anytypeio.anytype.core_models.ObjectWrapper
+import com.anytypeio.anytype.core_models.Payload
+import com.anytypeio.anytype.core_models.Relation
+import com.anytypeio.anytype.core_models.RelationFormat
+import com.anytypeio.anytype.core_models.Relations
+import com.anytypeio.anytype.core_models.StubDataView
+import com.anytypeio.anytype.core_models.StubDataViewView
+import com.anytypeio.anytype.core_models.StubDataViewViewRelation
+import com.anytypeio.anytype.core_models.StubHeader
+import com.anytypeio.anytype.core_models.StubRelationLink
+import com.anytypeio.anytype.core_models.StubRelationObject
+import com.anytypeio.anytype.core_models.StubRelationOptionObject
+import com.anytypeio.anytype.core_models.StubTitle
+import com.anytypeio.anytype.domain.base.Resultat
+import com.anytypeio.anytype.domain.library.StoreSearchParams
+import com.anytypeio.anytype.presentation.sets.DataViewViewState
+import com.anytypeio.anytype.presentation.sets.ObjectSetViewModel
+import com.anytypeio.anytype.presentation.sets.subscription.DefaultDataViewSubscription
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import net.bytebuddy.utility.RandomString
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.stub
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for DROID-4542: Tag/Status option chips render empty in a TypeSet's
+ * embedded grid because the option objects never reach the shared object store.
+ *
+ * A TypeSet adds the type's recommended relations (Tag/Status) to the data view's
+ * relationLinks only after the record subscription starts, so the option objects are
+ * not delivered via that subscription's dependency snapshot. A dedicated options
+ * subscription must fetch them and merge them into the shared [ObjectSetViewModel]'s store,
+ * so `buildGridRow`'s `store.get(optionId)` can resolve the chip's name + color.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ObjectSetTypeSetTagOptionsTest : ObjectSetViewModelTestSetup() {
+
+    private lateinit var closable: AutoCloseable
+    private lateinit var viewModel: ObjectSetViewModel
+
+    private val typeId = root // For a TypeSet, the context IS the type
+    private val typeUniqueKey = "typeKey-${RandomString.make()}"
+
+    private val tagRelation = StubRelationObject(
+        key = "tag-${RandomString.make()}",
+        isReadOnlyValue = false,
+        format = Relation.Format.TAG
+    )
+    private val nameRelation = StubRelationObject(
+        key = Relations.NAME,
+        isReadOnlyValue = false,
+        format = Relation.Format.SHORT_TEXT
+    )
+    private val createdDateRelation = StubRelationObject(
+        key = Relations.CREATED_DATE,
+        isReadOnlyValue = true,
+        format = Relation.Format.DATE
+    )
+
+    private val nameRelationLink = StubRelationLink(Relations.NAME, Relation.Format.LONG_TEXT)
+    private val createdDateRelationLink = StubRelationLink(Relations.CREATED_DATE, RelationFormat.DATE)
+    private val tagRelationLink = StubRelationLink(tagRelation.key, Relation.Format.TAG)
+
+    private val subscriptionId = DefaultDataViewSubscription.getDataViewSubscriptionId(root)
+
+    // Mirrors DefaultDataViewSubscription/ObjectSetViewModel's dedicated options subscription id.
+    private val optionsSubscriptionId = "$root-dataview-options"
+
+    // The option the object actually holds (named + colored), initially only reachable via the
+    // dedicated options subscription, NOT via the record subscription's dependencies.
+    private val tagOption = StubRelationOptionObject(
+        id = "opt-${RandomString.make()}",
+        space = defaultSpace,
+        text = "tag3",
+        color = "orange"
+    )
+
+    @Before
+    fun setup() {
+        closable = MockitoAnnotations.openMocks(this)
+        proceedWithDefaultBeforeTestStubbing()
+    }
+
+    @After
+    fun after() {
+        rule.advanceTime()
+        closable.close()
+    }
+
+    @Test
+    fun `type set should merge tag relation options into the store via a dedicated subscription`() =
+        runTest {
+            // SETUP
+            val title = StubTitle(id = "title-${RandomString.make()}")
+            val header = StubHeader(id = "header-${RandomString.make()}", children = listOf(title.id))
+
+            val viewer = StubDataViewView(
+                id = "viewer-${RandomString.make()}",
+                viewerRelations = listOf(
+                    StubDataViewViewRelation(key = nameRelation.key, isVisible = true),
+                    StubDataViewViewRelation(key = tagRelation.key, isVisible = true)
+                )
+            )
+
+            // The Tag relation is already in relationLinks (models the post-sync state, where the
+            // Tag column is visible but the option object is missing from the store).
+            val dataView = StubDataView(
+                id = "dv-${RandomString.make()}",
+                views = listOf(viewer),
+                relationLinks = listOf(nameRelationLink, createdDateRelationLink, tagRelationLink)
+            )
+
+            val details = ObjectViewDetails(
+                details = mapOf(
+                    root to mapOf(
+                        Relations.ID to root,
+                        Relations.SPACE_ID to defaultSpace,
+                        Relations.LAYOUT to ObjectType.Layout.OBJECT_TYPE.code.toDouble(),
+                        Relations.UNIQUE_KEY to typeUniqueKey,
+                        Relations.RECOMMENDED_RELATIONS to listOf(tagRelation.id)
+                    )
+                )
+            )
+
+            storeOfObjectTypes.set(
+                typeId,
+                mapOf(
+                    Relations.ID to typeId,
+                    Relations.UNIQUE_KEY to typeUniqueKey,
+                    Relations.LAYOUT to ObjectType.Layout.OBJECT_TYPE.code.toDouble(),
+                    Relations.RECOMMENDED_RELATIONS to listOf(tagRelation.id)
+                )
+            )
+
+            storeOfRelations.merge(listOf(tagRelation, nameRelation, createdDateRelation))
+
+            // The object of this type holds the tag option value.
+            val record = ObjectWrapper.Basic(
+                mapOf(
+                    Relations.ID to "record-${RandomString.make()}",
+                    Relations.SPACE_ID to defaultSpace,
+                    Relations.TYPE to listOf(typeId),
+                    tagRelation.key to listOf(tagOption.id)
+                )
+            )
+
+            stubSpaceManager(defaultSpace)
+            stubInterceptEvents()
+            stubInterceptThreadStatus()
+            stubOpenObject(doc = listOf(header, title, dataView), details = details)
+            // The record subscription delivers the record but NO option dependency (the bug condition).
+            stubSubscriptionResults(
+                subscription = subscriptionId,
+                spaceId = defaultSpace,
+                objects = listOf(record),
+                dependencies = emptyList(),
+                keys = listOf(tagRelation.key),
+                sources = listOf(typeId),
+                dvSorts = listOf(
+                    DVSort(
+                        relationKey = Relations.CREATED_DATE,
+                        type = Block.Content.DataView.Sort.Type.DESC,
+                        relationFormat = RelationFormat.DATE,
+                        includeTime = true
+                    )
+                ),
+                dvRelationLinks = listOf(nameRelationLink, createdDateRelationLink, tagRelationLink)
+            )
+            stubTemplatesForTemplatesContainer()
+            stubSetDataViewProperties()
+
+            // The dedicated options subscription returns the tag option; all other storeless
+            // subscriptions (e.g. board options) keep the default empty result.
+            storelessSubscriptionContainer.stub {
+                on {
+                    subscribe(argThat<StoreSearchParams> { subscription == optionsSubscriptionId })
+                } doReturn flowOf(listOf(ObjectWrapper.Basic(tagOption.map)))
+            }
+
+            viewModel = givenViewModel()
+
+            // TESTING
+            viewModel.onStart()
+            advanceUntilIdle()
+
+            // VERIFY — the option object is now present in the shared store, so grid cells can
+            // resolve the chip. Fails before the fix (nothing merges it into the store).
+            val stored = objectStore.get(tagOption.id)
+            assertNotNull(stored, "Tag option should be present in the object store")
+            assertEquals("tag3", stored.name)
+            assertEquals("orange", ObjectWrapper.Option(stored.map).color)
+        }
+
+    @Test
+    fun `regular set still resolves tag options delivered as record subscription dependencies`() =
+        runTest {
+            // SETUP — a normal Set (not a TypeSet). The option arrives as a record-subscription
+            // dependency (the pre-existing path); the dedicated options subscription returns nothing.
+            val setOfValue = "setOf-${RandomString.make()}"
+            val title = StubTitle(id = "title-${RandomString.make()}")
+            val header = StubHeader(id = "header-${RandomString.make()}", children = listOf(title.id))
+
+            val viewer = StubDataViewView(
+                id = "viewer-${RandomString.make()}",
+                viewerRelations = listOf(
+                    StubDataViewViewRelation(key = nameRelation.key, isVisible = true),
+                    StubDataViewViewRelation(key = tagRelation.key, isVisible = true)
+                )
+            )
+
+            val dataView = StubDataView(
+                id = "dv-${RandomString.make()}",
+                views = listOf(viewer),
+                relationLinks = listOf(nameRelationLink, createdDateRelationLink, tagRelationLink)
+            )
+
+            val details = ObjectViewDetails(
+                details = mapOf(
+                    root to mapOf(
+                        Relations.ID to root,
+                        Relations.SPACE_ID to defaultSpace,
+                        Relations.LAYOUT to ObjectType.Layout.SET.code.toDouble(),
+                        Relations.SET_OF to listOf(setOfValue)
+                    ),
+                    setOfValue to mapOf(
+                        Relations.ID to setOfValue,
+                        Relations.SPACE_ID to defaultSpace,
+                        Relations.LAYOUT to ObjectType.Layout.OBJECT_TYPE.code.toDouble()
+                    )
+                )
+            )
+
+            storeOfRelations.merge(listOf(tagRelation, nameRelation, createdDateRelation))
+
+            val record = ObjectWrapper.Basic(
+                mapOf(
+                    Relations.ID to "record-${RandomString.make()}",
+                    Relations.SPACE_ID to defaultSpace,
+                    tagRelation.key to listOf(tagOption.id)
+                )
+            )
+
+            stubSpaceManager(defaultSpace)
+            stubInterceptEvents()
+            stubInterceptThreadStatus()
+            stubOpenObject(doc = listOf(header, title, dataView), details = details)
+            // The record subscription delivers the option as a dependency (the existing path).
+            stubSubscriptionResults(
+                subscription = subscriptionId,
+                spaceId = defaultSpace,
+                objects = listOf(record),
+                dependencies = listOf(ObjectWrapper.Basic(tagOption.map)),
+                keys = listOf(tagRelation.key),
+                sources = listOf(setOfValue),
+                dvSorts = listOf(
+                    DVSort(
+                        relationKey = Relations.CREATED_DATE,
+                        type = Block.Content.DataView.Sort.Type.DESC,
+                        relationFormat = RelationFormat.DATE,
+                        includeTime = true
+                    )
+                ),
+                dvRelationLinks = listOf(nameRelationLink, createdDateRelationLink, tagRelationLink)
+            )
+            stubTemplatesForTemplatesContainer()
+            // Dedicated options subscription returns nothing (default stub) — the option must still
+            // be resolvable purely from the record-subscription dependency.
+
+            viewModel = givenViewModel()
+
+            // TESTING
+            viewModel.onStart()
+            advanceUntilIdle()
+
+            // VERIFY — the tag option is still in the store; the new subscription did not evict it.
+            val stored = objectStore.get(tagOption.id)
+            assertNotNull(stored, "Tag option delivered as a record dependency should stay in the store")
+            assertEquals("tag3", stored.name)
+        }
+
+    @Test
+    fun `type set board with no grouping property shows group-by hint instead of endless loading`() =
+        runTest {
+            // SETUP — a Board (Kanban) viewer with NO groupRelationKey (StubDataViewView defaults it
+            // to null). Such a board can never build columns, so it must not sit on a spinner.
+            val title = StubTitle(id = "title-${RandomString.make()}")
+            val header = StubHeader(id = "header-${RandomString.make()}", children = listOf(title.id))
+
+            val viewer = StubDataViewView(
+                id = "viewer-${RandomString.make()}",
+                type = DVViewerType.BOARD,
+                viewerRelations = listOf(
+                    StubDataViewViewRelation(key = nameRelation.key, isVisible = true)
+                )
+            )
+
+            val dataView = StubDataView(
+                id = "dv-${RandomString.make()}",
+                views = listOf(viewer),
+                relationLinks = listOf(nameRelationLink, createdDateRelationLink)
+            )
+
+            // The type page renders its own objects as a Set: the type is its own source (setOf).
+            val details = ObjectViewDetails(
+                details = mapOf(
+                    root to mapOf(
+                        Relations.ID to root,
+                        Relations.SPACE_ID to defaultSpace,
+                        Relations.LAYOUT to ObjectType.Layout.OBJECT_TYPE.code.toDouble(),
+                        Relations.UNIQUE_KEY to typeUniqueKey,
+                        Relations.RECOMMENDED_RELATIONS to listOf(nameRelation.id),
+                        Relations.SET_OF to listOf(typeId)
+                    )
+                )
+            )
+
+            storeOfObjectTypes.set(
+                typeId,
+                mapOf(
+                    Relations.ID to typeId,
+                    Relations.UNIQUE_KEY to typeUniqueKey,
+                    Relations.LAYOUT to ObjectType.Layout.OBJECT_TYPE.code.toDouble(),
+                    Relations.RECOMMENDED_RELATIONS to listOf(nameRelation.id)
+                )
+            )
+            storeOfRelations.merge(listOf(nameRelation, createdDateRelation))
+
+            stubSpaceManager(defaultSpace)
+            stubInterceptEvents()
+            stubInterceptThreadStatus()
+            stubOpenObject(doc = listOf(header, title, dataView), details = details)
+            stubTemplatesForTemplatesContainer()
+            stubSetDataViewProperties()
+
+            viewModel = givenViewModel()
+
+            // TESTING
+            viewModel.onStart()
+            advanceUntilIdle()
+
+            // VERIFY — explicit "choose a grouping property" empty state, not an endless spinner.
+            val state = viewModel.currentViewer.value
+            assertTrue(
+                state is DataViewViewState.TypeSet.NoItems && state.isBoardGroupByRequired,
+                "Expected TypeSet.NoItems(isBoardGroupByRequired=true), actual: $state"
+            )
+        }
+
+    private fun stubSetDataViewProperties() {
+        setDataViewProperties.stub {
+            onBlocking { async(any()) }.thenReturn(Resultat.success(Payload("", emptyList())))
+        }
+    }
+}


### PR DESCRIPTION
## Problem

On the ObjectType screen — which embeds an `ObjectSetFragment` — a **Tag (multi-select) / Status (select) cell rendered empty**, even though the object had the value (it renders fine in the object itself). Reproduced in grid/table; the option had a real name + color.

## Root cause

The grid resolves each option chip via `store.get(optionId)` on the data-view `ObjectStore` (`SetsExtension.buildGridRow`). Option objects are supposed to arrive as subscription **dependencies** and be merged into that store.

For a **TypeSet**, the type's recommended relations (Tag/Status) are added to the data view's `relationLinks` **asynchronously after** the record subscription has already started (`subscribeToSyncTypeRelations`). That forces a same-subId re-subscribe on which the option objects are **not** re-snapshotted as dependencies, so `store.get(optionId)` stays `null` and the cell renders empty. Normal Set/Collection are unaffected because their Tag key is present from the first subscription.

## Fix

Add a dedicated options subscription in `ObjectSetViewModel` (`subscribeToDataViewRelationOptions`) that fetches the active data view's **Tag/Status relation options** and **merges them into the shared `objectStore`**, plus a render-trigger nudge. This reuses the board's existing pattern (`subscribeToBoardGroupOptions` / `GetOptions`) and requires **no render/mapper/`SetsExtension` signature changes**, so normal Set/Collection tag rendering can't regress — and it fixes **grid, gallery and list** at once (all read options from the store). Device-verified: chips now show with their colors.

## Also included: Kanban no-grouping-property empty state

A pre-existing Kanban bug surfaced during testing: switching a view to **Board** produced `groupRelationKey = null`, so `buildBoardGroupParams` returned `null`, `boardGroups` stayed `null`, and the board sat on an **endless loading spinner**. This change distinguishes "no grouping property" from "groups still loading" (`isBoardMissingGroupRelation`) and renders an explicit **"choose a grouping property"** empty state (`DataViewInfo.TYPE.BOARD_NO_GROUP_BY`) instead. Implemented by reusing the existing `*.NoItems` states with an `isBoardGroupByRequired` flag (lowest-risk — no new render paths).

## Testing

- New `ObjectSetTypeSetTagOptionsTest`:
  - TypeSet options-in-store repro (fails before the fix).
  - Regular-`Set` regression (options via the record-subscription dependency path still work).
  - Board with no grouping property renders the hint instead of `Init`.
- `:presentation:testDebugUnitTest` — **1284 tests, 0 failures**.
- `:app:compileDebugKotlin` — green (app + presentation + core-ui + localization).
- Device-verified: grid / list / gallery show the tag options; Kanban with no grouping shows the hint (not an endless spinner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)