### PR TITLE
DROID-4548 Report networkId on network changes; fix default-network callback contract

### DIFF
--- a/data/src/main/java/com/anytypeio/anytype/data/auth/repo/block/BlockDataRepository.kt
+++ b/data/src/main/java/com/anytypeio/anytype/data/auth/repo/block/BlockDataRepository.kt
@@ -1254,8 +1254,8 @@ class BlockDataRepository(
         return remote.objectDateByTimestamp(command)
     }
 
-    override suspend fun setDeviceNetworkState(type: DeviceNetworkType) {
-        remote.setDeviceNetworkState(type)
+    override suspend fun setDeviceNetworkState(type: DeviceNetworkType, networkId: String) {
+        remote.setDeviceNetworkState(type, networkId)
     }
 
     override suspend fun setAppState(state: AppState) {

--- a/data/src/main/java/com/anytypeio/anytype/data/auth/repo/block/BlockRemote.kt
+++ b/data/src/main/java/com/anytypeio/anytype/data/auth/repo/block/BlockRemote.kt
@@ -529,7 +529,7 @@ interface BlockRemote {
 
     suspend fun debugAccountSelectTrace(dir: String): String
 
-    suspend fun setDeviceNetworkState(type: DeviceNetworkType)
+    suspend fun setDeviceNetworkState(type: DeviceNetworkType, networkId: String)
     suspend fun setAppState(state: AppState)
 
     suspend fun objectTypeListConflictingRelations(command: ObjectTypeConflictingFields): List<Id>

--- a/device/src/main/java/com/anytypeio/anytype/device/network_type/NetworkConnectionStatus.kt
+++ b/device/src/main/java/com/anytypeio/anytype/device/network_type/NetworkConnectionStatus.kt
@@ -9,8 +9,9 @@ import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
 import com.anytypeio.anytype.domain.block.repo.BlockRepository
 import com.anytypeio.anytype.domain.device.NetworkConnectionStatus
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 class NetworkConnectionStatusImpl(
@@ -20,96 +21,138 @@ class NetworkConnectionStatusImpl(
     private val dispatchers: AppCoroutineDispatchers
 ) : NetworkConnectionStatus {
 
+    private data class Report(val type: DeviceNetworkType, val networkId: String)
+
     private val connectivityManager =
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+
+    // Reports must reach the middleware in the order the OS produced them: heart
+    // coalesces bursts into one trailing run where the last value wins, so a stale
+    // report overtaking a newer one would wedge its view of connectivity. The
+    // channel lives for the object's lifetime and is never closed, so start/stop
+    // can cycle across login/logout.
+    private val reports = Channel<Report>(Channel.UNLIMITED)
+    private var consumer: Job? = null
+
+    @Volatile
     private var isMonitoring = false
 
+    @Volatile
     private var currentNetworkType: DeviceNetworkType = DeviceNetworkType.NOT_CONNECTED
 
     private val networkCallback = object : ConnectivityManager.NetworkCallback() {
-        override fun onAvailable(network: Network) {
-            // Called when the network is available
-            updateNetworkState(networkCapabilities = getNetworkCapabilities())
-        }
-
-        override fun onLost(network: Network) {
-            // Called when the network is disconnected
-            updateNetworkState(networkCapabilities = getNetworkCapabilities())
-        }
 
         override fun onCapabilitiesChanged(
             network: Network,
             networkCapabilities: NetworkCapabilities
         ) {
-            // Called when the network capabilities (like Wi-Fi vs Cellular) change
-            updateNetworkState(networkCapabilities)
+            // networkHandle is stable per network instance and changes on every
+            // reconnect -- exactly the identity semantics networkId wants.
+            report(mapNetworkType(networkCapabilities), network.networkHandle.toString())
+        }
+
+        // On a default-network callback onLost means "lost default status", not
+        // "disconnected": it fires on every Wi-Fi<->cellular handoff. Report the
+        // network that is default now; only a genuinely absent default yields
+        // NOT_CONNECTED, which heart treats as fully offline and throttles.
+        override fun onLost(network: Network) {
+            reportCurrent()
+        }
+
+        // Never delivered for registerDefaultNetworkCallback (the platform only
+        // calls it for requestNetwork with a timeout). Kept so a change of
+        // registration style cannot silently lose offline reports.
+        override fun onUnavailable() {
+            report(DeviceNetworkType.NOT_CONNECTED, "")
         }
     }
 
     override fun start() {
-        if (!isMonitoring) {
-            try {
-                connectivityManager?.registerDefaultNetworkCallback(networkCallback)
-                isMonitoring = true
-                updateNetworkState(networkCapabilities = getNetworkCapabilities())
-            } catch (
-                e: RuntimeException
-            ) {
-                Timber.w(e, "Failed to register network callback")
-                isMonitoring = false
-            }
+        if (isMonitoring) return
+        // Discard anything a late callback pushed after the previous session's
+        // stop() -- a stale value must not become heart's baseline for this one.
+        while (reports.tryReceive().isSuccess) {
+            // drop
         }
-    }
-
-    override fun stop() {
-        if (isMonitoring) {
-            try {
-                connectivityManager?.unregisterNetworkCallback(networkCallback)
-                isMonitoring = false
-            } catch (e: Throwable) {
-                Timber.w(e, "Failed to unregister network callback")
-                isMonitoring = false
-            }
-        }
-    }
-
-    private fun updateNetworkState(networkCapabilities: NetworkCapabilities?) {
-        coroutineScope.launch {
-            val networkType = mapNetworkType(networkCapabilities)
-            currentNetworkType = networkType
-            withContext(dispatchers.io) {
+        consumer = coroutineScope.launch(dispatchers.io) {
+            for (report in reports) {
                 try {
-                    blockRepository.setDeviceNetworkState(networkType)
-                } catch (
-                    e: Throwable
-                ) {
+                    blockRepository.setDeviceNetworkState(report.type, report.networkId)
+                } catch (e: Throwable) {
+                    // Per-report: a throw escaping the loop would silently disable
+                    // network reporting for the rest of the session.
                     Timber.w(e, "Failed to update network state")
                 }
             }
         }
+        try {
+            connectivityManager?.registerDefaultNetworkCallback(networkCallback)
+            isMonitoring = true
+        } catch (e: RuntimeException) {
+            Timber.w(e, "Failed to register network callback")
+            consumer?.cancel()
+            consumer = null
+            return
+        }
+        // No callback fires when there is no default network at launch, so prime
+        // heart's baseline explicitly; with a default up this is a cheap duplicate
+        // of the onCapabilitiesChanged that follows registration.
+        reportCurrent()
     }
 
-    private fun getNetworkCapabilities(): NetworkCapabilities? {
+    override fun stop() {
+        if (!isMonitoring) return
         try {
-            return connectivityManager?.getNetworkCapabilities(connectivityManager.activeNetwork)
+            connectivityManager?.unregisterNetworkCallback(networkCallback)
         } catch (e: Throwable) {
-            Timber.w(e, "Failed to get network capabilities")
-            return null
+            Timber.w(e, "Failed to unregister network callback")
+        } finally {
+            isMonitoring = false
+            consumer?.cancel()
+            consumer = null
         }
     }
 
+    override fun getCurrentNetworkType(): DeviceNetworkType =
+        if (isMonitoring) currentNetworkType
+        else mapNetworkType(activeNetworkAndCaps()?.second)
+
+    private fun report(type: DeviceNetworkType, networkId: String) {
+        currentNetworkType = type
+        // trySend on an UNLIMITED channel never suspends nor fails-on-full, so
+        // ConnectivityManager's callback thread is never blocked.
+        reports.trySend(Report(type, networkId))
+    }
+
+    private fun reportCurrent() {
+        val (network, caps) = activeNetworkAndCaps()
+            ?: return report(DeviceNetworkType.NOT_CONNECTED, "")
+        report(mapNetworkType(caps), network.networkHandle.toString())
+    }
+
+    /** The default network and its capabilities, or null if there is no usable default. */
+    private fun activeNetworkAndCaps(): Pair<Network, NetworkCapabilities>? {
+        val manager = connectivityManager ?: return null
+        val network = manager.activeNetwork ?: return null
+        val caps = try {
+            manager.getNetworkCapabilities(network)
+        } catch (e: Throwable) {
+            Timber.w(e, "Failed to get network capabilities")
+            null
+        } ?: return null
+        return network to caps
+    }
+
+    // Transport only. Deliberately NOT gated on NET_CAPABILITY_VALIDATED:
+    // validation gates internet, but a LAN-only network (or a captive portal)
+    // still syncs over local P2P, and heart throttles NOT_CONNECTED devices.
+    // See anytype-heart 8a2fa9d91 / docs/mobile-network-integration.md.
     private fun mapNetworkType(networkCapabilities: NetworkCapabilities?): DeviceNetworkType =
         when {
             networkCapabilities == null -> DeviceNetworkType.NOT_CONNECTED
-            networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> DeviceNetworkType.WIFI
-            networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> DeviceNetworkType.CELLULAR
-            else -> DeviceNetworkType.NOT_CONNECTED
+            networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) ->
+                DeviceNetworkType.CELLULAR
+            // wifi / ethernet / vpn / tethering, incl. LAN-only without internet
+            else -> DeviceNetworkType.WIFI
         }
-
-    override fun getCurrentNetworkType(): DeviceNetworkType {
-        if (!isMonitoring) {
-            return mapNetworkType(getNetworkCapabilities())
-        }
-        return currentNetworkType
-    }
 }

--- a/device/src/main/java/com/anytypeio/anytype/device/network_type/NetworkConnectionStatus.kt
+++ b/device/src/main/java/com/anytypeio/anytype/device/network_type/NetworkConnectionStatus.kt
@@ -74,7 +74,20 @@ class NetworkConnectionStatusImpl(
         while (reports.tryReceive().isSuccess) {
             // drop
         }
+        try {
+            connectivityManager?.registerDefaultNetworkCallback(networkCallback)
+            isMonitoring = true
+        } catch (e: RuntimeException) {
+            Timber.w(e, "Failed to register network callback")
+            return
+        }
+        val previous = consumer
         consumer = coroutineScope.launch(dispatchers.io) {
+            // Cancellation is cooperative and the RPC below is a blocking JNI call
+            // with no suspension points: a consumer stopped mid-call keeps running
+            // until the call returns. Wait it out so its report cannot complete
+            // after (and thereby override) this session's.
+            previous?.join()
             for (report in reports) {
                 try {
                     blockRepository.setDeviceNetworkState(report.type, report.networkId)
@@ -84,15 +97,6 @@ class NetworkConnectionStatusImpl(
                     Timber.w(e, "Failed to update network state")
                 }
             }
-        }
-        try {
-            connectivityManager?.registerDefaultNetworkCallback(networkCallback)
-            isMonitoring = true
-        } catch (e: RuntimeException) {
-            Timber.w(e, "Failed to register network callback")
-            consumer?.cancel()
-            consumer = null
-            return
         }
         // No callback fires when there is no default network at launch, so prime
         // heart's baseline explicitly; with a default up this is a cheap duplicate
@@ -108,8 +112,10 @@ class NetworkConnectionStatusImpl(
             Timber.w(e, "Failed to unregister network callback")
         } finally {
             isMonitoring = false
+            // Cancel but keep the reference: the next start()'s consumer joins it,
+            // so an RPC in flight right now cannot complete after -- and thereby
+            // override -- the next session's reports.
             consumer?.cancel()
-            consumer = null
         }
     }
 

--- a/device/src/test/java/com/anytypeio/anytype/device/network_type/NetworkConnectionStatusImplTest.kt
+++ b/device/src/test/java/com/anytypeio/anytype/device/network_type/NetworkConnectionStatusImplTest.kt
@@ -1,0 +1,387 @@
+package com.anytypeio.anytype.device.network_type
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import androidx.test.core.app.ApplicationProvider
+import com.anytypeio.anytype.core_models.DeviceNetworkType
+import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
+import com.anytypeio.anytype.domain.block.repo.BlockRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowNetwork
+import org.robolectric.shadows.ShadowNetworkCapabilities
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class NetworkConnectionStatusImplTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private lateinit var scope: CoroutineScope
+    private lateinit var repo: BlockRepository
+    private lateinit var connectivityManager: ConnectivityManager
+    private lateinit var subject: NetworkConnectionStatusImpl
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        connectivityManager =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        repo = mock()
+        scope = CoroutineScope(SupervisorJob() + dispatcher)
+        subject = NetworkConnectionStatusImpl(
+            context = context,
+            coroutineScope = scope,
+            blockRepository = repo,
+            dispatchers = AppCoroutineDispatchers(
+                io = dispatcher,
+                computation = dispatcher,
+                main = dispatcher
+            )
+        )
+    }
+
+    @After
+    fun tearDown() {
+        subject.stop()
+        scope.cancel()
+    }
+
+    // region helpers
+
+    private fun caps(vararg transports: Int): NetworkCapabilities {
+        val caps = ShadowNetworkCapabilities.newInstance()
+        transports.forEach { shadowOf(caps).addTransportType(it) }
+        return caps
+    }
+
+    private fun network(netId: Int): Network = ShadowNetwork.newInstance(netId)
+
+    private fun disconnectDefaultNetwork() {
+        shadowOf(connectivityManager).setDefaultNetworkActive(false)
+    }
+
+    /** The single callback registered by the subject. */
+    private fun registeredCallback(): ConnectivityManager.NetworkCallback =
+        shadowOf(connectivityManager).networkCallbacks.single()
+
+    private fun startDisconnected(): ConnectivityManager.NetworkCallback {
+        disconnectDefaultNetwork()
+        subject.start()
+        return registeredCallback()
+    }
+
+    // endregion
+
+    @Test
+    fun `wifi capabilities report WIFI with the network handle as id`() =
+        runTest(dispatcher.scheduler) {
+            val callback = startDisconnected()
+            val net = network(101)
+
+            callback.onCapabilitiesChanged(net, caps(NetworkCapabilities.TRANSPORT_WIFI))
+            advanceUntilIdle()
+
+            verify(repo).setDeviceNetworkState(
+                DeviceNetworkType.WIFI,
+                net.networkHandle.toString()
+            )
+        }
+
+    @Test
+    fun `cellular capabilities report CELLULAR with the network handle as id`() =
+        runTest(dispatcher.scheduler) {
+            val callback = startDisconnected()
+            val net = network(102)
+
+            callback.onCapabilitiesChanged(net, caps(NetworkCapabilities.TRANSPORT_CELLULAR))
+            advanceUntilIdle()
+
+            verify(repo).setDeviceNetworkState(
+                DeviceNetworkType.CELLULAR,
+                net.networkHandle.toString()
+            )
+        }
+
+    @Test
+    fun `ethernet reports WIFI not NOT_CONNECTED`() = runTest(dispatcher.scheduler) {
+        val callback = startDisconnected()
+        val net = network(103)
+
+        callback.onCapabilitiesChanged(net, caps(NetworkCapabilities.TRANSPORT_ETHERNET))
+        advanceUntilIdle()
+
+        verify(repo).setDeviceNetworkState(
+            DeviceNetworkType.WIFI,
+            net.networkHandle.toString()
+        )
+    }
+
+    @Test
+    fun `vpn over cellular reports CELLULAR`() = runTest(dispatcher.scheduler) {
+        val callback = startDisconnected()
+        val net = network(104)
+
+        callback.onCapabilitiesChanged(
+            net,
+            caps(NetworkCapabilities.TRANSPORT_VPN, NetworkCapabilities.TRANSPORT_CELLULAR)
+        )
+        advanceUntilIdle()
+
+        verify(repo).setDeviceNetworkState(
+            DeviceNetworkType.CELLULAR,
+            net.networkHandle.toString()
+        )
+    }
+
+    @Test
+    fun `wifi without VALIDATED capability still reports WIFI`() =
+        runTest(dispatcher.scheduler) {
+            // Regression guard for the DROID-4548 contract reversal: a LAN-only or
+            // captive-portal Wi-Fi (no NET_CAPABILITY_VALIDATED) must NOT report
+            // NOT_CONNECTED -- heart throttles offline devices, and local P2P sync
+            // still works on such networks. See anytype-heart 8a2fa9d91.
+            val callback = startDisconnected()
+            val net = network(105)
+            val lanOnlyWifi = caps(NetworkCapabilities.TRANSPORT_WIFI)
+            assertFalse(
+                lanOnlyWifi.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+            )
+
+            callback.onCapabilitiesChanged(net, lanOnlyWifi)
+            advanceUntilIdle()
+
+            verify(repo).setDeviceNetworkState(
+                DeviceNetworkType.WIFI,
+                net.networkHandle.toString()
+            )
+        }
+
+    @Test
+    fun `onLost with a replacement default up reports its type instead of NOT_CONNECTED`() =
+        runTest(dispatcher.scheduler) {
+            // A default-network callback delivers onLost on every handoff (the old
+            // default lost *default status*), not only on true disconnection. When a
+            // replacement is already up, reporting NOT_CONNECTED would flip heart's
+            // undebounced IsOffline and churn mDNS for nothing.
+            val callback = startDisconnected()
+            advanceUntilIdle()
+            clearInvocations(repo)
+
+            val replacement = shadowOf(connectivityManager).run {
+                setDefaultNetworkActive(true)
+                connectivityManager.activeNetwork!!.also {
+                    setNetworkCapabilities(it, caps(NetworkCapabilities.TRANSPORT_CELLULAR))
+                }
+            }
+
+            callback.onLost(network(106))
+            advanceUntilIdle()
+
+            verify(repo).setDeviceNetworkState(
+                DeviceNetworkType.CELLULAR,
+                replacement.networkHandle.toString()
+            )
+            verify(repo, never()).setDeviceNetworkState(DeviceNetworkType.NOT_CONNECTED, "")
+        }
+
+    @Test
+    fun `onLost with no default network reports NOT_CONNECTED with empty id`() =
+        runTest(dispatcher.scheduler) {
+            val callback = startDisconnected()
+            advanceUntilIdle()
+            clearInvocations(repo)
+
+            callback.onLost(network(107))
+            advanceUntilIdle()
+
+            verify(repo).setDeviceNetworkState(DeviceNetworkType.NOT_CONNECTED, "")
+        }
+
+    @Test
+    fun `onUnavailable reports NOT_CONNECTED with empty id`() =
+        runTest(dispatcher.scheduler) {
+            val callback = startDisconnected()
+            advanceUntilIdle()
+            clearInvocations(repo)
+
+            callback.onUnavailable()
+            advanceUntilIdle()
+
+            verify(repo).setDeviceNetworkState(DeviceNetworkType.NOT_CONNECTED, "")
+        }
+
+    @Test
+    fun `identical consecutive reports are both sent -- no client-side debounce`() =
+        runTest(dispatcher.scheduler) {
+            // Heart dedupes and coalesces server-side; the contract explicitly
+            // forbids client-side debounce.
+            val callback = startDisconnected()
+            val net = network(108)
+            val wifi = caps(NetworkCapabilities.TRANSPORT_WIFI)
+
+            callback.onCapabilitiesChanged(net, wifi)
+            callback.onCapabilitiesChanged(net, wifi)
+            advanceUntilIdle()
+
+            verify(repo, times(2)).setDeviceNetworkState(
+                DeviceNetworkType.WIFI,
+                net.networkHandle.toString()
+            )
+        }
+
+    @Test
+    fun `a burst of reports is delivered in callback order`() =
+        runTest(dispatcher.scheduler) {
+            val callback = startDisconnected()
+            advanceUntilIdle()
+            val wifiNet = network(109)
+            val cellNet = network(110)
+
+            callback.onCapabilitiesChanged(wifiNet, caps(NetworkCapabilities.TRANSPORT_WIFI))
+            callback.onCapabilitiesChanged(cellNet, caps(NetworkCapabilities.TRANSPORT_CELLULAR))
+            callback.onLost(cellNet)
+            advanceUntilIdle()
+
+            inOrder(repo) {
+                verify(repo).setDeviceNetworkState(
+                    DeviceNetworkType.WIFI, wifiNet.networkHandle.toString()
+                )
+                verify(repo).setDeviceNetworkState(
+                    DeviceNetworkType.CELLULAR, cellNet.networkHandle.toString()
+                )
+                verify(repo).setDeviceNetworkState(DeviceNetworkType.NOT_CONNECTED, "")
+            }
+        }
+
+    @Test
+    fun `a failing RPC does not kill the consumer -- the next report is still delivered`() =
+        runTest(dispatcher.scheduler) {
+            repo.stub {
+                onBlocking { setDeviceNetworkState(any(), any()) }
+                    .doThrow(IllegalStateException("middleware not ready"))
+                    .doReturn(Unit)
+            }
+            val callback = startDisconnected() // baseline NOT_CONNECTED -> throws
+            advanceUntilIdle()
+
+            val net = network(111)
+            callback.onCapabilitiesChanged(net, caps(NetworkCapabilities.TRANSPORT_WIFI))
+            advanceUntilIdle()
+
+            verify(repo).setDeviceNetworkState(
+                DeviceNetworkType.WIFI,
+                net.networkHandle.toString()
+            )
+        }
+
+    @Test
+    fun `start with no default network reports a NOT_CONNECTED baseline`() =
+        runTest(dispatcher.scheduler) {
+            // No callback fires when there is no default network at launch, so
+            // start() must prime heart's baseline explicitly.
+            disconnectDefaultNetwork()
+            subject.start()
+            advanceUntilIdle()
+
+            verify(repo).setDeviceNetworkState(DeviceNetworkType.NOT_CONNECTED, "")
+        }
+
+    @Test
+    fun `stop unregisters and a following start registers and delivers again`() =
+        runTest(dispatcher.scheduler) {
+            val callback = startDisconnected()
+            advanceUntilIdle()
+            subject.stop()
+            assertFalse(shadowOf(connectivityManager).networkCallbacks.contains(callback))
+            clearInvocations(repo)
+
+            subject.start()
+            val second = registeredCallback()
+            val net = network(112)
+            second.onCapabilitiesChanged(net, caps(NetworkCapabilities.TRANSPORT_CELLULAR))
+            advanceUntilIdle()
+
+            verify(repo).setDeviceNetworkState(
+                DeviceNetworkType.CELLULAR,
+                net.networkHandle.toString()
+            )
+        }
+
+    @Test
+    fun `a report landing after stop is dropped -- not replayed into the next session`() =
+        runTest(dispatcher.scheduler) {
+            // ConnectivityManager delivers callbacks asynchronously: one can land
+            // after stop(). It must not become heart's baseline for the next login.
+            val callback = startDisconnected()
+            advanceUntilIdle()
+            subject.stop()
+            clearInvocations(repo)
+
+            val stale = network(113)
+            callback.onCapabilitiesChanged(stale, caps(NetworkCapabilities.TRANSPORT_WIFI))
+
+            disconnectDefaultNetwork()
+            subject.start()
+            advanceUntilIdle()
+
+            verify(repo, never()).setDeviceNetworkState(
+                DeviceNetworkType.WIFI,
+                stale.networkHandle.toString()
+            )
+            verify(repo).setDeviceNetworkState(DeviceNetworkType.NOT_CONNECTED, "")
+        }
+
+    @Test
+    fun `getCurrentNetworkType reflects the last callback synchronously`() =
+        runTest(dispatcher.scheduler) {
+            val callback = startDisconnected()
+
+            callback.onCapabilitiesChanged(
+                network(114),
+                caps(NetworkCapabilities.TRANSPORT_CELLULAR)
+            )
+            // Deliberately no advanceUntilIdle: the type must be visible before the
+            // RPC coroutine runs.
+            assertEquals(DeviceNetworkType.CELLULAR, subject.getCurrentNetworkType())
+        }
+
+    @Test
+    fun `getCurrentNetworkType queries on demand when not monitoring`() {
+        disconnectDefaultNetwork()
+        assertEquals(DeviceNetworkType.NOT_CONNECTED, subject.getCurrentNetworkType())
+    }
+
+    @Test
+    fun `start registers exactly one default network callback`() {
+        disconnectDefaultNetwork()
+        subject.start()
+        subject.start() // idempotent
+        assertTrue(shadowOf(connectivityManager).networkCallbacks.size == 1)
+    }
+}

--- a/device/src/test/java/com/anytypeio/anytype/device/network_type/NetworkConnectionStatusImplTest.kt
+++ b/device/src/test/java/com/anytypeio/anytype/device/network_type/NetworkConnectionStatusImplTest.kt
@@ -8,9 +8,12 @@ import androidx.test.core.app.ApplicationProvider
 import com.anytypeio.anytype.core_models.DeviceNetworkType
 import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
 import com.anytypeio.anytype.domain.block.repo.BlockRepository
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -24,6 +27,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
@@ -358,6 +362,44 @@ class NetworkConnectionStatusImplTest {
         }
 
     @Test
+    fun `an in-flight RPC from a stopped session completes before the next session's reports`() =
+        runTest(dispatcher.scheduler) {
+            // Cancellation is cooperative and the real RPC is a blocking JNI call
+            // with no suspension points: a consumer stopped mid-call keeps running
+            // until the call returns. Its stale report must not complete after the
+            // next session's baseline -- heart trusts the last value it hears.
+            val gate = CompletableDeferred<Unit>()
+            val completions = mutableListOf<DeviceNetworkType>()
+            repo.stub {
+                onBlocking { setDeviceNetworkState(any(), any()) } doSuspendableAnswer { invocation ->
+                    val type = invocation.getArgument<DeviceNetworkType>(0)
+                    if (type == DeviceNetworkType.WIFI) {
+                        // Simulates the wedged JNI call: survives cancellation.
+                        withContext(NonCancellable) { gate.await() }
+                    }
+                    completions += type
+                    Unit
+                }
+            }
+
+            val callback = startDisconnected()
+            advanceUntilIdle() // baseline NOT_CONNECTED delivered
+            callback.onCapabilitiesChanged(network(120), caps(NetworkCapabilities.TRANSPORT_WIFI))
+            advanceUntilIdle() // consumer now wedged inside the WIFI RPC
+
+            subject.stop()
+            disconnectDefaultNetwork()
+            subject.start()
+            advanceUntilIdle() // next session's baseline queued (or wrongly delivered)
+
+            gate.complete(Unit) // the wedged call finally returns
+            advanceUntilIdle()
+
+            // The stale WIFI report must not be heart's final word for the new session.
+            assertEquals(DeviceNetworkType.NOT_CONNECTED, completions.last())
+        }
+
+    @Test
     fun `getCurrentNetworkType reflects the last callback synchronously`() =
         runTest(dispatcher.scheduler) {
             val callback = startDisconnected()
@@ -373,8 +415,13 @@ class NetworkConnectionStatusImplTest {
 
     @Test
     fun `getCurrentNetworkType queries on demand when not monitoring`() {
-        disconnectDefaultNetwork()
-        assertEquals(DeviceNetworkType.NOT_CONNECTED, subject.getCurrentNetworkType())
+        // WIFI differs from the field's initial NOT_CONNECTED, so this fails if
+        // the not-monitoring branch ever returns the stale cached value.
+        shadowOf(connectivityManager).setNetworkCapabilities(
+            connectivityManager.activeNetwork,
+            caps(NetworkCapabilities.TRANSPORT_WIFI)
+        )
+        assertEquals(DeviceNetworkType.WIFI, subject.getCurrentNetworkType())
     }
 
     @Test

--- a/docs/superpowers/specs/2026-07-16-droid-4548-network-state-design.md
+++ b/docs/superpowers/specs/2026-07-16-droid-4548-network-state-design.md
@@ -191,6 +191,9 @@ One `Channel<Report>(UNLIMITED)` lives for the object's lifetime, drained by a c
 ```kotlin
 override fun start() {
     if (isMonitoring) return
+    // Discard anything a late callback pushed after the previous session's
+    // stop() -- a stale value must not become heart's baseline for this one.
+    while (reports.tryReceive().isSuccess) { /* drop */ }
     consumer = coroutineScope.launch(dispatchers.io) {
         for (r in reports) {
             try {
@@ -220,10 +223,13 @@ override fun stop() {
     } finally {
         isMonitoring = false
         consumer?.cancel(); consumer = null
-        while (reports.tryReceive().isSuccess) { /* drop reports from the ended session */ }
     }
 }
 ```
+
+Both `isMonitoring` and `currentNetworkType` are `@Volatile`: written on the caller/callback threads, read by `getCurrentNetworkType()` from arbitrary threads. (The un-synchronized `isMonitoring` was a pre-existing hazard; this change touches the line anyway.)
+
+The stale-report drain lives at the top of `start()`, not in `stop()`: ConnectivityManager delivers callbacks asynchronously, so one can land *after* anything `stop()` does — draining on the next `start()` is the only placement that cannot be raced.
 
 Properties:
 - **FIFO is guaranteed** by the `Channel` contract, not inferred from a dispatcher's implementation.

--- a/docs/superpowers/specs/2026-07-16-droid-4548-network-state-design.md
+++ b/docs/superpowers/specs/2026-07-16-droid-4548-network-state-design.md
@@ -1,0 +1,299 @@
+# Report network changes (`networkId`) and correct the default-network callback contract
+
+- **Date:** 2026-07-16
+- **Status:** Proposed (pending approval)
+- **Scope:** `NetworkConnectionStatusImpl` + `networkId` plumbing (`commands.proto` → `BlockRepository` → `Middleware`)
+- **Type:** Contract compliance + latent-bug fix (sync recovery after network switches)
+- **Ticket:** DROID-4548 (Android side of GO-7379 / anytype-heart PR #3211)
+- **Heart contract:** `docs/mobile-network-integration.md` @ `go-7379-snappy-sync-connection-recovery`
+
+## 1. Background & problem
+
+Heart runs a connectivity-recovery pipeline (connection-pool flush → responsible-peer rebuild → immediate head-sync of all spaces) driven by `Rpc.Device.NetworkState.Set`. Correct signals make sync recover in ~1–2s after a network switch instead of riding a 30–40s transport timeout.
+
+The ticket asks for an audit against the contract, not just the new field. The audit was done; findings drive this design.
+
+### Audit results (verified against the current tree)
+
+| Contract item | Verdict |
+|---|---|
+| `NetworkState.Set` from a default-network callback on every capabilities change | **Partly.** `registerDefaultNetworkCallback` + `onCapabilitiesChanged` is correct, and there is no client-side debounce (contract-compliant). But `onUnavailable` is missing, and `onAvailable`/`onLost` discard the `Network` they are handed and re-query `activeNetwork`. |
+| `NOT_CONNECTED` reserved for true no-network; **not** derived from `VALIDATED` | **Compliant by accident.** `mapNetworkType` (`NetworkConnectionStatus.kt:101-107`) never checks `VALIDATED`. But its `else -> NOT_CONNECTED` fallback reports **Ethernet, VPN and Bluetooth-tethered networks as offline** — a real bug the ticket does not mention. |
+| `SetDeviceState(FOREGROUND/BACKGROUND)` sent promptly | **Compliant. No change.** `AppStateService` is a `DefaultLifecycleObserver` on `ProcessLifecycleOwner`, registered in `AndroidApplication.onCreate` with no gates, conditions, or debounce. |
+| Interface getter enumerates cellular | **Compliant. No change.** `DefaultInterfaceProvider` calls `NetworkInterface.getNetworkInterfaces()` with **zero filtering**, so `rmnet`/`ccmni` are enumerated alongside `wlan0`, re-read live on each Go pull (~5s). |
+| `networkId` (field 2) | **Missing everywhere.** Not in this repo's proto; not in heart `main`. Exists only on the unmerged `go-7379` branch. |
+
+Additionally: **zero tests** cover any of these three paths.
+
+### The `VALIDATED` reversal
+
+The ticket originally said "map missing `NET_CAPABILITY_VALIDATED` to `NOT_CONNECTED`". That instruction is **superseded**. Heart commit `8a2fa9d91` (2026-07-16 11:28) removed it from the guide:
+
+> reporting NOT_CONNECTED must not degrade local-only P2P sync (the same `manageResponsiblePeers` loop that re-dials nodes also refreshes LAN peers, so the 2min offline cadence delayed mDNS peer pickup) … validation gates internet, not LAN sync.
+
+The Linear description now carries a "Revised 2026-07-16" banner saying the same. Android's own documentation independently confirms the reasoning: *"A carrier's mobile network typically has the `INTERNET` capability, while a local P2P Wi-Fi network typically doesn't."* `VALIDATED` must not feed this RPC. It remains legitimate elsewhere (connectivity UI, upload policies) — see §8.
+
+## 2. Goals / non-goals
+
+### Goals
+- Send `networkId` so heart can detect same-type path changes (Wi-Fi→Wi-Fi, cellular PDP re-attach) instantly instead of falling back to its 5s interface poll.
+- Report type **by transport only**, per the revised contract.
+- Reserve `NOT_CONNECTED` for genuine no-default-network.
+- Preserve "no client-side debounce" — heart coalesces bursts.
+- Deliver reports to heart **in the order the OS produced them**.
+- Cover the callback contract with tests; the file currently has none.
+
+### Non-goals
+- `AppStateService` and the interface getter: audited compliant, untouched.
+- No use-case layer for this path, no un-commenting `Middleware` logging, no `SetAppState` retry — deliberate scope call (§8).
+- No client-side dedup/conflation. Heart dedupes (`!typeChanged && !idChanged → return`); duplicating that here would risk diverging from it.
+
+## 3. Design
+
+### 3.1 Proto (`protocol/src/main/proto/commands.proto:8924`)
+
+Add field 2, copied **verbatim** from heart `go-7379` (`pb/protos/commands.proto:8995-9000`), comments included, so the eventual `make update_mw` overwrite is a zero-diff no-op:
+
+```proto
+message Request {
+    anytype.model.DeviceNetworkType deviceNetworkType = 1;
+    // opaque identity of the current network path as reported by the OS
+    // (iOS: NWPath interfaces/gateway digest; Android: Network#getNetworkHandle()).
+    // When it changes while the type stays the same (Wi-Fi to Wi-Fi switch,
+    // cellular re-attach) the middleware still resets connections and re-syncs.
+    // Optional: empty means unknown, only type transitions are used then.
+    string networkId = 2;
+}
+```
+
+**Why hand-editing the proto is safe.** `scripts/mw/update-mw.sh` overwrites `protocol/src/main/proto/` wholesale from the heart release tarball, so this edit is temporary by construction — and idempotent, because the released proto will carry the identical field. `make update_mw_custom` documents manual proto edits as a supported workflow. On the wire, Wire 5.3.5 emits field 2 as a proto3 string; MW `v0.50.12` treats it as an unknown field and ignores it. This is what lets the change ship ahead of heart.
+
+### 3.2 Plumbing — second parameter through six signatures
+
+| File | Line | Change |
+|---|---|---|
+| `domain/…/block/repo/BlockRepository.kt` | 579 | `suspend fun setDeviceNetworkState(type: DeviceNetworkType, networkId: String)` |
+| `data/…/repo/block/BlockDataRepository.kt` | 1257 | pass through |
+| `data/…/repo/block/BlockRemote.kt` | 532 | signature |
+| `middleware/…/block/BlockMiddleware.kt` | 1234 | pass through |
+| `middleware/…/interactor/Middleware.kt` | 3320 | `Rpc.Device.NetworkState.Set.Request(deviceNetworkType = type.mw(), networkId = networkId)` |
+
+`MiddlewareService` / `MiddlewareServiceImplementation` are unchanged — they already take the built `Request`. `ToMiddlewareModelMappers.kt:685` (`DeviceNetworkType.mw()`) is unchanged; the enum is untouched.
+
+No default value on `networkId`. There is exactly one call site, and every caller should be forced to decide what identity it is reporting.
+
+### 3.3 `NetworkConnectionStatusImpl` (rewrite)
+
+```kotlin
+private data class Report(val type: DeviceNetworkType, val networkId: String)
+
+private val reports = Channel<Report>(Channel.UNLIMITED)
+private var consumer: Job? = null
+private var isMonitoring = false
+
+@Volatile
+private var currentNetworkType: DeviceNetworkType = DeviceNetworkType.NOT_CONNECTED
+
+private val networkCallback = object : ConnectivityManager.NetworkCallback() {
+    override fun onCapabilitiesChanged(network: Network, caps: NetworkCapabilities) {
+        report(mapNetworkType(caps), network.networkHandle.toString())
+    }
+
+    // onLost on a default-network callback means "lost default status", not
+    // "disconnected": it fires on every Wi-Fi<->cellular handoff. Report the
+    // network that is actually default now; only a genuinely absent default
+    // yields NOT_CONNECTED. See §3.4.
+    override fun onLost(network: Network) = reportCurrent()
+
+    // Never delivered for registerDefaultNetworkCallback (the platform only
+    // calls it for requestNetwork-with-timeout). Kept per the heart contract
+    // so registration style can change without silently losing offline reports.
+    override fun onUnavailable() = report(DeviceNetworkType.NOT_CONNECTED, "")
+}
+
+// Transport only. Deliberately NOT gated on NET_CAPABILITY_VALIDATED:
+// validation gates internet, but a LAN-only network (or a captive portal)
+// still syncs over local P2P, and heart throttles NOT_CONNECTED devices.
+// See anytype-heart 8a2fa9d91.
+private fun mapNetworkType(caps: NetworkCapabilities?): DeviceNetworkType = when {
+    caps == null -> DeviceNetworkType.NOT_CONNECTED
+    caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> DeviceNetworkType.CELLULAR
+    else -> DeviceNetworkType.WIFI   // wifi / ethernet / vpn / tethering, incl. LAN-only
+}
+
+private fun report(type: DeviceNetworkType, networkId: String) {
+    currentNetworkType = type
+    reports.trySend(Report(type, networkId))
+}
+
+private fun reportCurrent() {
+    val (network, caps) = activeNetworkAndCaps() ?: return report(DeviceNetworkType.NOT_CONNECTED, "")
+    report(mapNetworkType(caps), network.networkHandle.toString())
+}
+
+/** The default network and its capabilities, or null if there is no usable default. */
+private fun activeNetworkAndCaps(): Pair<Network, NetworkCapabilities>? {
+    val cm = connectivityManager ?: return null
+    val network = cm.activeNetwork ?: return null
+    val caps = try {
+        cm.getNetworkCapabilities(network)
+    } catch (e: Throwable) {
+        Timber.w(e, "Failed to get network capabilities")
+        null
+    } ?: return null
+    return network to caps
+}
+
+// Unchanged semantics: while monitoring, serve the last reported value (now
+// written synchronously by report()); otherwise query on demand.
+override fun getCurrentNetworkType(): DeviceNetworkType =
+    if (isMonitoring) currentNetworkType else mapNetworkType(activeNetworkAndCaps()?.second)
+```
+
+`onAvailable` is **dropped**: `onCapabilitiesChanged` is guaranteed to follow it (immediately, on API 26+, which is our `minSdk`), and the existing override re-queries `activeNetwork` — the racy pattern being removed.
+
+`start()` keeps an explicit `reportCurrent()` baseline: when there is no default network at launch **no callback fires at all**, so without priming heart would never receive the initial `NOT_CONNECTED`.
+
+`currentNetworkType` is assigned synchronously on the callback thread (hence `@Volatile`), so `getCurrentNetworkType()` no longer lags a coroutine hop behind reality.
+
+#### Transport mapping rationale (verified against platform docs)
+
+- **VPN is handled correctly by cellular-first.** Android unions the underlying transports into the VPN network: *"a VPN operating over both Wi-Fi and mobile networks. The VPN has the Wi-Fi, mobile, and VPN transports."* So VPN-over-cellular carries `TRANSPORT_CELLULAR` → `CELLULAR`. A VPN spanning both yields `CELLULAR` — the conservative answer.
+- **`else -> WIFI` is the only sane catch-all** for a three-value enum. Ethernet, USB/Bluetooth tethering and Wi-Fi Aware must not land on `NOT_CONNECTED`, which is the state heart throttles.
+- **Known caveat, does not apply here.** Google warns `hasTransport` is *"a poor proxy for the bandwidth or meteredness of the network"* and recommends `NET_CAPABILITY_NOT_METERED` for metered decisions. We report path identity, not meteredness. If heart's Wi-Fi-gate hook is semantically a *metered* gate, that is a heart-side question — out of scope.
+- **`networkHandle` is a valid identity.** *"Even if the device later reconnects to the same appliance, a new Network object represents the new network"* — so the handle changes across reconnects, which is exactly the semantics `networkId` wants.
+
+### 3.4 Why `onLost` reports the current default rather than `NOT_CONNECTED`
+
+The heart guide's Android snippet reports `NOT_CONNECTED` unconditionally from `onLost`. On a default-network callback that is wrong in a way that costs real UX, and heart does **not** absorb it:
+
+- `networkstate.go:255-262` — `IsOffline()` returns `true` the instant state is `NOT_CONNECTED`, with **no debounce**. Only `triggerRecovery` is debounced (leading-edge + 5s suppression + trailing run).
+- `networkstate.go:225-227` — `runOnNetworkUpdateHook` fires on every `typeChanged`, so the Wi-Fi-gate/mDNS hooks tear down and rebuild.
+
+Since `onLost` fires on **every** Wi-Fi↔cellular handoff (documented sequence: `onLost(wifi)` → `onAvailable(cellular)` → `onCapabilitiesChanged(cellular)`), the snippet would flip sync status offline and churn mDNS on every switch.
+
+`reportCurrent()` avoids this: Android keeps cellular warm, so the replacement default is normally already up and we report its real type with no blip. Behaviour by case:
+
+| Case | `activeNetwork` at `onLost` | Reported |
+|---|---|---|
+| Wi-Fi→cellular handoff | cellular (already up) | `CELLULAR` + handle — no blip |
+| True disconnect (airplane mode) | `null` | `NOT_CONNECTED` — the only signal, since no `onCapabilitiesChanged` follows |
+| Handoff with a real gap | `null` briefly | `NOT_CONNECTED`, corrected by the next `onCapabilitiesChanged` — correct, we genuinely are offline |
+
+**Follow-up:** send a patch to `docs/mobile-network-integration.md` so the published guide matches, and so iOS is not left following advice Android rejected. Tracked separately; not a blocker.
+
+### 3.5 Ordering — serialize reports through a channel
+
+`updateNetworkState` currently does `coroutineScope.launch { withContext(dispatchers.io) { … } }` on a `Dispatchers.Default` scope. ConnectivityManager delivers callbacks serialized on one thread, but each `launch` is dispatched independently, so **two rapid callbacks can reach the RPC out of order**. Latent today; sharper now, because heart coalesces bursts into one trailing run where the *last* value wins — so a `NOT_CONNECTED` overtaken by a stale `WIFI` leaves heart believing it is online while the device is offline, until the next callback.
+
+One `Channel<Report>(UNLIMITED)` lives for the object's lifetime, drained by a consumer `Job`:
+
+```kotlin
+override fun start() {
+    if (isMonitoring) return
+    consumer = coroutineScope.launch(dispatchers.io) {
+        for (r in reports) {
+            try {
+                blockRepository.setDeviceNetworkState(r.type, r.networkId)
+            } catch (e: Throwable) {
+                Timber.w(e, "Failed to update network state")   // per-report; must not kill the loop
+            }
+        }
+    }
+    try {
+        connectivityManager?.registerDefaultNetworkCallback(networkCallback)
+        isMonitoring = true
+    } catch (e: RuntimeException) {
+        Timber.w(e, "Failed to register network callback")
+        consumer?.cancel(); consumer = null
+        return
+    }
+    reportCurrent()
+}
+
+override fun stop() {
+    if (!isMonitoring) return
+    try {
+        connectivityManager?.unregisterNetworkCallback(networkCallback)
+    } catch (e: Throwable) {
+        Timber.w(e, "Failed to unregister network callback")
+    } finally {
+        isMonitoring = false
+        consumer?.cancel(); consumer = null
+        while (reports.tryReceive().isSuccess) { /* drop reports from the ended session */ }
+    }
+}
+```
+
+Properties:
+- **FIFO is guaranteed** by the `Channel` contract, not inferred from a dispatcher's implementation.
+- **Never closed**, so `start()`/`stop()` can cycle across login→logout→login. Nothing accumulates while stopped, because the callback is unregistered and `reportCurrent()` only runs from `start()`.
+- **Callbacks never block.** `trySend` on an `UNLIMITED` channel never suspends and never fails-on-full, so ConnectivityManager's thread is never held.
+- **No conflation** — contract-compliant.
+- The drain in `stop()` discards reports from the ended session so a stale value cannot become heart's *baseline* (`first`) after the next login.
+
+## 4. Data flow
+
+```
+onCapabilitiesChanged(net, caps)        [CM thread, serialized]
+  → report(type, net.networkHandle)     [sets @Volatile currentNetworkType; trySend, non-blocking]
+  → reports: Channel(UNLIMITED)         [FIFO]
+  → consumer Job on dispatchers.io      [single consumer; per-report try/catch]
+  → blockRepository.setDeviceNetworkState(type, networkId)
+  → BlockDataRepository → BlockRemote → BlockMiddleware → Middleware
+  → Rpc.Device.NetworkState.Set.Request(deviceNetworkType, networkId)
+  → service.deviceNetworkStateSet(...)  [JNI, blocking]
+```
+
+## 5. Error handling
+
+- **Per-report `try/catch` inside the loop.** This is load-bearing: a throw inside `for (r in reports)` terminates the loop and silently disables network reporting for the rest of the session. The current code's catch is per-`launch`, so this hazard is introduced by the channel refactor and must not be missed.
+- `trySend` failure is impossible for `UNLIMITED`/open; the return is ignored deliberately.
+- Registration failure leaves `isMonitoring = false` and cancels the consumer, matching current behaviour.
+- `getNetworkCapabilities` throwing is caught in `activeNetworkAndCaps()` → treated as no network.
+
+## 6. Testing
+
+New: `device/src/test/java/com/anytypeio/anytype/device/network_type/NetworkConnectionStatusImplTest.kt`. Robolectric 4.11.1, mockito-kotlin and coroutine-testing are already on `device`'s test classpath — no dependency changes. Callbacks are retrieved via `shadowOf(connectivityManager).networkCallbacks` and invoked directly; assertions are `verify` on a mocked `BlockRepository`.
+
+| Test | Asserts |
+|---|---|
+| `onCapabilitiesChanged` with `TRANSPORT_WIFI` | `WIFI`, id = handle |
+| `onCapabilitiesChanged` with `TRANSPORT_CELLULAR` | `CELLULAR`, id = handle |
+| `onCapabilitiesChanged` with `TRANSPORT_ETHERNET` | `WIFI` (regression guard for `else -> NOT_CONNECTED`) |
+| `onCapabilitiesChanged` with VPN + cellular transports | `CELLULAR` |
+| `onCapabilitiesChanged` **without** `NET_CAPABILITY_VALIDATED` | `WIFI`, **not** `NOT_CONNECTED` (regression guard for the reversal) |
+| `onLost` with another default already up | that network's type — **no** `NOT_CONNECTED` |
+| `onLost` with no active network | `NOT_CONNECTED`, id `""` |
+| `onUnavailable` | `NOT_CONNECTED`, id `""` |
+| two identical `onCapabilitiesChanged` | **two** RPCs (no client-side debounce) |
+| burst of distinct reports | delivered in order (`inOrder` verify) |
+| RPC throws on report *n* | report *n+1* still delivered (consumer survives) |
+| `start()` with no active network | baseline `NOT_CONNECTED` emitted |
+| `stop()` then `start()` | callback re-registered; consumer drains again |
+
+## 7. Risks
+
+1. **Robolectric may not support `Network.networkHandle`.** `ShadowNetwork.newInstance(netId)` exists, but the handle accessor is unverified. **Spike this first.** Fallback: inject a `networkIdOf: (Network) -> String` seam defaulting to `{ it.networkHandle.toString() }` — a testing seam, not a production abstraction.
+2. **No end-to-end verification until heart ships.** `networkId` cannot be observed against MW `v0.50.12`. Mitigated by unit tests + wire-level backward compatibility. When GO-7379 releases, verify per the guide: one `connectivity recovery` log per Wi-Fi→Wi-Fi switch; airplane-mode toggle flips offline ~1s and recovers ~2s.
+3. **`onLost` deviates from the published guide.** Justified in §3.4 and evidenced against heart's source; the doc patch keeps them from drifting.
+4. **`make update_mw` will overwrite the proto edit.** By design, and idempotent — but if heart's released field ever differs in name or number, the Kotlin build breaks loudly at the `Middleware.kt` call site rather than silently. Acceptable.
+
+## 8. Out of scope → follow-up tickets
+
+- **Captive-portal onboarding.** `OnboardingMnemonicViewModel.shouldShowEmail()` (`:88-95`) treats `NOT_CONNECTED` as "no network" and asks a question this enum can't answer ("is there real internet?"). Ethernet/VPN improves for free here (previously `NOT_CONNECTED` → email screen wrongly skipped); captive-portal Wi-Fi keeps today's behaviour (`WIFI` → email screen shown, submit fails). Pre-existing, not a regression. Proper fix: a `VALIDATED`-backed `hasInternet()` — the legitimate use of `VALIDATED`.
+- `AppStateService` swallows RPC failures with `Timber.d` and never retries; a FOREGROUND sent before account start is lost until the next lifecycle transition.
+- `Middleware.setDeviceNetworkState` has its `logRequestIfDebug`/`logResponseIfDebug` calls commented out (`Middleware.kt:3324,3326`) and discards the response.
+- This path bypasses the use-case layer, unlike the sibling `SetAppState`.
+- `LocalNetworkAddressProvider.start()` is fire-and-forget on `GlobalScope`, leaving a startup window where Go's `interfaceGetter` is nil and `GetInterfacesAddrs()` errors.
+- Patch `docs/mobile-network-integration.md` in anytype-heart for the `onLost` correction (§3.4).
+
+## 9. Sequencing
+
+1. Spike Robolectric `networkHandle` support (risk 1) — decides the test seam.
+2. Proto field 2 + Wire regen; confirm `:protocol:compileDebugKotlin`.
+3. Plumbing: the six signatures, `Middleware` last.
+4. Rewrite `NetworkConnectionStatusImpl` (mapping, callbacks, channel).
+5. Tests.
+6. `./gradlew :device:testDebugUnitTest`, then `make test_debug_all`.
+7. File the §8 follow-ups.

--- a/docs/superpowers/specs/2026-07-16-droid-4548-network-state-design.md
+++ b/docs/superpowers/specs/2026-07-16-droid-4548-network-state-design.md
@@ -194,7 +194,16 @@ override fun start() {
     // Discard anything a late callback pushed after the previous session's
     // stop() -- a stale value must not become heart's baseline for this one.
     while (reports.tryReceive().isSuccess) { /* drop */ }
+    try {
+        connectivityManager?.registerDefaultNetworkCallback(networkCallback)
+        isMonitoring = true
+    } catch (e: RuntimeException) {
+        Timber.w(e, "Failed to register network callback")
+        return   // consumer chain untouched -- nothing was launched
+    }
+    val previous = consumer
     consumer = coroutineScope.launch(dispatchers.io) {
+        previous?.join()   // see the join bullet below
         for (r in reports) {
             try {
                 blockRepository.setDeviceNetworkState(r.type, r.networkId)
@@ -202,14 +211,6 @@ override fun start() {
                 Timber.w(e, "Failed to update network state")   // per-report; must not kill the loop
             }
         }
-    }
-    try {
-        connectivityManager?.registerDefaultNetworkCallback(networkCallback)
-        isMonitoring = true
-    } catch (e: RuntimeException) {
-        Timber.w(e, "Failed to register network callback")
-        consumer?.cancel(); consumer = null
-        return
     }
     reportCurrent()
 }
@@ -222,7 +223,8 @@ override fun stop() {
         Timber.w(e, "Failed to unregister network callback")
     } finally {
         isMonitoring = false
-        consumer?.cancel(); consumer = null
+        // Cancel but KEEP the reference: the next start()'s consumer joins it.
+        consumer?.cancel()
     }
 }
 ```
@@ -236,7 +238,8 @@ Properties:
 - **Never closed**, so `start()`/`stop()` can cycle across login→logout→login. Nothing accumulates while stopped, because the callback is unregistered and `reportCurrent()` only runs from `start()`.
 - **Callbacks never block.** `trySend` on an `UNLIMITED` channel never suspends and never fails-on-full, so ConnectivityManager's thread is never held.
 - **No conflation** — contract-compliant.
-- The drain in `stop()` discards reports from the ended session so a stale value cannot become heart's *baseline* (`first`) after the next login.
+- The drain at the top of `start()` discards reports from the ended session so a stale value cannot become heart's *baseline* (`first`) after the next login.
+- The consumer `join()`s its predecessor before processing: cancellation is cooperative and the RPC chain has no suspension points, so a consumer stopped mid-JNI-call keeps running until the call returns — without the join, its stale report could complete *after* the next session's baseline and become heart's final word.
 
 ## 4. Data flow
 
@@ -255,7 +258,7 @@ onCapabilitiesChanged(net, caps)        [CM thread, serialized]
 
 - **Per-report `try/catch` inside the loop.** This is load-bearing: a throw inside `for (r in reports)` terminates the loop and silently disables network reporting for the rest of the session. The current code's catch is per-`launch`, so this hazard is introduced by the channel refactor and must not be missed.
 - `trySend` failure is impossible for `UNLIMITED`/open; the return is ignored deliberately.
-- Registration failure leaves `isMonitoring = false` and cancels the consumer, matching current behaviour.
+- Registration happens *before* the consumer is launched: a registration failure returns early with `isMonitoring = false` and the consumer chain untouched, so a predecessor still draining is unaffected.
 - `getNetworkCapabilities` throwing is caught in `activeNetworkAndCaps()` → treated as no network.
 
 ## 6. Testing

--- a/domain/src/main/java/com/anytypeio/anytype/domain/block/repo/BlockRepository.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/block/repo/BlockRepository.kt
@@ -576,7 +576,7 @@ interface BlockRepository {
 
     suspend fun objectDateByTimestamp(command: Command.ObjectDateByTimestamp): Struct?
 
-    suspend fun setDeviceNetworkState(type: DeviceNetworkType)
+    suspend fun setDeviceNetworkState(type: DeviceNetworkType, networkId: String)
 
     suspend fun setAppState(state: AppState)
 

--- a/middleware/src/main/java/com/anytypeio/anytype/middleware/block/BlockMiddleware.kt
+++ b/middleware/src/main/java/com/anytypeio/anytype/middleware/block/BlockMiddleware.kt
@@ -1231,8 +1231,8 @@ class BlockMiddleware(
         return middleware.objectDateByTimestamp(command)
     }
 
-    override suspend fun setDeviceNetworkState(type: DeviceNetworkType) {
-        middleware.setDeviceNetworkState(type)
+    override suspend fun setDeviceNetworkState(type: DeviceNetworkType, networkId: String) {
+        middleware.setDeviceNetworkState(type, networkId)
     }
 
     override suspend fun setAppState(state: AppState) {

--- a/middleware/src/main/java/com/anytypeio/anytype/middleware/interactor/Middleware.kt
+++ b/middleware/src/main/java/com/anytypeio/anytype/middleware/interactor/Middleware.kt
@@ -3317,9 +3317,10 @@ class Middleware @Inject constructor(
     }
 
     @Throws(Exception::class)
-    fun setDeviceNetworkState(type: DeviceNetworkType) {
+    fun setDeviceNetworkState(type: DeviceNetworkType, networkId: String) {
         val request = Rpc.Device.NetworkState.Set.Request(
-            deviceNetworkType = type.mw()
+            deviceNetworkType = type.mw(),
+            networkId = networkId
         )
         //logRequestIfDebug(request)
         val (response, time) = measureTimedValue { service.deviceNetworkStateSet(request) }

--- a/protocol/src/main/proto/commands.proto
+++ b/protocol/src/main/proto/commands.proto
@@ -8922,6 +8922,12 @@ message Rpc {
             message Set {
                 message Request {
                     anytype.model.DeviceNetworkType deviceNetworkType = 1;
+                    // opaque identity of the current network path as reported by the OS
+                    // (iOS: NWPath interfaces/gateway digest; Android: Network#getNetworkHandle()).
+                    // When it changes while the type stays the same (Wi-Fi to Wi-Fi switch,
+                    // cellular re-attach) the middleware still resets connections and re-syncs.
+                    // Optional: empty means unknown, only type transitions are used then.
+                    string networkId = 2;
                 }
                 message Response {
                     Error error = 2;


### PR DESCRIPTION
Android side of GO-7379 (anytype-heart #3211): heart's connectivity-recovery pipeline (connection reset → peer re-dial → immediate head-sync) is driven by the signals this app sends. Design spec with the full audit: `docs/superpowers/specs/2026-07-16-droid-4548-network-state-design.md`.

## Audit results (ticket asked to verify, not just add the field)

| Contract item | Verdict |
|---|---|
| `SetDeviceState(FOREGROUND/BACKGROUND)` prompt on lifecycle | ✅ compliant, untouched |
| Interface getter enumerates cellular (`rmnet`/`ccmni`) | ✅ compliant (no filtering at all), untouched |
| `NetworkState.Set` on every capabilities change, no client debounce | ⚠️ mostly — fixed the gaps below |
| `networkId` (field 2) | ❌ missing everywhere — added |

## Changes

- **`networkId`**: field 2 added to `Rpc.Device.NetworkState.Set` (verbatim from heart `go-7379`, so the next `make update_mw` is a zero-diff no-op) and threaded through `BlockRepository → … → Middleware`. `onCapabilitiesChanged` reports `Network#getNetworkHandle()` — stable per network instance, changes on reconnect — so heart detects same-type switches (Wi-Fi→Wi-Fi, PDP re-attach) instantly instead of via its 5s interface poll. Old middleware ignores the unknown field: ships independently of the heart release.
- **Transport-only mapping**: `CELLULAR` if `TRANSPORT_CELLULAR`, else `WIFI`. Fixes Ethernet/VPN/tethering reporting as *offline* (`else -> NOT_CONNECTED`), and per the revised contract `NET_CAPABILITY_VALIDATED` is deliberately not consulted — a LAN-only network still syncs over local P2P, and heart throttles `NOT_CONNECTED` devices (heart `8a2fa9d91`).
- **`onLost` reports the current default, not unconditional `NOT_CONNECTED`**: on a default-network callback `onLost` means "lost default status" and fires on every Wi-Fi↔cellular handoff; the unconditional report would flip heart's undebounced `IsOffline` and churn mDNS on every switch. True disconnection (`activeNetwork == null`) still reports `NOT_CONNECTED`, primed at `start()` for the offline-at-launch case. This deviates from the heart guide's snippet on purpose — doc patch tracked as follow-up.
- **FIFO report delivery**: reports go through an unbounded channel with a single consumer instead of one racy `launch` per callback (heart's coalescing trusts the last value it hears, so a stale report overtaking `NOT_CONNECTED` would wedge it "online"). The consumer joins its predecessor across `stop()`/`start()` so an RPC in flight at logout can't complete after the next session's baseline; errors are caught per report; stale reports are drained at `start()`.

## Testing

- 18 Robolectric tests for the callback contract (file previously had zero coverage), incl. a completion-order regression test for the cross-session race using a `NonCancellable` gate.
- Full repo unit-test suite (`make test_debug_all`) passes; all modules compile from `:protocol` (Wire regen) through `:app`.
- Reviewed by a model agent; all findings fixed (see `4a76bff66`).
- E2E (`connectivity recovery` heart logs per switch) deferred until a heart release with GO-7379; not observable against pinned MW v0.50.12.

## Out of scope (follow-ups)

Captive-portal-aware `hasInternet()` for onboarding email screen; `AppStateService` swallowed-failure retry; heart doc patch for the `onLost` correction.