### PR TITLE
DROID-4543 tag and status  values fix

### DIFF
--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
@@ -22,7 +22,6 @@ import com.anytypeio.anytype.presentation.analytics.AnalyticSpaceHelperDelegate
 import com.anytypeio.anytype.presentation.common.BaseViewModel
 import com.anytypeio.anytype.presentation.extension.sendAnalyticsRelationEvent
 import com.anytypeio.anytype.presentation.relations.providers.ObjectValueProvider
-import com.anytypeio.anytype.presentation.sets.filterIdsById
 import com.anytypeio.anytype.presentation.util.Dispatcher
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
@@ -95,10 +94,15 @@ class TagOrStatusValueViewModel(
     // overwriting our optimistic update before middleware confirms the change
     private var optionEventLockTimestamp: Long? = null
 
+    // Cached after init so click handlers can rebuild viewState optimistically without
+    // re-reading the (possibly orphaned / never re-emitting) value store. See proceedWithOptimisticUpdate.
+    private var currentRelation: ObjectWrapper.Relation? = null
+
     init {
         viewModelScope.launch {
             val relation = storeOfRelations.getByKey(key = viewModelParams.relationKey) ?: return@launch
             setupIsRelationNotEditable(relation)
+            currentRelation = relation
             combine(
                 values.subscribe(
                     ctx = viewModelParams.ctx,
@@ -364,106 +368,118 @@ class TagOrStatusValueViewModel(
         }
     }
 
+    /**
+     * Reconstructs the current ordered list of selected option ids from the *UI* state
+     * ([viewState]) rather than from [values], whose backing store may never re-emit for
+     * some hosts (see [proceedWithOptimisticUpdate]). For tags the selection order is carried
+     * by [RelationsListItem.Item.Tag.number] (1-based index among selected); status has at
+     * most one selected item.
+     */
+    private fun currentSelectedIds(content: TagStatusViewState.Content): List<Id> =
+        content.items
+            .filter { it.isSelected }
+            .sortedBy { (it as? RelationsListItem.Item.Tag)?.number ?: 0 }
+            .map { it.optionId }
+
     private fun addTag(tag: Id) {
-        viewModelScope.launch {
-            val obj = values.get(ctx = viewModelParams.ctx, target = viewModelParams.objectId)
-            val result = mutableListOf<Id>()
-            val value = obj[viewModelParams.relationKey]
-            if (value is List<*>) {
-                result.addAll(value.typeOf())
-            } else if (value is Id) {
-                result.add(value)
-            }
-            result.add(tag)
-            setObjectDetails(
-                UpdateDetail.Params(
-                    target = viewModelParams.objectId,
-                    key = viewModelParams.relationKey,
-                    value = result
-                )
-            ).process(
-                failure = { Timber.e(it, "Error while adding tag") },
-                success = {
-                    dispatcher.send(it)
-                    analytics.sendAnalyticsRelationEvent(
-                        eventName = if (result.isEmpty()) EventsDictionary.relationDeleteValue
-                        else EventsDictionary.relationChangeValue,
-                        storeOfRelations = storeOfRelations,
-                        relationKey = viewModelParams.relationKey,
-                        spaceParams = provideParams(viewModelParams.space.id)
-                    )
-                }
-            )
-        }
+        val content = viewState.value as? TagStatusViewState.Content ?: return
+        val newIds = currentSelectedIds(content) + tag
+        proceedWithOptimisticUpdate(
+            newIds = newIds,
+            persistedValue = newIds,
+            analyticsEvent = EventsDictionary.relationChangeValue,
+            dismissOnSuccess = false
+        )
     }
 
     private fun removeTag(tag: Id) {
-        viewModelScope.launch {
-            val obj = values.get(ctx = viewModelParams.ctx, target = viewModelParams.objectId)
-            val remaining = obj[viewModelParams.relationKey].filterIdsById(tag)
-            setObjectDetails(
-                UpdateDetail.Params(
-                    target = viewModelParams.objectId,
-                    key = viewModelParams.relationKey,
-                    value = remaining
-                )
-            ).process(
-                failure = { Timber.e(it, "Error while adding tag") },
-                success = {
-                    dispatcher.send(it)
-                    analytics.sendAnalyticsRelationEvent(
-                        eventName = if (remaining.isEmpty()) EventsDictionary.relationDeleteValue
-                        else EventsDictionary.relationChangeValue,
-                        storeOfRelations = storeOfRelations,
-                        relationKey = viewModelParams.relationKey,
-                        spaceParams = provideParams(viewModelParams.space.id)
-                    )
-                })
-        }
+        val content = viewState.value as? TagStatusViewState.Content ?: return
+        val newIds = currentSelectedIds(content) - tag
+        proceedWithOptimisticUpdate(
+            newIds = newIds,
+            persistedValue = newIds,
+            analyticsEvent = if (newIds.isEmpty()) EventsDictionary.relationDeleteValue
+            else EventsDictionary.relationChangeValue,
+            dismissOnSuccess = false
+        )
     }
 
     private fun addStatus(status: Id) {
-        viewModelScope.launch {
-            setObjectDetails(
-                UpdateDetail.Params(
-                    target = viewModelParams.objectId,
-                    key = viewModelParams.relationKey,
-                    value = listOf(status)
-                )
-            ).process(
-                failure = { Timber.e(it, "Error while adding tag") },
-                success = {
-                    dispatcher.send(it)
-                    analytics.sendAnalyticsRelationEvent(
-                        eventName = EventsDictionary.relationChangeValue,
-                        storeOfRelations = storeOfRelations,
-                        relationKey = viewModelParams.relationKey,
-                        spaceParams = provideParams(viewModelParams.space.id)
-                    )
-                    emitCommand(command = Command.Dismiss, delay = DELAY_UNTIL_CLOSE)
-                }
-            )
-        }
+        val newIds = listOf(status)
+        proceedWithOptimisticUpdate(
+            newIds = newIds,
+            persistedValue = newIds,
+            analyticsEvent = EventsDictionary.relationChangeValue,
+            dismissOnSuccess = true
+        )
     }
 
     private fun clearTagsOrStatus() {
+        proceedWithOptimisticUpdate(
+            newIds = emptyList(),
+            persistedValue = null,
+            analyticsEvent = EventsDictionary.relationDeleteValue,
+            dismissOnSuccess = false
+        )
+    }
+
+    /**
+     * Single entry point for value edits. The sheet's list is normally rebuilt only when
+     * [values].subscribe re-emits, but some hosts have no live writer for the backing store,
+     * so a click would never be reflected. To fix that we update [viewState] optimistically:
+     * 1. lock event processing so a stale [values] re-emission can't clobber the UI,
+     * 2. rebuild [viewState] from [newIds] via [initViewState] (reuses filterOptions +
+     *    option mapping / number recompute + create-item logic),
+     * 3. persist via [setObjectDetails],
+     * 4. on failure revert to the pre-click snapshot and toast,
+     * 5. on success dispatch the payload, send analytics, optionally dismiss.
+     */
+    private fun proceedWithOptimisticUpdate(
+        newIds: List<Id>,
+        persistedValue: Any?,
+        analyticsEvent: String,
+        dismissOnSuccess: Boolean
+    ) {
+        val relation = currentRelation ?: return
+        val previousState = viewState.value
         viewModelScope.launch {
+            // Lock BEFORE the optimistic write so any concurrent combine emission is skipped.
+            activateOptionEventLock()
+            val options = storeOfRelationOptions
+                .getByRelationKey(viewModelParams.relationKey)
+                .sortedBy { it.orderId }
+            val query = input.value
+            initViewState(
+                relation = relation,
+                options = filterOptions(query, options, newIds),
+                query = query,
+                ids = newIds
+            )
             setObjectDetails(
                 UpdateDetail.Params(
                     target = viewModelParams.objectId,
                     key = viewModelParams.relationKey,
-                    value = null
+                    value = persistedValue
                 )
             ).process(
-                failure = { Timber.e(it, "Error while clearing tags or select") },
+                failure = { e ->
+                    Timber.e(e, "Error while updating tag/status value")
+                    // Revert optimistic update and release the lock so real events are honored again.
+                    optionEventLockTimestamp = null
+                    viewState.value = previousState
+                    sendToast("Error while updating value")
+                },
                 success = {
                     dispatcher.send(it)
                     analytics.sendAnalyticsRelationEvent(
-                        eventName = EventsDictionary.relationDeleteValue,
+                        eventName = analyticsEvent,
                         storeOfRelations = storeOfRelations,
                         relationKey = viewModelParams.relationKey,
                         spaceParams = provideParams(viewModelParams.space.id)
                     )
+                    if (dismissOnSuccess) {
+                        emitCommand(command = Command.Dismiss, delay = DELAY_UNTIL_CLOSE)
+                    }
                 }
             )
         }

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt
@@ -1,0 +1,323 @@
+package com.anytypeio.anytype.presentation.relations.value.tagstatus
+
+import app.cash.turbine.Event
+import app.cash.turbine.test
+import com.anytypeio.anytype.analytics.base.Analytics
+import com.anytypeio.anytype.core_models.Id
+import com.anytypeio.anytype.core_models.ObjectWrapper
+import com.anytypeio.anytype.core_models.Payload
+import com.anytypeio.anytype.core_models.RelationFormat
+import com.anytypeio.anytype.core_models.Relations
+import com.anytypeio.anytype.core_models.ThemeColor
+import com.anytypeio.anytype.core_models.primitives.SpaceId
+import com.anytypeio.anytype.domain.base.Either
+import com.anytypeio.anytype.domain.`object`.UpdateDetail
+import com.anytypeio.anytype.domain.objects.DefaultStoreOfRelationOptions
+import com.anytypeio.anytype.domain.objects.DefaultStoreOfRelations
+import com.anytypeio.anytype.domain.objects.StoreOfRelationOptions
+import com.anytypeio.anytype.domain.objects.StoreOfRelations
+import com.anytypeio.anytype.domain.relations.DeleteRelationOptions
+import com.anytypeio.anytype.domain.relations.SetRelationOptionOrder
+import com.anytypeio.anytype.presentation.analytics.AnalyticSpaceHelperDelegate
+import com.anytypeio.anytype.presentation.relations.providers.FakeObjectValueProvider
+import com.anytypeio.anytype.presentation.util.Dispatcher
+import com.anytypeio.anytype.presentation.util.DefaultCoroutineTestRule
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TagOrStatusValueViewModelTest {
+
+    @get:Rule
+    val coroutineTestRule = DefaultCoroutineTestRule()
+
+    @Mock
+    lateinit var setObjectDetails: UpdateDetail
+
+    @Mock
+    lateinit var dispatcher: Dispatcher<Payload>
+
+    @Mock
+    lateinit var analytics: Analytics
+
+    @Mock
+    lateinit var deleteRelationOptions: DeleteRelationOptions
+
+    @Mock
+    lateinit var setRelationOptionOrder: SetRelationOptionOrder
+
+    @Mock
+    lateinit var analyticSpaceHelperDelegate: AnalyticSpaceHelperDelegate
+
+    private lateinit var storeOfRelations: StoreOfRelations
+    private lateinit var storeOfRelationOptions: StoreOfRelationOptions
+    private lateinit var values: FakeObjectValueProvider
+
+    private val ctx: Id = "ctx-id"
+    private val objectId: Id = "object-id"
+    private val space = SpaceId("space-id")
+    private val relationKey = "custom-tag"
+
+    private val tagA = "opt-a"
+    private val tagB = "opt-b"
+    private val tagC = "opt-c"
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        storeOfRelations = DefaultStoreOfRelations()
+        storeOfRelationOptions = DefaultStoreOfRelationOptions()
+        whenever(analyticSpaceHelperDelegate.provideParams(any()))
+            .thenReturn(AnalyticSpaceHelperDelegate.Params.EMPTY)
+    }
+
+    // region helpers
+
+    private fun tagRelation() = ObjectWrapper.Relation(
+        mapOf(
+            Relations.ID to "rel-$relationKey",
+            Relations.RELATION_KEY to relationKey,
+            Relations.NAME to "Tags",
+            Relations.RELATION_FORMAT to RelationFormat.TAG.code.toDouble()
+        )
+    )
+
+    private fun statusRelation() = ObjectWrapper.Relation(
+        mapOf(
+            Relations.ID to "rel-$relationKey",
+            Relations.RELATION_KEY to relationKey,
+            Relations.NAME to "Status",
+            Relations.RELATION_FORMAT to RelationFormat.STATUS.code.toDouble()
+        )
+    )
+
+    private fun option(id: Id, order: String, key: String = relationKey) = ObjectWrapper.Option(
+        mapOf(
+            Relations.ID to id,
+            Relations.RELATION_KEY to key,
+            Relations.NAME to id,
+            Relations.ORDER_ID to order,
+            Relations.RELATION_OPTION_COLOR to ThemeColor.RED.code
+        )
+    )
+
+    private fun stubPersistSuccess() {
+        setObjectDetails.stub {
+            onBlocking { invoke(any()) } doReturn Either.Right(Payload(context = objectId, events = emptyList()))
+        }
+    }
+
+    private fun stubPersistFailure() {
+        setObjectDetails.stub {
+            onBlocking { invoke(any()) } doReturn Either.Left(RuntimeException("boom"))
+        }
+    }
+
+    private fun buildViewModel(initialIds: List<Id>): TagOrStatusValueViewModel {
+        values = FakeObjectValueProvider(
+            values = mapOf(objectId to mapOf(relationKey to initialIds))
+        )
+        return TagOrStatusValueViewModel(
+            viewModelParams = TagOrStatusValueViewModel.ViewModelParams(
+                ctx = ctx,
+                space = space,
+                objectId = objectId,
+                relationKey = relationKey,
+                isLocked = false,
+                relationContext = RelationContext.DATA_VIEW
+            ),
+            values = values,
+            dispatcher = dispatcher,
+            setObjectDetails = setObjectDetails,
+            analytics = analytics,
+            deleteRelationOptions = deleteRelationOptions,
+            setRelationOptionOrder = setRelationOptionOrder,
+            analyticSpaceHelperDelegate = analyticSpaceHelperDelegate,
+            storeOfRelations = storeOfRelations,
+            storeOfRelationOptions = storeOfRelationOptions
+        )
+    }
+
+    private fun TagOrStatusValueViewModel.items(): List<RelationsListItem.Item> =
+        (viewState.value as TagStatusViewState.Content).items
+
+    private fun List<RelationsListItem.Item>.byId(id: Id) = first { it.optionId == id }
+
+    private fun params(value: Any?) = UpdateDetail.Params(target = objectId, key = relationKey, value = value)
+
+    // endregion
+
+    @Test
+    fun `clicking an unselected tag selects it in viewState without any subscribe re-emit`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+        stubPersistSuccess()
+
+        val vm = buildViewModel(initialIds = emptyList())
+        advanceUntilIdle()
+
+        // Initial: nothing selected.
+        assertTrue(vm.items().none { it.isSelected })
+
+        val tagBItem = vm.items().byId(tagB)
+        vm.onAction(TagStatusAction.Click(tagBItem))
+        advanceUntilIdle()
+
+        val updated = vm.items()
+        val b = updated.byId(tagB) as RelationsListItem.Item.Tag
+        assertTrue(b.isSelected)
+        assertEquals(1, b.number)
+        assertFalse(updated.byId(tagA).isSelected)
+        verifyBlocking(setObjectDetails) { invoke(params(listOf(tagB))) }
+    }
+
+    @Test
+    fun `clicking a selected tag removes it and recomputes numbers`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+        stubPersistSuccess()
+
+        val vm = buildViewModel(initialIds = listOf(tagA, tagB))
+        advanceUntilIdle()
+
+        val tagAItem = vm.items().byId(tagA)
+        assertTrue(tagAItem.isSelected)
+        vm.onAction(TagStatusAction.Click(tagAItem))
+        advanceUntilIdle()
+
+        val updated = vm.items()
+        assertFalse(updated.byId(tagA).isSelected)
+        val b = updated.byId(tagB) as RelationsListItem.Item.Tag
+        assertTrue(b.isSelected)
+        assertEquals(1, b.number)
+        verifyBlocking(setObjectDetails) { invoke(params(listOf(tagB))) }
+    }
+
+    @Test
+    fun `tag selection order drives number, independent of display order`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1"), option(tagC, "2")))
+        stubPersistSuccess()
+
+        val vm = buildViewModel(initialIds = listOf(tagA))
+        advanceUntilIdle()
+
+        // Click C (unselected), then B (unselected). Selection order: A, C, B.
+        vm.onAction(TagStatusAction.Click(vm.items().byId(tagC)))
+        advanceUntilIdle()
+        vm.onAction(TagStatusAction.Click(vm.items().byId(tagB)))
+        advanceUntilIdle()
+
+        val updated = vm.items()
+        assertEquals(1, (updated.byId(tagA) as RelationsListItem.Item.Tag).number)
+        assertEquals(2, (updated.byId(tagC) as RelationsListItem.Item.Tag).number)
+        assertEquals(3, (updated.byId(tagB) as RelationsListItem.Item.Tag).number)
+        verifyBlocking(setObjectDetails) { invoke(params(listOf(tagA, tagC, tagB))) }
+    }
+
+    @Test
+    fun `status single-select selects then clears and dismisses on select`() = runTest {
+        storeOfRelations.merge(listOf(statusRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+        stubPersistSuccess()
+
+        val vm = buildViewModel(initialIds = emptyList())
+        advanceUntilIdle()
+
+        // Select statusA and confirm the sheet dismisses.
+        vm.commands.test {
+            vm.onAction(TagStatusAction.Click(vm.items().byId(tagA)))
+            advanceUntilIdle()
+            val emitted = cancelAndConsumeRemainingEvents()
+                .filterIsInstance<Event.Item<Command>>()
+                .map { it.value }
+            assertTrue(emitted.contains(Command.Dismiss))
+        }
+
+        assertTrue(vm.items().byId(tagA).isSelected)
+        assertFalse(vm.items().byId(tagB).isSelected)
+        verifyBlocking(setObjectDetails) { invoke(params(listOf(tagA))) }
+
+        // Click the selected status again → clears.
+        vm.onAction(TagStatusAction.Click(vm.items().byId(tagA)))
+        advanceUntilIdle()
+
+        assertTrue(vm.items().none { it.isSelected })
+        verifyBlocking(setObjectDetails) { invoke(params(null)) }
+    }
+
+    @Test
+    fun `clear action empties the selection`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+        stubPersistSuccess()
+
+        val vm = buildViewModel(initialIds = listOf(tagA, tagB))
+        advanceUntilIdle()
+
+        vm.onAction(TagStatusAction.Clear)
+        advanceUntilIdle()
+
+        assertTrue(vm.items().none { it.isSelected })
+        verifyBlocking(setObjectDetails) { invoke(params(null)) }
+    }
+
+    @Test
+    fun `failure reverts the optimistic update and toasts`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+        stubPersistFailure()
+
+        val vm = buildViewModel(initialIds = emptyList())
+        advanceUntilIdle()
+        val snapshot = vm.viewState.value
+
+        vm.toasts.test {
+            vm.onAction(TagStatusAction.Click(vm.items().byId(tagB)))
+            advanceUntilIdle()
+            val messages = cancelAndConsumeRemainingEvents()
+                .filterIsInstance<Event.Item<String>>()
+                .map { it.value }
+            assertTrue(messages.contains("Error while updating value"))
+        }
+
+        // Reverted to the pre-click state.
+        assertEquals(snapshot, vm.viewState.value)
+    }
+
+    @Test
+    fun `stale subscription emission does not clobber the optimistic state`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+        stubPersistSuccess()
+
+        // Provider streams an empty value once and never re-emits (orphaned-store condition).
+        val vm = buildViewModel(initialIds = emptyList())
+        advanceUntilIdle()
+
+        vm.onAction(TagStatusAction.Click(vm.items().byId(tagB)))
+        advanceUntilIdle()
+        assertTrue(vm.items().byId(tagB).isSelected)
+
+        // Force the combine to re-run (via a store change) while the option-event lock is active.
+        // The cached record value is still empty; without the lock this would deselect tagB.
+        storeOfRelationOptions.merge(listOf(option("unrelated", "0", key = "other-key")))
+        advanceUntilIdle()
+
+        assertTrue(vm.items().byId(tagB).isSelected)
+    }
+}


