### PR TITLE
DROID-4545 Fix filtered collections and Status property not appearing

### DIFF
--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/objects/ObjectWrapperExtensions.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/objects/ObjectWrapperExtensions.kt
@@ -255,7 +255,7 @@ suspend fun ObjectWrapper.Basic.statuses(
 ) : List<StatusView> {
     val result = mutableListOf<StatusView>()
     val keys : List<Id> = when(val value = map.getOrDefault(relation, null)) {
-        is Id -> listOf(id)
+        is Id -> listOf(value)
         is List<*> -> value.typeOf()
         else -> emptyList()
     }
@@ -280,7 +280,7 @@ suspend fun ObjectWrapper.Basic.tags(
 ) : List<TagView> {
     val result = mutableListOf<TagView>()
     val keys : List<Id> = when(val value = map.getOrDefault(relation, null)) {
-        is Id -> listOf(id)
+        is Id -> listOf(value)
         is List<*> -> value.typeOf()
         else -> emptyList()
     }
@@ -305,7 +305,7 @@ suspend fun ObjectWrapper.Basic.files(
 ) : List<FileView> {
     val result = mutableListOf<FileView>()
     val ids : List<Id> = when(val value = map.getOrDefault(relation, null)) {
-        is Id -> listOf(id)
+        is Id -> listOf(value)
         is List<*> -> value.typeOf()
         else -> emptyList()
     }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetExtension.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetExtension.kt
@@ -143,10 +143,14 @@ fun ObjectState.DataView.Collection.getObjectOrderIds(currentViewerId: String): 
  *
  * For DATE formats: adds the relationFormat to the filter.
  * For OBJECT formats: adds the relationFormat and normalizes EQUAL condition to IN.
+ * For STATUS/TAG formats: adds the relationFormat so the option-id value is matched as a
+ * select value instead of falling back to `longtext` (which matches nothing) when the
+ * filter arrives without a format set (e.g. created on Desktop). SELECT conditions
+ * (In/AllIn/NotIn/Empty/NotEmpty) never use EQUAL, so no condition normalization is needed.
  *
  * @param filter the filter to transform.
  * @param format the relation format to apply (null means no transformation).
- * @return the transformed filter, or the original if format is null or not DATE/OBJECT.
+ * @return the transformed filter, or the original if format is null or not DATE/OBJECT/STATUS/TAG.
  */
 private fun transformFilterWithFormat(filter: DVFilter, format: RelationFormat?): DVFilter {
     return when (format) {
@@ -163,6 +167,9 @@ private fun transformFilterWithFormat(filter: DVFilter, format: RelationFormat?)
                     filter.condition
                 }
             )
+        }
+        RelationFormat.STATUS, RelationFormat.TAG -> {
+            filter.copy(relationFormat = format)
         }
         else -> filter
     }

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/extension/FilterSubscriptionSupportTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/extension/FilterSubscriptionSupportTest.kt
@@ -464,4 +464,107 @@ class FilterSubscriptionSupportTest {
     }
 
     // endregion
+
+    // region updateFormatForSubscription — STATUS/TAG filters (DROID-4545)
+
+    @Test
+    fun `updateFormatForSubscription stamps STATUS format so a status filter is not sent as longtext`() = runBlocking {
+        val statusRelationKey = "status"
+
+        val storeOfRelations = DefaultStoreOfRelations()
+        storeOfRelations.merge(
+            listOf(
+                StubRelationObject(
+                    key = statusRelationKey,
+                    format = com.anytypeio.anytype.core_models.Relation.Format.STATUS
+                )
+            )
+        )
+
+        // Arrives mislabeled as LONG_TEXT (e.g. created on Desktop / format not set by MW).
+        val statusFilter = StubFilter(
+            relationKey = statusRelationKey,
+            relationFormat = RelationFormat.LONG_TEXT,
+            condition = DVFilterCondition.IN,
+            value = listOf("optionId")
+        )
+
+        val result = listOf(statusFilter).updateFormatForSubscription(storeOfRelations)
+
+        assertEquals(1, result.size)
+        assertEquals(
+            RelationFormat.STATUS,
+            result.first().relationFormat,
+            "Status filter must be re-stamped as STATUS, otherwise it is serialized as longtext and matches nothing"
+        )
+    }
+
+    @Test
+    fun `updateFormatForSubscription stamps TAG format so a tag filter is not sent as longtext`() = runBlocking {
+        val tagRelationKey = "tag"
+
+        val storeOfRelations = DefaultStoreOfRelations()
+        storeOfRelations.merge(
+            listOf(
+                StubRelationObject(
+                    key = tagRelationKey,
+                    format = com.anytypeio.anytype.core_models.Relation.Format.TAG
+                )
+            )
+        )
+
+        val tagFilter = StubFilter(
+            relationKey = tagRelationKey,
+            relationFormat = RelationFormat.LONG_TEXT,
+            condition = DVFilterCondition.IN,
+            value = listOf("optionId")
+        )
+
+        val result = listOf(tagFilter).updateFormatForSubscription(storeOfRelations)
+
+        assertEquals(1, result.size)
+        assertEquals(
+            RelationFormat.TAG,
+            result.first().relationFormat,
+            "Tag filter must be re-stamped as TAG, otherwise it is serialized as longtext and matches nothing"
+        )
+    }
+
+    @Test
+    fun `updateFormatForSubscription stamps STATUS format on a nested status filter inside a group`() = runBlocking {
+        val statusRelationKey = "status"
+
+        val storeOfRelations = DefaultStoreOfRelations()
+        storeOfRelations.merge(
+            listOf(
+                StubRelationObject(
+                    key = statusRelationKey,
+                    format = com.anytypeio.anytype.core_models.Relation.Format.STATUS
+                )
+            )
+        )
+
+        val nestedStatusFilter = StubFilter(
+            relationKey = statusRelationKey,
+            relationFormat = RelationFormat.LONG_TEXT,
+            condition = DVFilterCondition.IN,
+            value = listOf("optionId")
+        )
+        val advancedGroup = StubFilter(
+            operator = DVFilterOperator.AND,
+            condition = DVFilterCondition.EQUAL,
+            nestedFilters = listOf(nestedStatusFilter)
+        )
+
+        val result = listOf(advancedGroup).updateFormatForSubscription(storeOfRelations)
+
+        assertEquals(1, result.size)
+        assertEquals(
+            RelationFormat.STATUS,
+            result.first().nestedFilters.first().relationFormat,
+            "Nested status filter should also be re-stamped as STATUS"
+        )
+    }
+
+    // endregion
 }

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/mapper/ObjectWrapperExtensionsKtTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/mapper/ObjectWrapperExtensionsKtTest.kt
@@ -8,10 +8,13 @@ import com.anytypeio.anytype.domain.debugging.Logger
 import com.anytypeio.anytype.domain.misc.DateProvider
 import com.anytypeio.anytype.core_models.UrlBuilder
 import com.anytypeio.anytype.domain.objects.GetDateObjectByTimestamp
