### PR TITLE
DROID-4529 Fix frozen blank set header after returning from an object (Kanban)

### DIFF
--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/widgets/FeaturedRelationGroupWidget.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/widgets/FeaturedRelationGroupWidget.kt
@@ -3,17 +3,28 @@ package com.anytypeio.anytype.core_ui.widgets
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
-import androidx.constraintlayout.helper.widget.Flow
-import androidx.constraintlayout.widget.ConstraintLayout
+import android.view.ViewGroup
 import com.anytypeio.anytype.presentation.editor.editor.listener.ListenerType
 import com.anytypeio.anytype.presentation.editor.editor.model.BlockView
 import com.anytypeio.anytype.presentation.relations.ObjectRelationView
+import kotlin.math.max
 
+/**
+ * Lays featured relations out in horizontal rows, wrapping to a new row when the
+ * available width is exhausted (start-aligned, packed — same visual behavior as the
+ * previous ConstraintLayout + Flow implementation).
+ *
+ * Deliberately a plain [ViewGroup] with hand-rolled measure/layout: the previous
+ * ConstraintLayout + Flow-helper version non-deterministically produced a solve in
+ * which children stayed unmeasured (0x0) while the widget itself expanded to the
+ * full AT_MOST height — freezing the data-view header as a giant blank area after
+ * the fragment view was recreated (DROID-4529).
+ */
 class FeaturedRelationGroupWidget @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
