### PR TITLE
DROID-4543 Dedupe viewerRelations→SimpleRelationView mapping in Objec…

### DIFF
--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/ObjectSetSettingsViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/ObjectSetSettingsViewModel.kt
@@ -84,8 +84,9 @@ class ObjectSetSettingsViewModel(
 
                 // Display list: viewerRelations + relationLinks-only relations (e.g. a TypeSet's
                 // recommended properties) surfaced as OFF toggles. Ports iOS sortedRelations.
+                // Reuses the already-computed completeRelations to avoid recomputing it.
                 val relations = buildDisplayRelations(
-                    viewerRelations = viewer.viewerRelations,
+                    completeRelations = completeRelations,
                     inStore = inStore
                 )
                     .filterVisible()
@@ -101,8 +102,9 @@ class ObjectSetSettingsViewModel(
     /**
      * Builds the display list of relations for the Properties screen — ports iOS
      * SetContentViewDataBuilder.sortedRelations. Union of:
-     *  1) relations present in [viewerRelations] (view order, real visibility), and
-     *  2) relations in [inStore] (from dataview.relationLinks) but NOT in [viewerRelations] —
+     *  1) relations already present in [completeRelations] (the viewerRelations-derived list, in
+     *     view order with real visibility), and
+     *  2) relations in [inStore] (from dataview.relationLinks) but NOT in [completeRelations] —
      *     appended as OFF toggles (isVisible = false), in relationLinks order.
      *
      * (2) fixes DROID-4543: a TypeSet's recommended properties land in relationLinks but are not
@@ -111,22 +113,26 @@ class ObjectSetSettingsViewModel(
      * reports links.isHidden = false, also by [Relations.systemRelationKeys] so internal system
      * relations (e.g. "links") never leak in.
      *
+     * [completeRelations] is passed in already computed (see onStart) so the viewerRelations →
+     * SimpleRelationView mapping is done once. Relations in the appended group are, by construction,
+     * absent from viewerRelations, so their visibility is always false — hence the empty
+     * viewerRelations argument to [mapToSimpleRelationView].
+     *
      * Made internal for testing purposes.
      */
     internal fun buildDisplayRelations(
-        viewerRelations: List<DVViewerRelation>,
+        completeRelations: List<SimpleRelationView>,
         inStore: List<ObjectWrapper.Relation>
     ): List<SimpleRelationView> {
-        val present = viewerRelations.toSimpleRelationView(inStore)
-        val presentKeys = present.mapTo(HashSet()) { it.key }
+        val presentKeys = completeRelations.mapTo(HashSet()) { it.key }
         val notPresent = inStore
             .filter { relation ->
                 relation.key !in presentKeys &&
                     relation.isValidToUse &&
                     !Relations.systemRelationKeys.contains(relation.key)
             }
-            .mapToSimpleRelationView(viewerRelations)
-        return present + notPresent
+            .mapToSimpleRelationView(emptyList())
+        return completeRelations + notPresent
     }
 
     fun onEditButtonClicked() {


### PR DESCRIPTION
…tSetSettingsViewModel

buildDisplayRelations recomputed viewer.viewerRelations.toSimpleRelationView(inStore) internally as 'present', duplicating the completeRelations computation already done in onStart. Change buildDisplayRelations to accept the already-computed completeRelations list so the mapping runs once. Relations in the appended group are, by construction, absent from viewerRelations, so their visibility is always false; pass an empty viewerRelations list to mapToSimpleRelationView, preserving behavior.


Claude-Session: https://claude.ai/code/session_01DyxfWGNUpwSR4gX29N7Srp

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