+import com.anytypeio.anytype.domain.objects.ObjectStore
 import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
 import com.anytypeio.anytype.domain.primitives.FieldParser
 import com.anytypeio.anytype.domain.primitives.FieldParserImpl
 import com.anytypeio.anytype.domain.resources.StringResourceProvider
+import com.anytypeio.anytype.presentation.objects.statuses
+import com.anytypeio.anytype.presentation.objects.tags
 import com.anytypeio.anytype.presentation.objects.toViews
 import com.anytypeio.anytype.test_utils.MockDataFactory
 import kotlin.test.assertEquals
@@ -22,6 +25,7 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
 
 class ObjectWrapperExtensionsKtTest {
@@ -226,6 +230,80 @@ class ObjectWrapperExtensionsKtTest {
         assertNull(result.layout)
         assertNull(resultType.layout)
     }
+
+    // region DROID-4545 — Gallery/List single-value Status/Tag must resolve the option, not the host
+
+    @Test
+    fun `statuses resolves a single-Id value to the option and not the host object`() = runTest {
+        val statusKey = "status"
+        val optionId = "opt-in-progress"
+        val hostId = "host-1"
+
+        val option = ObjectWrapper.Basic(
+            mapOf(
+                Relations.ID to optionId,
+                Relations.NAME to "In progress",
+                Relations.RELATION_OPTION_COLOR to "red"
+            )
+        )
+        val host = ObjectWrapper.Basic(
+            mapOf(
+                Relations.ID to hostId,
+                Relations.NAME to "Ao Ashi",
+                statusKey to optionId // single Id, NOT a list
+            )
+        )
+
+        val store = mock<ObjectStore>()
+        store.stub {
+            onBlocking { get(optionId) } doReturn option
+            onBlocking { get(hostId) } doReturn host
+        }
+
+        val result = host.statuses(relation = statusKey, storeOfObjects = store)
+
+        assertEquals(1, result.size)
+        assertEquals(optionId, result.first().id)
+        assertEquals("In progress", result.first().status)
+        assertEquals("red", result.first().color)
+    }
+
+    @Test
+    fun `tags resolves a single-Id value to the option and not the host object`() = runTest {
+        val tagKey = "tag"
+        val optionId = "opt-drama"
+        val hostId = "host-2"
+
+        val option = ObjectWrapper.Basic(
+            mapOf(
+                Relations.ID to optionId,
+                Relations.NAME to "Drama",
+                Relations.RELATION_OPTION_COLOR to "blue"
+            )
+        )
+        val host = ObjectWrapper.Basic(
+            mapOf(
+                Relations.ID to hostId,
+                Relations.NAME to "Firefly Wedding",
+                tagKey to optionId // single Id, NOT a list
+            )
+        )
+
+        val store = mock<ObjectStore>()
+        store.stub {
+            onBlocking { get(optionId) } doReturn option
+            onBlocking { get(hostId) } doReturn host
+        }
+
+        val result = host.tags(relation = tagKey, storeOfObjects = store)
+
+        assertEquals(1, result.size)
+        assertEquals(optionId, result.first().id)
+        assertEquals("Drama", result.first().tag)
+        assertEquals("blue", result.first().color)
+    }
+
+    // endregion
 
     fun stubUrlBuilder(targetObjectId: String) {
         urlBuilder.stub {

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/mapper/ObjectWrapperExtensionsKtTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/mapper/ObjectWrapperExtensionsKtTest.kt
@@ -13,6 +13,7 @@ import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
 import com.anytypeio.anytype.domain.primitives.FieldParser
 import com.anytypeio.anytype.domain.primitives.FieldParserImpl
 import com.anytypeio.anytype.domain.resources.StringResourceProvider
+import com.anytypeio.anytype.presentation.objects.files
 import com.anytypeio.anytype.presentation.objects.statuses
 import com.anytypeio.anytype.presentation.objects.tags
 import com.anytypeio.anytype.presentation.objects.toViews
@@ -301,6 +302,43 @@ class ObjectWrapperExtensionsKtTest {
         assertEquals(optionId, result.first().id)
         assertEquals("Drama", result.first().tag)
         assertEquals("blue", result.first().color)
+    }
+
+    @Test
+    fun `files resolves a single-Id value to the file object and not the host object`() = runTest {
+        val fileKey = "attachment"
+        val fileId = "file-1"
+        val hostId = "host-3"
+
+        val file = ObjectWrapper.Basic(
+            mapOf(
+                Relations.ID to fileId,
+                Relations.NAME to "cover",
+                Relations.FILE_MIME_TYPE to "image/png",
+                Relations.FILE_EXT to "png"
+            )
+        )
+        val host = ObjectWrapper.Basic(
+            mapOf(
+                Relations.ID to hostId,
+                Relations.NAME to "Behind the Supermarket",
+                fileKey to fileId // single Id, NOT a list
+            )
+        )
+
+        val store = mock<ObjectStore>()
+        store.stub {
+            onBlocking { get(fileId) } doReturn file
+            onBlocking { get(hostId) } doReturn host
+        }
+
+        val result = host.files(relation = fileKey, storeOfObjects = store)
+
+        assertEquals(1, result.size)
+        assertEquals(fileId, result.first().id)
+        assertEquals("cover", result.first().name)
+        assertEquals("image/png", result.first().mime)
+        assertEquals("png", result.first().ext)
     }
 
     // endregion

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/main/ObjectSetTypeSetTagOptionsTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/main/ObjectSetTypeSetTagOptionsTest.kt
@@ -364,6 +364,113 @@ class ObjectSetTypeSetTagOptionsTest : ObjectSetViewModelTestSetup() {
             )
         }
 
+    @Test
+    fun `collection should merge status relation options into the store via a dedicated subscription`() =
+        runTest {
+            // SETUP — a Collection (DROID-4545). A Status property is visible and lives in the
+            // data view's relationLinks, but its option object is NOT delivered as a record
+            // subscription dependency, so the Status cell would render empty ("takes up space"
+            // but blank) without the dedicated options subscription. The store-merge under test
+            // is viewer-agnostic (it feeds Grid, Gallery and List alike), so we assert it on the
+            // default Grid viewer like the sibling Set/TypeSet cases.
+            val statusRelation = StubRelationObject(
+                key = "status-${RandomString.make()}",
+                isReadOnlyValue = false,
+                format = Relation.Format.STATUS
+            )
+            val statusRelationLink = StubRelationLink(statusRelation.key, Relation.Format.STATUS)
+            val statusOption = StubRelationOptionObject(
+                id = "opt-${RandomString.make()}",
+                space = defaultSpace,
+                text = "In progress",
+                color = "red"
+            )
+
+            val title = StubTitle(id = "title-${RandomString.make()}")
+            val header = StubHeader(id = "header-${RandomString.make()}", children = listOf(title.id))
+
+            val viewer = StubDataViewView(
+                id = "viewer-${RandomString.make()}",
+                viewerRelations = listOf(
+                    StubDataViewViewRelation(key = nameRelation.key, isVisible = true),
+                    StubDataViewViewRelation(key = statusRelation.key, isVisible = true)
+                )
+            )
+
+            val dataView = StubDataView(
+                id = "dv-${RandomString.make()}",
+                views = listOf(viewer),
+                relationLinks = listOf(nameRelationLink, createdDateRelationLink, statusRelationLink),
+                isCollection = true
+            )
+
+            val details = ObjectViewDetails(
+                details = mapOf(
+                    root to mapOf(
+                        Relations.ID to root,
+                        Relations.SPACE_ID to defaultSpace,
+                        Relations.LAYOUT to ObjectType.Layout.COLLECTION.code.toDouble()
+                    )
+                )
+            )
+
+            storeOfRelations.merge(listOf(statusRelation, nameRelation, createdDateRelation))
+
+            val record = ObjectWrapper.Basic(
+                mapOf(
+                    Relations.ID to "record-${RandomString.make()}",
+                    Relations.SPACE_ID to defaultSpace,
+                    statusRelation.key to listOf(statusOption.id)
+                )
+            )
+
+            stubSpaceManager(defaultSpace)
+            stubInterceptEvents()
+            stubInterceptThreadStatus()
+            stubOpenObject(doc = listOf(header, title, dataView), details = details)
+            // Collection subscription (collection = ctx, no sources); the option is NOT a dependency.
+            stubSubscriptionResults(
+                subscription = subscriptionId,
+                spaceId = defaultSpace,
+                collection = root,
+                objects = listOf(record),
+                dependencies = emptyList(),
+                keys = listOf(statusRelation.key),
+                sources = emptyList(),
+                dvSorts = listOf(
+                    DVSort(
+                        relationKey = Relations.CREATED_DATE,
+                        type = Block.Content.DataView.Sort.Type.DESC,
+                        relationFormat = RelationFormat.DATE,
+                        includeTime = true
+                    )
+                ),
+                dvRelationLinks = listOf(nameRelationLink, createdDateRelationLink, statusRelationLink)
+            )
+            stubTemplatesForTemplatesContainer()
+            stubSetDataViewProperties()
+
+            // The dedicated options subscription returns the status option.
+            storelessSubscriptionContainer.stub {
+                on {
+                    subscribe(argThat<StoreSearchParams> { subscription == optionsSubscriptionId })
+                } doReturn flowOf(listOf(ObjectWrapper.Basic(statusOption.map)))
+            }
+
+            viewModel = givenViewModel()
+
+            // TESTING
+            viewModel.onStart()
+            advanceUntilIdle()
+
+            // VERIFY — the option object reaches the shared store so a Collection's Status cell
+            // can resolve the chip's name + color. Fails if the options merge is skipped for Collections.
+            val stored = objectStore.get(statusOption.id)
+            assertNotNull(stored, "Status option should be present in the object store for a Collection")
+            assertEquals("In progress", stored.name)
+            assertEquals("red", ObjectWrapper.Option(stored.map).color)
+        }
+
     private fun stubSetDataViewProperties() {
         setDataViewProperties.stub {
             onBlocking { async(any()) }.thenReturn(Resultat.success(Payload("", emptyList())))


### PR DESCRIPTION
## Problem

Reported on Android: **collections filtered by a specific property no longer appear** since the latest update, and the **Status property doesn't render** on cards.

Investigation split this into two independent root causes (plus one already fixed by DROID-4542, verified here with a new regression test).

### 1. Filtered collection appears empty — `transformFilterWithFormat`
`transformFilterWithFormat` (`ObjectSetExtension.kt`) re-stamped `relationFormat` only for `DATE`/`OBJECT`. `STATUS`/`TAG` filters fell through unchanged, so a filter that loaded with an unset format (default `longtext`) was serialized to middleware as `longtext` → the option-id was text-matched → **zero results**. This was latent and got exposed as a regression by the MW 0.50.12 bump.

Fix: stamp `STATUS`/`TAG` filters with their real format. No condition normalization needed — SELECT conditions are `In/AllIn/NotIn/Empty/NotEmpty`, never `Equal`.

### 2. Gallery/List single-value Status/Tag used the wrong id — `ObjectWrapperExtensions.kt`
`statuses()`/`tags()`/`files()` did `is Id -> listOf(id)` — the record object's own id instead of the relation value. The grid path (`SetsExtension.kt`) correctly uses the value. This corrupted single-string values authored on Desktop/iOS (Android writes a list, so the buggy branch was dead for Android-written values).

Fix: `is Id -> listOf(value)`, matching the grid path.

### 3. Status cell empty ("takes up space") — already fixed by DROID-4542
Relation option objects not merged into the data-view store. `subscribeToDataViewRelationOptions()` (already merged) runs unconditionally for Collections. Guarded here with a new Collection regression test (the suite previously covered Set/TypeSet only).

## Tests
- `FilterSubscriptionSupportTest` — STATUS/TAG filter format stamping (flat + nested).
- `ObjectWrapperExtensionsKtTest` — single-Id Status/Tag resolves the option, not the host object.
- `ObjectSetTypeSetTagOptionsTest` — Collection merges Status options into the store.

Full `:presentation:testDebugUnitTest` passes. Manually verified on device (Nothing Phone): filtered collections show items, Status chips render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)