-) : ConstraintLayout(context, attrs, defStyleAttr) {
+) : ViewGroup(context, attrs, defStyleAttr) {
 
     private var objectTypeIds = mutableListOf<Int>()
 
@@ -21,17 +32,7 @@ class FeaturedRelationGroupWidget @JvmOverloads constructor(
         item: BlockView.FeaturedRelation,
         click: (ListenerType.Relation) -> Unit
     ) {
-        val ids = mutableListOf<Int>()
         clear()
-        val flow = Flow(context).apply {
-            id = View.generateViewId()
-            setOrientation(Flow.HORIZONTAL)
-            setWrapMode(Flow.WRAP_CHAIN)
-            setHorizontalStyle(Flow.CHAIN_PACKED)
-            setHorizontalBias(0f)
-            setHorizontalAlign(Flow.HORIZONTAL_ALIGN_START)
-        }
-        addView(flow)
         item.relations.forEachIndexed { index, relation ->
             val view = createRelationValueListWidget(
                 context = context,
@@ -40,9 +41,7 @@ class FeaturedRelationGroupWidget @JvmOverloads constructor(
                 click = click
             )
             addView(view)
-            ids.add(view.id)
         }
-        flow.referencedIds = ids.toIntArray()
     }
 
     fun clear() {
@@ -58,7 +57,62 @@ class FeaturedRelationGroupWidget @JvmOverloads constructor(
         }
     }
 
-    private fun createRelationValueListWidget(context: Context, relation: ObjectRelationView, isLast: Boolean, click: (ListenerType.Relation) -> Unit): RelationValueListWidget {
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val availableWidth =
+            (MeasureSpec.getSize(widthMeasureSpec) - paddingStart - paddingEnd).coerceAtLeast(0)
+        var rowWidth = 0
+        var rowHeight = 0
+        var totalHeight = 0
+        var maxRowWidth = 0
+        for (i in 0 until childCount) {
+            val child = getChildAt(i)
+            if (child.visibility == GONE) continue
+            child.measure(
+                MeasureSpec.makeMeasureSpec(availableWidth, MeasureSpec.AT_MOST),
+                MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
+            )
+            if (rowWidth > 0 && rowWidth + child.measuredWidth > availableWidth) {
+                totalHeight += rowHeight
+                maxRowWidth = max(maxRowWidth, rowWidth)
+                rowWidth = 0
+                rowHeight = 0
+            }
+            rowWidth += child.measuredWidth
+            rowHeight = max(rowHeight, child.measuredHeight)
+        }
+        totalHeight += rowHeight
+        maxRowWidth = max(maxRowWidth, rowWidth)
+        setMeasuredDimension(
+            resolveSize(maxRowWidth + paddingStart + paddingEnd, widthMeasureSpec),
+            resolveSize(totalHeight + paddingTop + paddingBottom, heightMeasureSpec)
+        )
+    }
+
+    override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
+        val availableWidth = (r - l - paddingStart - paddingEnd).coerceAtLeast(0)
+        var x = paddingStart
+        var y = paddingTop
+        var rowHeight = 0
+        for (i in 0 until childCount) {
+            val child = getChildAt(i)
+            if (child.visibility == GONE) continue
+            if (x > paddingStart && x - paddingStart + child.measuredWidth > availableWidth) {
+                x = paddingStart
+                y += rowHeight
+                rowHeight = 0
+            }
+            child.layout(x, y, x + child.measuredWidth, y + child.measuredHeight)
+            x += child.measuredWidth
+            rowHeight = max(rowHeight, child.measuredHeight)
+        }
+    }
+
+    private fun createRelationValueListWidget(
+        context: Context,
+        relation: ObjectRelationView,
+        isLast: Boolean,
+        click: (ListenerType.Relation) -> Unit
+    ): RelationValueListWidget {
         return RelationValueListWidget(context).apply {
             id = generateViewId()
             setRelation(relation, isLast, click)

--- a/core-ui/src/test/java/com/anytypeio/anytype/core_ui/widgets/FeaturedRelationGroupWidgetTest.kt
+++ b/core-ui/src/test/java/com/anytypeio/anytype/core_ui/widgets/FeaturedRelationGroupWidgetTest.kt
@@ -1,0 +1,138 @@
+package com.anytypeio.anytype.core_ui.widgets
+
+import android.content.Context
+import android.os.Build
+import android.view.View
+import androidx.test.core.app.ApplicationProvider
+import com.anytypeio.anytype.core_models.Relation
+import com.anytypeio.anytype.core_ui.R
+import com.anytypeio.anytype.presentation.editor.editor.model.BlockView
+import com.anytypeio.anytype.presentation.relations.ObjectRelationView
+import com.anytypeio.anytype.test_utils.MockDataFactory
+import kotlin.test.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+class FeaturedRelationGroupWidgetTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun before() {
+        context.setTheme(R.style.Theme_MaterialComponents)
+    }
+
+    private fun givenItem(count: Int) = BlockView.FeaturedRelation(
+        id = MockDataFactory.randomUuid(),
+        relations = (1..count).map { index ->
+            ObjectRelationView.Default(
+                id = MockDataFactory.randomUuid(),
+                key = MockDataFactory.randomUuid(),
+                name = "Relation $index",
+                value = "value $index",
+                system = false,
+                format = Relation.Format.SHORT_TEXT
+            )
+        }
+    )
+
+    @Test
+    fun `all children are measured and the widget wraps its content height`() {
+        val widget = FeaturedRelationGroupWidget(context)
+
+        widget.set(item = givenItem(count = 3), click = {})
+
+        widget.measure(
+            View.MeasureSpec.makeMeasureSpec(1016, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(1838, View.MeasureSpec.AT_MOST)
+        )
+        widget.layout(0, 0, widget.measuredWidth, widget.measuredHeight)
+
+        // The broken ConstraintLayout+Flow implementation left children unmeasured
+        // (0x0) while the widget itself expanded to the full AT_MOST height.
+        (0 until widget.childCount).forEach { index ->
+            val child = widget.getChildAt(index)
+            assertTrue(
+                actual = child.measuredHeight > 0 && child.measuredWidth > 0,
+                message = "Child $index must be measured but was " +
+                    "${child.measuredWidth}x${child.measuredHeight}"
+            )
+        }
+        assertTrue(
+            actual = widget.measuredHeight in 1 until 1838,
+            message = "Widget must wrap content height but was ${widget.measuredHeight}"
+        )
+    }
+
+    @Test
+    fun `re-populating the widget re-measures the new children`() {
+        val widget = FeaturedRelationGroupWidget(context)
+
+        widget.set(item = givenItem(count = 8), click = {})
+        widget.set(item = givenItem(count = 1), click = {})
+
+        widget.measure(
+            View.MeasureSpec.makeMeasureSpec(400, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(2000, View.MeasureSpec.AT_MOST)
+        )
+        widget.layout(0, 0, widget.measuredWidth, widget.measuredHeight)
+
+        assertTrue(
+            actual = widget.childCount == 1,
+            message = "Repopulation must replace children but count was ${widget.childCount}"
+        )
+        val child = widget.getChildAt(0)
+        assertTrue(
+            actual = child.measuredWidth > 0 && child.measuredHeight > 0,
+            message = "Re-populated child must be measured but was " +
+                "${child.measuredWidth}x${child.measuredHeight}"
+        )
+    }
+
+    /** A child whose size does not depend on Robolectric's zero-width text measurement. */
+    private class FixedSizeView(
+        context: Context,
+        private val w: Int,
+        private val h: Int
+    ) : View(context) {
+        override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+            setMeasuredDimension(w, h)
+        }
+    }
+
+    @Test
+    fun `children wrap to new rows when the available width is exhausted`() {
+        val widget = FeaturedRelationGroupWidget(context)
+        repeat(6) { widget.addView(FixedSizeView(context, w = 100, h = 20)) }
+
+        widget.measure(
+            View.MeasureSpec.makeMeasureSpec(3000, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+        )
+        val singleRowHeight = widget.measuredHeight
+
+        widget.measure(
+            View.MeasureSpec.makeMeasureSpec(300, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+        )
+        widget.layout(0, 0, 300, widget.measuredHeight)
+        val wrappedHeight = widget.measuredHeight
+
+        // 6 children x 100px in a 300px-wide widget = 2 rows of 3.
+        assertTrue(
+            actual = singleRowHeight == 20 && wrappedHeight == 40,
+            message = "Narrow width must wrap rows (wide=$singleRowHeight, narrow=$wrappedHeight)"
+        )
+        // Second row children are laid out below the first row.
+        assertTrue(
+            actual = widget.getChildAt(3).top == 20 && widget.getChildAt(3).left == 0,
+            message = "4th child must start the 2nd row but was at " +
+                "(${widget.getChildAt(3).left}, ${widget.getChildAt(3).top})"
+        )
+    }
+}


### PR DESCRIPTION
Linear: [DROID-4529](https://linear.app/anytype/issue/DROID-4529)

## Symptom

Kanban → open a card → Back: the set screen renders with a giant blank area between the title and the view controls — the "Kanban / New" row is pushed to the bottom edge and the board itself off-screen. The state never recovers (screenshot pair in the ticket).

## Root cause (confirmed by on-device instrumentation)

The featured-relations widget (`FeaturedRelationGroupWidget`, used in the set header and the editor's featured block) was a `ConstraintLayout` populated via a `Flow` helper. After the fragment view is recreated on return, its solve **non-deterministically returned the full `AT_MOST` height (~full screen) without measuring any child**:

```
broken:  onMeasure specs=[EXACTLY 1016, AT_MOST 1838] -> 1016x1838  children measured: [0, 0, 0]
healthy: onMeasure specs=[EXACTLY 1016, AT_MOST 1838] -> 1016x47    children measured: [47, 47, 47]
```

Suspects ruled out by the same instrumentation:
- **MotionLayout** (screen root) was settled at the start state, `progress = 0.0` — not mid-transition; `layoutDuringTransition="honorRequest"` did not help.
- **Lost layout request** — a `post { requestLayout() }` after (re)population did not help either; measure was reached, the solve itself was broken.

Since the bound state is deduplicated upstream (`StateFlow`), no further `set()` ever arrived to heal the widget — the header froze permanently.

## Fix

`FeaturedRelationGroupWidget` is now a plain `ViewGroup` with hand-rolled measure/layout (~50 lines): children flow into horizontal rows and wrap when the available width is exhausted — same start-aligned packed behavior as the `Flow` setup, but fully deterministic. Public API (`set`/`clear`/`getObjectTypeView`) and child creation are unchanged; no XML changes needed for either host.

## Verification

- Robolectric tests: children always measured; widget wraps content height; repopulation replaces and re-measures children; exact wrap geometry (6×100px children in 300px width → 2 rows, 4th child at (0, 20)).
- Manually on device: the repro (Kanban → card → Back, with and without partial board drag) no longer reproduces across repeated attempts; the editor's featured block renders and behaves as before.
- Full `core-ui` unit test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)