### PR DESCRIPTION
(cherry picked from commit 34aedf729579596bdbce5dbceed93735ebbb199c)

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

Fixes tag/status values not updating in the value bottom sheet on hosts where the backing value store never re-emits (orphaned-store condition, e.g. some data-view contexts).

Previously each edit handler (`addTag`, `removeTag`, `addStatus`, `clearTagsOrStatus`) read the current value from `values.get()`, persisted the change, and then relied on `values.subscribe()` re-emitting to rebuild the list. When no live writer pushed a new value into the store, the change was persisted but the UI never reflected the click.

This PR reworks all four handlers to funnel through a single `proceedWithOptimisticUpdate(...)`:

- Rebuilds the selection from the **UI** state (`currentSelectedIds`, ordered by each tag's `number`) instead of the possibly-orphaned value store.
- Updates `viewState` optimistically via the existing `initViewState` path (reusing option filtering, mapping, number recompute, and create-item logic).
- Activates the option-event lock **before** the optimistic write so a stale concurrent `combine` emission can't clobber it.
- On failure, reverts to the pre-click snapshot, releases the lock, and shows a toast (previously failures were only logged).
- On success, dispatches the payload, sends the relation analytics event, and dismisses the sheet for status single-select.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

DROID-4543

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 👍 yes

New `TagOrStatusValueViewModelTest` covers: selecting/deselecting tags without a subscribe re-emit, selection order driving `number`, status single-select then clear + dismiss, the clear action, failure revert + toast, and the stale-subscription-emission race (lock protects the optimistic state).

### Added to documentation?

- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
