### PR TITLE
DROID-4516 Invite sharing: owner-held invites, share-within-space toggle, link reset (GO-7222)

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/ui/multiplayer/RequestJoinSpaceFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/multiplayer/RequestJoinSpaceFragment.kt
@@ -294,6 +294,12 @@ class RequestJoinSpaceFragment : BaseBottomSheetComposeFragment() {
                     is MultiplayerError.Generic.NoSuchSpace -> {
                         toast(resources.getString(R.string.share_space_error_no_such_space))
                     }
+                    is MultiplayerError.Generic.InviteAlreadyShared -> {
+                        toast(resources.getString(R.string.share_space_error_invite_already_shared))
+                    }
+                    is MultiplayerError.Generic.InviteNotShareable -> {
+                        toast(resources.getString(R.string.share_space_error_invite_not_shareable))
+                    }
                 }
             }
             is RequestJoinSpaceViewModel.Command.SwitchToSpace -> {

--- a/app/src/main/java/com/anytypeio/anytype/ui/multiplayer/ShareSpaceFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/multiplayer/ShareSpaceFragment.kt
@@ -73,6 +73,14 @@ class ShareSpaceFragment : BaseBottomSheetComposeFragment() {
                     onInviteLinkAccessLevelSelected = vm::onInviteLinkAccessLevelSelected,
                     onInviteLinkAccessChangeConfirmed = vm::onInviteLinkAccessChangeConfirmed,
                     onInviteLinkAccessChangeCancel = vm::onInviteLinkAccessChangeCancel,
+                    shareInviteConfirmationDialog = vm.shareInviteConfirmationDialog.collectAsStateWithLifecycle().value,
+                    onShareWithinSpaceClicked = vm::onShareWithinSpaceClicked,
+                    onShareWithinSpaceConfirmed = vm::onShareWithinSpaceConfirmed,
+                    onShareWithinSpaceCancelled = vm::onShareWithinSpaceCancelled,
+                    resetLinkConfirmationDialog = vm.resetLinkConfirmationDialog.collectAsStateWithLifecycle().value,
+                    onResetLinkClicked = vm::onResetLinkClicked,
+                    onResetLinkConfirmed = vm::onResetLinkConfirmed,
+                    onResetLinkCancelled = vm::onResetLinkCancelled,
                     onCopyInviteLinkClicked = vm::onCopyInviteLinkClicked,
                     isCurrentUserOwner = vm.isCurrentUserOwner.collectAsStateWithLifecycle().value,
                     onMakePrivateClicked = vm::onMakePrivateClicked,
@@ -169,6 +177,22 @@ class ShareSpaceFragment : BaseBottomSheetComposeFragment() {
                             onDismissRequest = { vm.dismissShareSpaceErrors() }
                         )
                     }
+                    ShareSpaceErrors.InviteAlreadyShared -> {
+                        BaseAlertDialog(
+                            dialogText = stringResource(R.string.share_space_error_invite_already_shared),
+                            buttonText = stringResource(R.string.button_ok),
+                            onButtonClick = { vm.dismissShareSpaceErrors() },
+                            onDismissRequest = { vm.dismissShareSpaceErrors() }
+                        )
+                    }
+                    ShareSpaceErrors.InviteNotShareable -> {
+                        BaseAlertDialog(
+                            dialogText = stringResource(R.string.share_space_error_invite_not_shareable),
+                            buttonText = stringResource(R.string.button_ok),
+                            onButtonClick = { vm.dismissShareSpaceErrors() },
+                            onDismissRequest = { vm.dismissShareSpaceErrors() }
+                        )
+                    }
                 }
             }
         }
@@ -260,6 +284,12 @@ class ShareSpaceFragment : BaseBottomSheetComposeFragment() {
                     }
                     is MultiplayerError.Generic.NoSuchSpace -> {
                         toast(resources.getString(R.string.share_space_error_no_such_space))
+                    }
+                    is MultiplayerError.Generic.InviteAlreadyShared -> {
+                        toast(resources.getString(R.string.share_space_error_invite_already_shared))
+                    }
+                    is MultiplayerError.Generic.InviteNotShareable -> {
+                        toast(resources.getString(R.string.share_space_error_invite_not_shareable))
                     }
                 }
             }

--- a/app/src/main/java/com/anytypeio/anytype/ui/multiplayer/SpaceJoinRequestFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/multiplayer/SpaceJoinRequestFragment.kt
@@ -97,6 +97,12 @@ class SpaceJoinRequestFragment : BaseBottomSheetComposeFragment() {
                     is MultiplayerError.Generic.NoSuchSpace -> {
                         toast(resources.getString(R.string.share_space_error_no_such_space))
                     }
+                    is MultiplayerError.Generic.InviteAlreadyShared -> {
+                        toast(resources.getString(R.string.share_space_error_invite_already_shared))
+                    }
+                    is MultiplayerError.Generic.InviteNotShareable -> {
+                        toast(resources.getString(R.string.share_space_error_invite_not_shareable))
+                    }
                 }
             }
         }

--- a/core-models/src/main/java/com/anytypeio/anytype/core_models/multiplayer/Multiplayer.kt
+++ b/core-models/src/main/java/com/anytypeio/anytype/core_models/multiplayer/Multiplayer.kt
@@ -7,9 +7,16 @@ data class SpaceInviteLink(
     val fileKey: String,
     val contentId: String,
     val inviteType: InviteType,
-    val permissions: SpaceMemberPermissions
+    val permissions: SpaceMemberPermissions,
+    val heldByOwner: Boolean = false
 ) {
     val scheme = "https://invite.any.coop/$contentId#$fileKey"
+
+    /**
+     * A member's device receives a successful InviteGetCurrent response with empty
+     * cid + key when the invite is held by the owner. Such a link must never be rendered.
+     */
+    val isLinkVisible: Boolean = contentId.isNotEmpty() && fileKey.isNotEmpty()
 }
 
 data class SpaceInviteView(
@@ -99,6 +106,18 @@ sealed class MultiplayerError : Exception() {
         class RequestFailed : Generic()
         class NoSuchSpace : Generic()
         class IncorrectPermissions : Generic()
+
+        /**
+         * Requested shareWithinSpace = false while the current invite is already shared
+         * within the space. A shared invite cannot be taken back — offer link reset.
+         */
+        class InviteAlreadyShared : Generic()
+
+        /**
+         * The invite cannot be shared within the space: it lets anyone join
+         * with above-Reader permissions without approval.
+         */
+        class InviteNotShareable : Generic()
     }
 }
 

--- a/core-models/src/main/java/com/anytypeio/anytype/core_models/multiplayer/SpaceInviteLinkSettings.kt
+++ b/core-models/src/main/java/com/anytypeio/anytype/core_models/multiplayer/SpaceInviteLinkSettings.kt
@@ -11,9 +11,20 @@ sealed class SpaceInviteLinkAccessLevel {
     data class LinkDisabled(val possibleToUpdate: Boolean = true) : SpaceInviteLinkAccessLevel()
 
     /**
-     * Editor access - users can edit the space content
+     * Invite exists but is held by the space owner — its cid and key sync only to the
+     * owner's devices. This is what a non-owner member sees: there is no link to render.
      */
-    data class EditorAccess(val link: String) : SpaceInviteLinkAccessLevel() {
+    data object HeldByOwner : SpaceInviteLinkAccessLevel()
+
+    /**
+     * Editor access - users can edit the space content
+     *
+     * @property isShared true when the invite is shared within the space (every member can see and share it)
+     */
+    data class EditorAccess(
+        val link: String,
+        val isShared: Boolean = false
+    ) : SpaceInviteLinkAccessLevel() {
         companion object {
             val EMPTY = EditorAccess("")
         }
@@ -21,8 +32,13 @@ sealed class SpaceInviteLinkAccessLevel {
 
     /**
      * Viewer access - users can only view the space content
+     *
+     * @property isShared true when the invite is shared within the space (every member can see and share it)
      */
-    data class ViewerAccess(val link: String) : SpaceInviteLinkAccessLevel() {
+    data class ViewerAccess(
+        val link: String,
+        val isShared: Boolean = false
+    ) : SpaceInviteLinkAccessLevel() {
         companion object {
             val EMPTY = ViewerAccess("")
         }
@@ -30,12 +46,40 @@ sealed class SpaceInviteLinkAccessLevel {
 
     /**
      * Request access - users need approval to join
+     *
+     * @property isShared true when the invite is shared within the space (every member can see and share it)
      */
-    data class RequestAccess(val link: String) : SpaceInviteLinkAccessLevel() {
+    data class RequestAccess(
+        val link: String,
+        val isShared: Boolean = false
+    ) : SpaceInviteLinkAccessLevel() {
         companion object {
             val EMPTY = RequestAccess("")
         }
     }
+
+    /**
+     * True when there is an active invite shared within the space.
+     */
+    val isSharedWithinSpace: Boolean
+        get() = when (this) {
+            is EditorAccess -> isShared
+            is ViewerAccess -> isShared
+            is RequestAccess -> isShared
+            is LinkDisabled, is HeldByOwner -> false
+        }
+
+    /**
+     * The invite link when there is one to render on this device, null otherwise.
+     * An invite held by the owner has no link on a member's device — never render it.
+     */
+    val linkOrNull: String?
+        get() = when (this) {
+            is EditorAccess -> link.ifEmpty { null }
+            is ViewerAccess -> link.ifEmpty { null }
+            is RequestAccess -> link.ifEmpty { null }
+            is LinkDisabled, is HeldByOwner -> null
+        }
 
     /**
      * Checks if changing to the new access level requires user confirmation
@@ -49,6 +93,7 @@ sealed class SpaceInviteLinkAccessLevel {
             is ViewerAccess -> this !is EditorAccess
             is RequestAccess -> true // Always needs confirmation
             is LinkDisabled -> true // Always needs confirmation
+            is HeldByOwner -> false // Never a selection target
         }
     }
 }

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/multiplayer/InviteLinkAccessSelector.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/multiplayer/InviteLinkAccessSelector.kt
@@ -67,12 +67,17 @@ val DEFAULT_OPTIONS = listOf(
 
 /**
  * Component for selecting space invite link access level
+ *
+ * @param isEditorOptionEnabled false when the invite is shared within the space —
+ * a shared invite must not grant editor access without approval, so only Viewer
+ * and Request access are offered (mirrors middleware INVITE_NOT_SHAREABLE).
  */
 @Composable
 fun InviteLinkAccessSelector(
     modifier: Modifier = Modifier,
     currentAccessLevel: SpaceInviteLinkAccessLevel,
     onAccessLevelChanged: (SpaceInviteLinkAccessLevel) -> Unit,
+    isEditorOptionEnabled: Boolean = true
 ) {
     Column(
         modifier = modifier
@@ -92,9 +97,10 @@ fun InviteLinkAccessSelector(
 
         DEFAULT_OPTIONS.forEachIndexed { index, item ->
             val isSelected = currentAccessLevel.getInviteLinkItemParams() == item
+            val isOptionDisabled = item == UiInviteLinkAccess.EDITOR && !isEditorOptionEnabled
             AccessLevelOption(
                 modifier = Modifier.noRippleThrottledClickable {
-                    if (!isSelected) {
+                    if (!isSelected && !isOptionDisabled) {
                         onAccessLevelChanged(
                             when (item) {
                                 UiInviteLinkAccess.EDITOR -> SpaceInviteLinkAccessLevel.EditorAccess.EMPTY
@@ -106,7 +112,13 @@ fun InviteLinkAccessSelector(
                     }
                 },
                 uiItemUI = item,
-                isSelected = isSelected
+                isSelected = isSelected,
+                isDisabled = isOptionDisabled,
+                descriptionOverride = if (isOptionDisabled) {
+                    stringResource(id = R.string.multiplayer_editor_access_disabled_shared)
+                } else {
+                    null
+                }
             )
             if (index < DEFAULT_OPTIONS.lastIndex) {
                 Divider(paddingStart = 16.dp, paddingEnd = 16.dp)
@@ -121,7 +133,8 @@ fun AccessLevelOption(
     uiItemUI: UiInviteLinkAccess,
     isSelected: Boolean = false,
     isCurrentUserOwner: Boolean = false,
-    isDisabled: Boolean = false
+    isDisabled: Boolean = false,
+    descriptionOverride: String? = null
 ) {
     Row(
         modifier = modifier
@@ -153,7 +166,7 @@ fun AccessLevelOption(
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = stringResource(id = uiItemUI.descRes),
+                text = descriptionOverride ?: stringResource(id = uiItemUI.descRes),
                 style = Relations2,
                 color = colorResource(id = R.color.text_secondary)
             )
@@ -188,6 +201,8 @@ fun SpaceInviteLinkAccessLevel.getInviteLinkItemParams(): UiInviteLinkAccess = w
     is SpaceInviteLinkAccessLevel.ViewerAccess -> UiInviteLinkAccess.VIEWER
     is SpaceInviteLinkAccessLevel.RequestAccess -> UiInviteLinkAccess.REQUEST
     is SpaceInviteLinkAccessLevel.LinkDisabled -> UiInviteLinkAccess.DISABLED
+    // Members with an owner-held invite never open the selector; render as disabled.
+    is SpaceInviteLinkAccessLevel.HeldByOwner -> UiInviteLinkAccess.DISABLED
 }
 
 @DefaultPreviews

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/multiplayer/ShareSpaceScreen.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/multiplayer/ShareSpaceScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -30,6 +31,8 @@ import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -121,6 +124,16 @@ fun ShareSpaceScreen(
     onInviteLinkAccessChangeConfirmed: () -> Unit,
     onInviteLinkAccessChangeCancel: () -> Unit,
 
+    shareInviteConfirmationDialog: Boolean = false,
+    onShareWithinSpaceClicked: () -> Unit = {},
+    onShareWithinSpaceConfirmed: () -> Unit = {},
+    onShareWithinSpaceCancelled: () -> Unit = {},
+
+    resetLinkConfirmationDialog: Boolean = false,
+    onResetLinkClicked: () -> Unit = {},
+    onResetLinkConfirmed: () -> Unit = {},
+    onResetLinkCancelled: () -> Unit = {},
+
     onShareInviteLinkClicked: (String) -> Unit,
     onCopyInviteLinkClicked: (String, String) -> Unit,
     onShareQrCodeClicked: (String, String) -> Unit,
@@ -184,50 +197,53 @@ fun ShareSpaceScreen(
                     Section(
                         title = stringResource(R.string.multiplayer_members_invite_links_section)
                     )
-                    val item = inviteLinkAccessLevel.getInviteLinkItemParams()
-                    val isAccessLevelDisabled =
-                        (inviteLinkAccessLevel as? SpaceInviteLinkAccessLevel.LinkDisabled)?.possibleToUpdate == false
-                    AccessLevelOption(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(end = 12.dp)
-                            .noRippleThrottledClickable {
-                                // Only owners can modify invite link access settings
-                                if (isCurrentUserOwner && !isAccessLevelDisabled) {
-                                    showInviteLinkAccessSelector = !showInviteLinkAccessSelector
-                                }
-                            },
-                        uiItemUI = item,
-                        isCurrentUserOwner = isCurrentUserOwner,
-                        isDisabled = isAccessLevelDisabled
-                    )
+                    if (inviteLinkAccessLevel is SpaceInviteLinkAccessLevel.HeldByOwner) {
+                        // The invite exists but its link syncs only to the owner's
+                        // devices — nothing to render or manage here.
+                        InviteHeldByOwnerMessage()
+                    } else {
+                        val item = inviteLinkAccessLevel.getInviteLinkItemParams()
+                        val isAccessLevelDisabled =
+                            (inviteLinkAccessLevel as? SpaceInviteLinkAccessLevel.LinkDisabled)?.possibleToUpdate == false
+                        AccessLevelOption(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(end = 12.dp)
+                                .noRippleThrottledClickable {
+                                    // Only owners can modify invite link access settings
+                                    if (isCurrentUserOwner && !isAccessLevelDisabled) {
+                                        showInviteLinkAccessSelector = !showInviteLinkAccessSelector
+                                    }
+                                },
+                            uiItemUI = item,
+                            isCurrentUserOwner = isCurrentUserOwner,
+                            isDisabled = isAccessLevelDisabled
+                        )
+                    }
                 }
 
                 item {
-                    // Show invite link and copy button when not LINK_DISABLED
-                    when (inviteLinkAccessLevel) {
-                        is SpaceInviteLinkAccessLevel.EditorAccess -> InviteLinkDisplay(
-                            link = inviteLinkAccessLevel.link,
+                    // Show invite link and copy button when there is a link to render
+                    val link = inviteLinkAccessLevel.linkOrNull
+                    if (link != null) {
+                        InviteLinkDisplay(
+                            link = link,
                             onCopyClicked = onCopyInviteLinkClicked,
                             onShareClicked = onShareInviteLinkClicked,
                             onQrCodeClicked = onShareQrCodeClicked
                         )
+                    }
+                }
 
-                        is SpaceInviteLinkAccessLevel.RequestAccess -> InviteLinkDisplay(
-                            link = inviteLinkAccessLevel.link,
-                            onCopyClicked = onCopyInviteLinkClicked,
-                            onShareClicked = onShareInviteLinkClicked,
-                            onQrCodeClicked = onShareQrCodeClicked
+                item {
+                    // Owner-only invite controls: share-within-space toggle,
+                    // safety warnings and link reset
+                    if (isCurrentUserOwner && inviteLinkAccessLevel.linkOrNull != null) {
+                        InviteOwnerControls(
+                            inviteLinkAccessLevel = inviteLinkAccessLevel,
+                            onShareWithinSpaceClicked = onShareWithinSpaceClicked,
+                            onResetLinkClicked = onResetLinkClicked
                         )
-
-                        is SpaceInviteLinkAccessLevel.ViewerAccess -> InviteLinkDisplay(
-                            link = inviteLinkAccessLevel.link,
-                            onCopyClicked = onCopyInviteLinkClicked,
-                            onShareClicked = onShareInviteLinkClicked,
-                            onQrCodeClicked = onShareQrCodeClicked
-                        )
-
-                        is SpaceInviteLinkAccessLevel.LinkDisabled -> {}
                     }
                 }
                 item {
@@ -290,7 +306,9 @@ fun ShareSpaceScreen(
                     onAccessLevelChanged = {
                         showInviteLinkAccessSelector = false
                         onInviteLinkAccessLevelSelected(it)
-                    }
+                    },
+                    // A shared invite must not grant editor access without approval
+                    isEditorOptionEnabled = !inviteLinkAccessLevel.isSharedWithinSpace
                 )
             }
         }
@@ -325,6 +343,28 @@ fun ShareSpaceScreen(
                 onConfirmed = { onMakeAdminConfirmed(makeAdminConfirmation) },
                 onCancelled = onMakeAdminCancelled,
                 onDismissRequest = onMakeAdminCancelled
+            )
+        }
+
+        // Confirmation dialog for sharing the invite within the space (one-way)
+        if (shareInviteConfirmationDialog) {
+            InviteActionConfirmationSheet(
+                title = stringResource(id = R.string.multiplayer_invite_share_confirm_title),
+                description = stringResource(id = R.string.multiplayer_invite_share_confirm_description),
+                isLoading = inviteLinkAccessLoading,
+                onConfirmed = onShareWithinSpaceConfirmed,
+                onCancelled = onShareWithinSpaceCancelled
+            )
+        }
+
+        // Confirmation dialog for resetting the invite link
+        if (resetLinkConfirmationDialog) {
+            InviteActionConfirmationSheet(
+                title = stringResource(id = R.string.multiplayer_invite_reset_confirm_title),
+                description = stringResource(id = R.string.multiplayer_invite_reset_confirm_description),
+                isLoading = inviteLinkAccessLoading,
+                onConfirmed = onResetLinkConfirmed,
+                onCancelled = onResetLinkCancelled
             )
         }
     }
@@ -391,6 +431,154 @@ private fun showConfirmScreen(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun InviteActionConfirmationSheet(
+    title: String,
+    description: String,
+    isLoading: Boolean,
+    onConfirmed: () -> Unit,
+    onCancelled: () -> Unit
+) {
+    ModalBottomSheet(
+        onDismissRequest = onCancelled,
+        containerColor = colorResource(id = R.color.background_secondary),
+        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+        dragHandle = null
+    ) {
+        GenericAlert(
+            onFirstButtonClicked = onCancelled,
+            onSecondButtonClicked = onConfirmed,
+            config = AlertConfig.WithTwoButtons(
+                title = title,
+                description = description,
+                firstButtonText = stringResource(R.string.cancel),
+                secondButtonText = stringResource(R.string.confirm),
+                firstButtonType = BUTTON_SECONDARY,
+                secondButtonType = BUTTON_PRIMARY,
+                icon = R.drawable.ic_popup_alert_56,
+                isSecondButtonLoading = isLoading,
+            )
+        )
+    }
+}
+
+/**
+ * A member's view of an invite held by the space owner: there is no link, copy
+ * button or QR code on this device, and nothing to generate.
+ */
+@Composable
+private fun InviteHeldByOwnerMessage() {
+    Text(
+        text = stringResource(id = R.string.multiplayer_invite_held_by_owner),
+        style = BodyCalloutRegular,
+        color = colorResource(id = R.color.text_secondary),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    )
+}
+
+/**
+ * Owner-only controls under the invite link:
+ * - "Everyone in the space can share this invite" toggle — off by default, one-way
+ *   (once shared it can only be undone by resetting the link) and unavailable for
+ *   a no-approval editor invite;
+ * - safety tips and the legacy-unsafe-invite warning;
+ * - the "Reset link" action.
+ */
+@Composable
+private fun InviteOwnerControls(
+    inviteLinkAccessLevel: SpaceInviteLinkAccessLevel,
+    onShareWithinSpaceClicked: () -> Unit,
+    onResetLinkClicked: () -> Unit
+) {
+    val isShared = inviteLinkAccessLevel.isSharedWithinSpace
+    val isEditor = inviteLinkAccessLevel is SpaceInviteLinkAccessLevel.EditorAccess
+    val isAutoApproval = isEditor || inviteLinkAccessLevel is SpaceInviteLinkAccessLevel.ViewerAccess
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+    ) {
+        // Share-within-space toggle
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 52.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(id = R.string.multiplayer_invite_share_toggle_title),
+                style = BodyRegular,
+                color = colorResource(id = R.color.text_primary),
+                modifier = Modifier.weight(1f)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Switch(
+                checked = isShared,
+                // One-way: a shared invite cannot be made private again, and a
+                // no-approval editor invite cannot be shared at all.
+                enabled = !isShared && !isEditor,
+                onCheckedChange = { onShareWithinSpaceClicked() },
+                colors = SwitchDefaults.colors(
+                    checkedTrackColor = colorResource(R.color.color_accent_80)
+                )
+            )
+        }
+        val toggleHint = when {
+            isShared -> stringResource(id = R.string.multiplayer_invite_share_toggle_locked_hint)
+            isEditor -> stringResource(id = R.string.multiplayer_invite_share_disabled_reason)
+            else -> null
+        }
+        if (toggleHint != null) {
+            Text(
+                text = toggleHint,
+                style = Caption1Regular,
+                color = colorResource(id = R.color.text_secondary),
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+
+        // Tips and warnings
+        val warning = when {
+            isEditor && isShared ->
+                // Legacy unsafe invite: shared + anyone-can-join + editor
+                stringResource(id = R.string.multiplayer_invite_legacy_unsafe_warning)
+            isEditor ->
+                stringResource(id = R.string.multiplayer_invite_auto_approval_warning) +
+                        "\n\n" +
+                        stringResource(id = R.string.multiplayer_invite_editor_upgrade_note)
+            isAutoApproval ->
+                stringResource(id = R.string.multiplayer_invite_auto_approval_warning)
+            else -> null
+        }
+        if (warning != null) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = warning,
+                style = Caption1Regular,
+                color = colorResource(
+                    id = if (isEditor && isShared) R.color.palette_system_red else R.color.text_secondary
+                ),
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+
+        // Reset link — the only way out of a shared invite
+        Text(
+            text = stringResource(id = R.string.multiplayer_invite_reset_link),
+            style = BodyRegular,
+            color = colorResource(id = R.color.palette_system_red),
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 44.dp)
+                .noRippleThrottledClickable { onResetLinkClicked() }
+                .padding(vertical = 12.dp)
+        )
+    }
+}
+
 @Composable
 private fun ShareSpaceHeader(
     title: String,
@@ -431,15 +619,11 @@ private fun ShareSpaceHeader(
                 contentScale = ContentScale.Inside
             )
 
-            // Dropdown menu
-            val link = when (inviteLinkAccessLevel) {
-                is SpaceInviteLinkAccessLevel.EditorAccess -> inviteLinkAccessLevel.link
-                is SpaceInviteLinkAccessLevel.RequestAccess -> inviteLinkAccessLevel.link
-                is SpaceInviteLinkAccessLevel.ViewerAccess -> inviteLinkAccessLevel.link
-                is SpaceInviteLinkAccessLevel.LinkDisabled -> ""
-            }
+            // Dropdown menu. An owner-held invite has no link on a member's
+            // device — the link actions are disabled just like with no invite.
+            val link = inviteLinkAccessLevel.linkOrNull.orEmpty()
 
-            val isLinkDisabled = inviteLinkAccessLevel is SpaceInviteLinkAccessLevel.LinkDisabled
+            val isLinkDisabled = inviteLinkAccessLevel.linkOrNull == null
 
             DropdownMenu(
                 modifier = Modifier.widthIn(min = 252.dp),

--- a/data/src/main/java/com/anytypeio/anytype/data/auth/repo/block/BlockDataRepository.kt
+++ b/data/src/main/java/com/anytypeio/anytype/data/auth/repo/block/BlockDataRepository.kt
@@ -1001,12 +1001,14 @@ class BlockDataRepository(
     override suspend fun generateSpaceInviteLink(
         space: SpaceId,
         inviteType: InviteType?,
-        permissions: SpaceMemberPermissions?
+        permissions: SpaceMemberPermissions?,
+        shareWithinSpace: Boolean
     ): SpaceInviteLink {
         return remote.generateSpaceInviteLink(
             space = space,
             inviteType = inviteType,
-            permissions = permissions
+            permissions = permissions,
+            shareWithinSpace = shareWithinSpace
         )
     }
 

--- a/data/src/main/java/com/anytypeio/anytype/data/auth/repo/block/BlockRemote.kt
+++ b/data/src/main/java/com/anytypeio/anytype/data/auth/repo/block/BlockRemote.kt
@@ -442,7 +442,8 @@ interface BlockRemote {
     suspend fun generateSpaceInviteLink(
         space: SpaceId,
         inviteType: InviteType?,
-        permissions: SpaceMemberPermissions?
+        permissions: SpaceMemberPermissions?,
+        shareWithinSpace: Boolean
     ): SpaceInviteLink
     suspend fun revokeSpaceInviteLink(space: SpaceId)
     suspend fun approveSpaceRequest(

--- a/domain/src/main/java/com/anytypeio/anytype/domain/block/repo/BlockRepository.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/block/repo/BlockRepository.kt
@@ -494,7 +494,8 @@ interface BlockRepository {
     suspend fun generateSpaceInviteLink(
         space: SpaceId,
         inviteType: InviteType?,
-        permissions: SpaceMemberPermissions?
+        permissions: SpaceMemberPermissions?,
+        shareWithinSpace: Boolean = false
     ): SpaceInviteLink
     suspend fun revokeSpaceInviteLink(space: SpaceId)
     suspend fun approveSpaceRequest(

--- a/domain/src/main/java/com/anytypeio/anytype/domain/invite/GetCurrentInviteAccessLevel.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/invite/GetCurrentInviteAccessLevel.kt
@@ -63,10 +63,22 @@ class GetCurrentInviteAccessLevel @Inject constructor(
     private fun mapInviteToAccessLevel(
         spaceInviteLink: SpaceInviteLink
     ): SpaceInviteLinkAccessLevel {
+        // A member's device gets a successful response with empty cid + key when the
+        // invite is held by the owner. There is no link to render — only the fact that
+        // an invite exists and the owner is the one to ask.
+        if (!spaceInviteLink.isLinkVisible) {
+            return if (spaceInviteLink.heldByOwner) {
+                SpaceInviteLinkAccessLevel.HeldByOwner
+            } else {
+                SpaceInviteLinkAccessLevel.LinkDisabled()
+            }
+        }
+        // The invite is shared within the space when it is not held by the owner.
+        val isShared = !spaceInviteLink.heldByOwner
         return when (spaceInviteLink.inviteType) {
             InviteType.MEMBER -> {
                 // MEMBER type = request access (manual approval)
-                SpaceInviteLinkAccessLevel.RequestAccess(spaceInviteLink.scheme)
+                SpaceInviteLinkAccessLevel.RequestAccess(spaceInviteLink.scheme, isShared)
             }
 
             InviteType.GUEST -> {
@@ -80,11 +92,13 @@ class GetCurrentInviteAccessLevel @Inject constructor(
                     SpaceMemberPermissions.OWNER,
                     SpaceMemberPermissions.WRITER,
                     SpaceMemberPermissions.ADMIN -> SpaceInviteLinkAccessLevel.EditorAccess(
-                        spaceInviteLink.scheme
+                        spaceInviteLink.scheme,
+                        isShared
                     )
 
                     SpaceMemberPermissions.READER -> SpaceInviteLinkAccessLevel.ViewerAccess(
-                        spaceInviteLink.scheme
+                        spaceInviteLink.scheme,
+                        isShared
                     )
 
                     SpaceMemberPermissions.NO_PERMISSIONS -> SpaceInviteLinkAccessLevel.LinkDisabled()

--- a/domain/src/main/java/com/anytypeio/anytype/domain/multiplayer/GenerateSpaceInviteLink.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/multiplayer/GenerateSpaceInviteLink.kt
@@ -18,13 +18,15 @@ class GenerateSpaceInviteLink @Inject constructor(
         return repo.generateSpaceInviteLink(
             space = params.space,
             inviteType = params.inviteType,
-            permissions = params.permissions
+            permissions = params.permissions,
+            shareWithinSpace = params.shareWithinSpace
         )
     }
 
     data class Params(
         val space: SpaceId,
         val inviteType: InviteType?,
-        val permissions: SpaceMemberPermissions?
+        val permissions: SpaceMemberPermissions?,
+        val shareWithinSpace: Boolean = false
     )
 }

--- a/domain/src/main/java/com/anytypeio/anytype/domain/multiplayer/GetSpaceInviteLink.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/multiplayer/GetSpaceInviteLink.kt
@@ -1,5 +1,6 @@
 package com.anytypeio.anytype.domain.multiplayer
 
+import com.anytypeio.anytype.core_models.multiplayer.SpaceInviteError
 import com.anytypeio.anytype.core_models.multiplayer.SpaceInviteLink
 import com.anytypeio.anytype.core_models.primitives.SpaceId
 import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
@@ -13,6 +14,10 @@ class GetSpaceInviteLink @Inject constructor(
 ) : ResultInteractor<SpaceId, SpaceInviteLink>(dispatchers.io) {
 
     override suspend fun doWork(params: SpaceId): SpaceInviteLink {
-        return repo.getSpaceInviteLink(spaceId = params)
+        val invite = repo.getSpaceInviteLink(spaceId = params)
+        // A member's device gets a successful response with empty cid + key when
+        // the invite is held by the owner. There is no link to hand out in that case.
+        if (!invite.isLinkVisible) throw SpaceInviteError.InviteNotActive
+        return invite
     }
 }

--- a/domain/src/test/java/com/anytypeio/anytype/domain/invite/GetCurrentInviteAccessLevelTest.kt
+++ b/domain/src/test/java/com/anytypeio/anytype/domain/invite/GetCurrentInviteAccessLevelTest.kt
@@ -1,0 +1,193 @@
+package com.anytypeio.anytype.domain.invite
+
+import com.anytypeio.anytype.core_models.CoroutineTestRule
+import com.anytypeio.anytype.core_models.multiplayer.InviteType
+import com.anytypeio.anytype.core_models.multiplayer.SpaceInviteError
+import com.anytypeio.anytype.core_models.multiplayer.SpaceInviteLink
+import com.anytypeio.anytype.core_models.multiplayer.SpaceInviteLinkAccessLevel
+import com.anytypeio.anytype.core_models.multiplayer.SpaceMemberPermissions
+import com.anytypeio.anytype.core_models.primitives.SpaceId
+import com.anytypeio.anytype.domain.block.repo.BlockRepository
+import com.anytypeio.anytype.domain.debugging.Logger
+import com.anytypeio.anytype.domain.util.dispatchers
+import com.anytypeio.anytype.test_utils.MockDataFactory
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.stub
+
+class GetCurrentInviteAccessLevelTest {
+
+    @ExperimentalCoroutinesApi
+    @get:Rule
+    var rule = CoroutineTestRule()
+
+    @Mock
+    lateinit var repo: BlockRepository
+
+    @Mock
+    lateinit var logger: Logger
+
+    private lateinit var store: SpaceInviteLinkStore
+    private lateinit var usecase: GetCurrentInviteAccessLevel
+
+    private val space = SpaceId(MockDataFactory.randomUuid())
+    private val params = GetCurrentInviteAccessLevel.Params(space = space)
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        store = SpaceInviteLinkStoreImpl()
+        usecase = GetCurrentInviteAccessLevel(
+            dispatchers = dispatchers,
+            repo = repo,
+            logger = logger,
+            store = store
+        )
+    }
+
+    private fun stubInvite(invite: SpaceInviteLink) {
+        repo.stub {
+            onBlocking { getSpaceInviteLink(space) } doReturn invite
+        }
+    }
+
+    private fun invite(
+        contentId: String = MockDataFactory.randomUuid(),
+        fileKey: String = MockDataFactory.randomUuid(),
+        inviteType: InviteType = InviteType.MEMBER,
+        permissions: SpaceMemberPermissions = SpaceMemberPermissions.READER,
+        heldByOwner: Boolean = false
+    ) = SpaceInviteLink(
+        contentId = contentId,
+        fileKey = fileKey,
+        inviteType = inviteType,
+        permissions = permissions,
+        heldByOwner = heldByOwner
+    )
+
+    @Test
+    fun `member device with owner-held invite maps to HeldByOwner`() = runBlocking {
+        // A member's InviteGetCurrent succeeds with empty cid + key
+        stubInvite(
+            invite(
+                contentId = "",
+                fileKey = "",
+                heldByOwner = true
+            )
+        )
+
+        val result = usecase.execute(params).getOrNull()
+
+        assertEquals(SpaceInviteLinkAccessLevel.HeldByOwner, result)
+        assertEquals(SpaceInviteLinkAccessLevel.HeldByOwner, store.state.value[space])
+    }
+
+    @Test
+    fun `owner device with owner-held member invite maps to RequestAccess not shared`() = runBlocking {
+        val invite = invite(inviteType = InviteType.MEMBER, heldByOwner = true)
+        stubInvite(invite)
+
+        val result = usecase.execute(params).getOrNull()
+
+        assertEquals(
+            SpaceInviteLinkAccessLevel.RequestAccess(invite.scheme, isShared = false),
+            result
+        )
+    }
+
+    @Test
+    fun `invite shared within space maps with isShared true`() = runBlocking {
+        val invite = invite(inviteType = InviteType.MEMBER, heldByOwner = false)
+        stubInvite(invite)
+
+        val result = usecase.execute(params).getOrNull()
+
+        assertEquals(
+            SpaceInviteLinkAccessLevel.RequestAccess(invite.scheme, isShared = true),
+            result
+        )
+    }
+
+    @Test
+    fun `shared anyone-can-join reader invite maps to shared ViewerAccess`() = runBlocking {
+        val invite = invite(
+            inviteType = InviteType.WITHOUT_APPROVE,
+            permissions = SpaceMemberPermissions.READER,
+            heldByOwner = false
+        )
+        stubInvite(invite)
+
+        val result = usecase.execute(params).getOrNull()
+
+        assertEquals(
+            SpaceInviteLinkAccessLevel.ViewerAccess(invite.scheme, isShared = true),
+            result
+        )
+    }
+
+    @Test
+    fun `owner-held anyone-can-join writer invite maps to EditorAccess not shared`() = runBlocking {
+        val invite = invite(
+            inviteType = InviteType.WITHOUT_APPROVE,
+            permissions = SpaceMemberPermissions.WRITER,
+            heldByOwner = true
+        )
+        stubInvite(invite)
+
+        val result = usecase.execute(params).getOrNull()
+
+        assertEquals(
+            SpaceInviteLinkAccessLevel.EditorAccess(invite.scheme, isShared = false),
+            result
+        )
+    }
+
+    @Test
+    fun `legacy unsafe invite - shared anyone-can-join writer - maps to shared EditorAccess`() = runBlocking {
+        // The exact state that triggers the red legacy warning and the Editor lockout
+        val invite = invite(
+            inviteType = InviteType.WITHOUT_APPROVE,
+            permissions = SpaceMemberPermissions.WRITER,
+            heldByOwner = false
+        )
+        stubInvite(invite)
+
+        val result = usecase.execute(params).getOrNull()
+
+        assertEquals(
+            SpaceInviteLinkAccessLevel.EditorAccess(invite.scheme, isShared = true),
+            result
+        )
+    }
+
+    @Test
+    fun `guest invite maps to LinkDisabled`() = runBlocking {
+        stubInvite(invite(inviteType = InviteType.GUEST))
+
+        val result = usecase.execute(params).getOrNull()
+
+        assertEquals(SpaceInviteLinkAccessLevel.LinkDisabled(), result)
+    }
+
+    @Test
+    fun `no active invite maps to LinkDisabled`() = runBlocking {
+        repo.stub {
+            onBlocking { getSpaceInviteLink(space) } doAnswer {
+                throw SpaceInviteError.InviteNotActive
+            }
+        }
+
+        val result = usecase.execute(params).getOrNull()
+
+        assertEquals(SpaceInviteLinkAccessLevel.LinkDisabled(), result)
+        assertEquals(SpaceInviteLinkAccessLevel.LinkDisabled(), store.state.value[space])
+    }
+}

--- a/domain/src/test/java/com/anytypeio/anytype/domain/multiplayer/GetSpaceInviteLinkTest.kt
+++ b/domain/src/test/java/com/anytypeio/anytype/domain/multiplayer/GetSpaceInviteLinkTest.kt
@@ -1,0 +1,98 @@
+package com.anytypeio.anytype.domain.multiplayer
+
+import com.anytypeio.anytype.core_models.CoroutineTestRule
+import com.anytypeio.anytype.core_models.multiplayer.InviteType
+import com.anytypeio.anytype.core_models.multiplayer.SpaceInviteError
+import com.anytypeio.anytype.core_models.multiplayer.SpaceInviteLink
+import com.anytypeio.anytype.core_models.multiplayer.SpaceMemberPermissions
+import com.anytypeio.anytype.core_models.primitives.SpaceId
+import com.anytypeio.anytype.domain.block.repo.BlockRepository
+import com.anytypeio.anytype.domain.util.dispatchers
+import com.anytypeio.anytype.test_utils.MockDataFactory
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.stub
+
+class GetSpaceInviteLinkTest {
+
+    @ExperimentalCoroutinesApi
+    @get:Rule
+    var rule = CoroutineTestRule()
+
+    @Mock
+    lateinit var repo: BlockRepository
+
+    private lateinit var usecase: GetSpaceInviteLink
+
+    private val space = SpaceId(MockDataFactory.randomUuid())
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        usecase = GetSpaceInviteLink(repo = repo, dispatchers = dispatchers)
+    }
+
+    @Test
+    fun `returns invite when link is visible`() = runBlocking {
+        val invite = SpaceInviteLink(
+            contentId = MockDataFactory.randomUuid(),
+            fileKey = MockDataFactory.randomUuid(),
+            inviteType = InviteType.MEMBER,
+            permissions = SpaceMemberPermissions.READER
+        )
+        repo.stub {
+            onBlocking { getSpaceInviteLink(space) } doReturn invite
+        }
+
+        val result = usecase.execute(space).getOrNull()
+
+        assertEquals(invite, result)
+    }
+
+    @Test
+    fun `fails with InviteNotActive when invite is held by owner and cid is empty`() = runBlocking {
+        // A member's device receives a successful response with empty cid + key —
+        // there is no link to hand out, so consumers must treat it as no invite.
+        repo.stub {
+            onBlocking { getSpaceInviteLink(space) } doReturn SpaceInviteLink(
+                contentId = "",
+                fileKey = "",
+                inviteType = InviteType.MEMBER,
+                permissions = SpaceMemberPermissions.READER,
+                heldByOwner = true
+            )
+        }
+
+        val result = usecase.execute(space)
+
+        assertNull(result.getOrNull())
+        assertTrue(result.exceptionOrNull() is SpaceInviteError.InviteNotActive)
+    }
+
+    @Test
+    fun `fails with InviteNotActive when cid is empty even if not held by owner`() = runBlocking {
+        repo.stub {
+            onBlocking { getSpaceInviteLink(space) } doReturn SpaceInviteLink(
+                contentId = "",
+                fileKey = "",
+                inviteType = InviteType.MEMBER,
+                permissions = SpaceMemberPermissions.READER,
+                heldByOwner = false
+            )
+        }
+
+        val result = usecase.execute(space)
+
+        assertNull(result.getOrNull())
+        assertTrue(result.exceptionOrNull() is SpaceInviteError.InviteNotActive)
+    }
+}

--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/presentation/ChatViewModel.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/presentation/ChatViewModel.kt
@@ -2427,7 +2427,8 @@ class ChatViewModel @Inject constructor(
             is SpaceInviteLinkAccessLevel.EditorAccess -> proceedWithShowingQRCode(inviteLinkState.link)
             is SpaceInviteLinkAccessLevel.RequestAccess -> proceedWithShowingQRCode(inviteLinkState.link)
             is SpaceInviteLinkAccessLevel.ViewerAccess -> proceedWithShowingQRCode(inviteLinkState.link)
-            is SpaceInviteLinkAccessLevel.LinkDisabled -> {
+            is SpaceInviteLinkAccessLevel.LinkDisabled,
+            is SpaceInviteLinkAccessLevel.HeldByOwner -> {
                 Timber.w("Invite link is not ready yet")
                 sendToast("Invite link is not available")
                 return

--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/Misc.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/Misc.kt
@@ -89,7 +89,7 @@ internal fun EmptyState(
                         modifier = Modifier
                     )
                 }
-                if (inviteLinkAccessLevel !is SpaceInviteLinkAccessLevel.LinkDisabled) {
+                if (inviteLinkAccessLevel.linkOrNull != null) {
                     ButtonPrimary(
                         text = stringResource(R.string.chat_empty_state_show_qr_button),
                         onClick = onShowQRCodeClick,

--- a/localization/src/main/res/values/strings.xml
+++ b/localization/src/main/res/values/strings.xml
@@ -1531,6 +1531,20 @@
     <string name="multiplayer_change_to_viewer_confirmation">Anyone with the link will only be able to view the space content.</string>
     <string name="multiplayer_change_to_request_confirmation">Anyone with the link will need to request access to join the space.</string>
     <string name="multiplayer_invite_link_copied">Invite link copied to clipboard</string>
+    <!-- Invite sharing (GO-7222): owner-held invites, share-within-space toggle, link reset -->
+    <string name="multiplayer_invite_share_toggle_title">Everyone in the space can share this invite</string>
+    <string name="multiplayer_invite_share_toggle_locked_hint">To make this invite private again, reset the link.</string>
+    <string name="multiplayer_invite_share_disabled_reason">Anyone with this link joins as an editor, without approval. Only you can share it.</string>
+    <string name="multiplayer_invite_share_confirm_title">Share invite with all members?</string>
+    <string name="multiplayer_invite_share_confirm_description">All space members will be able to see this invite link and share it with anyone. To make it private again, you\'ll need to reset the link.</string>
+    <string name="multiplayer_invite_auto_approval_warning">Anyone who gains access to this invitation link will be able to join this space at any time, until you reset the link.</string>
+    <string name="multiplayer_invite_editor_upgrade_note">Any existing Viewer who gains access to this invitation link can use it to upgrade themselves to Editor.</string>
+    <string name="multiplayer_invite_legacy_unsafe_warning">Every member of this space can see and share this invite link, and anyone who has it joins as an editor without approval. Any existing Viewer can use it to upgrade themselves to Editor.</string>
+    <string name="multiplayer_invite_held_by_owner">The invite link is held by the space owner. Ask them to share it.</string>
+    <string name="multiplayer_invite_reset_link">Reset link</string>
+    <string name="multiplayer_invite_reset_confirm_title">Reset invite link?</string>
+    <string name="multiplayer_invite_reset_confirm_description">The current link stops working for everyone who has it, including the people you meant to invite. A new link is created in its place.</string>
+    <string name="multiplayer_editor_access_disabled_shared">Unavailable while everyone in the space can share this invite. Reset the link first.</string>
     <string name="link_copied">Link copied to clipboard</string>
     <string name="remove_from_collection">Unlink from Collection</string>
     <string name="multiplayer_copy_link">Copy link</string>
@@ -2436,6 +2450,8 @@
     <string name="share_space_error_make_private_failed">
         Failed to make the space private. Please try again later.
     </string>
+    <string name="share_space_error_invite_already_shared">This invite is already shared with all space members and cannot be made private. Reset the link to create a new private invite.</string>
+    <string name="share_space_error_invite_not_shareable">Anyone with this link joins as an editor, without approval. Switch the link to Viewer access before sharing it.</string>
     <string name="private_local_yours_forever">encrypted, local, yours forever</string>
     <string name="private_channel">Direct channel</string>
     <string name="space_header_private_channel">Private channel</string>

--- a/middleware/src/main/java/com/anytypeio/anytype/middleware/block/BlockMiddleware.kt
+++ b/middleware/src/main/java/com/anytypeio/anytype/middleware/block/BlockMiddleware.kt
@@ -966,12 +966,14 @@ class BlockMiddleware(
     override suspend fun generateSpaceInviteLink(
         space: SpaceId,
         inviteType: InviteType?,
-        permissions: SpaceMemberPermissions?
+        permissions: SpaceMemberPermissions?,
+        shareWithinSpace: Boolean
     ): SpaceInviteLink {
         return middleware.generateSpaceInviteLink(
             space = space,
             inviteType = inviteType,
-            permissions = permissions
+            permissions = permissions,
+            shareWithinSpace = shareWithinSpace
         )
     }
 

--- a/middleware/src/main/java/com/anytypeio/anytype/middleware/interactor/Middleware.kt
+++ b/middleware/src/main/java/com/anytypeio/anytype/middleware/interactor/Middleware.kt
@@ -2628,29 +2628,17 @@ class Middleware @Inject constructor(
     fun generateSpaceInviteLink(
         space: SpaceId,
         inviteType: InviteType?,
-        permissions: SpaceMemberPermissions?
+        permissions: SpaceMemberPermissions?,
+        shareWithinSpace: Boolean
     ): SpaceInviteLink {
-        val request = if (inviteType != null && permissions != null) {
-            Rpc.Space.InviteGenerate.Request(
-                spaceId = space.id,
-                inviteType = inviteType.toMiddleware(),
-                permissions = permissions.toMw()
-            )
-        } else if (inviteType != null) {
-            Rpc.Space.InviteGenerate.Request(
-                spaceId = space.id,
-                inviteType = inviteType.toMiddleware()
-            )
-        } else if (permissions != null) {
-            Rpc.Space.InviteGenerate.Request(
-                spaceId = space.id,
-                permissions = permissions.toMw()
-            )
-        } else {
-            Rpc.Space.InviteGenerate.Request(
-                spaceId = space.id
-            )
-        }
+        // Proto3 omits fields set to their default value, so passing the defaults
+        // for null inviteType/permissions is equivalent to not setting them.
+        val request = Rpc.Space.InviteGenerate.Request(
+            spaceId = space.id,
+            inviteType = inviteType?.toMiddleware() ?: anytype.model.InviteType.Member,
+            permissions = permissions?.toMw() ?: anytype.model.ParticipantPermissions.Reader,
+            shareWithinSpace = shareWithinSpace
+        )
 
         logRequestIfDebug(request)
         val (response, time) = measureTimedValue { service.spaceInviteGenerate(request) }
@@ -2816,7 +2804,8 @@ class Middleware @Inject constructor(
             fileKey = response.inviteFileKey,
             contentId = response.inviteCid,
             permissions = response.permissions.toCore(),
-            inviteType = response.inviteType.toCoreModel()
+            inviteType = response.inviteType.toCoreModel(),
+            heldByOwner = response.heldByOwner
         )
     }
 

--- a/middleware/src/main/java/com/anytypeio/anytype/middleware/service/MiddlewareServiceImplementation.kt
+++ b/middleware/src/main/java/com/anytypeio/anytype/middleware/service/MiddlewareServiceImplementation.kt
@@ -2031,6 +2031,12 @@ class MiddlewareServiceImplementation @Inject constructor(
                 Rpc.Space.InviteGenerate.Response.Error.Code.REQUEST_FAILED -> {
                     throw MultiplayerError.Generic.RequestFailed()
                 }
+                Rpc.Space.InviteGenerate.Response.Error.Code.INVITE_ALREADY_SHARED -> {
+                    throw MultiplayerError.Generic.InviteAlreadyShared()
+                }
+                Rpc.Space.InviteGenerate.Response.Error.Code.INVITE_NOT_SHAREABLE -> {
+                    throw MultiplayerError.Generic.InviteNotShareable()
+                }
                 else -> throw Exception(error.description)
             }
         } else {
@@ -3017,6 +3023,9 @@ class MiddlewareServiceImplementation @Inject constructor(
                 }
                 Rpc.Space.InviteChange.Response.Error.Code.REQUEST_FAILED -> {
                     throw MultiplayerError.Generic.RequestFailed()
+                }
+                Rpc.Space.InviteChange.Response.Error.Code.INVITE_NOT_SHAREABLE -> {
+                    throw MultiplayerError.Generic.InviteNotShareable()
                 }
                 else -> throw Exception(error.description)
             }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/multiplayer/ShareSpaceViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/multiplayer/ShareSpaceViewModel.kt
@@ -118,6 +118,10 @@ class ShareSpaceViewModel(
     val inviteLinkAccessLevel = MutableStateFlow<SpaceInviteLinkAccessLevel>(SpaceInviteLinkAccessLevel.LinkDisabled())
     val inviteLinkAccessLoading = MutableStateFlow(false)
     val inviteLinkConfirmationDialog = MutableStateFlow<SpaceInviteLinkAccessLevel?>(null)
+    // "Everyone in the space can share this invite" confirmation (one-way action)
+    val shareInviteConfirmationDialog = MutableStateFlow(false)
+    // Reset link confirmation: revoke + regenerate, old link stops working for everyone
+    val resetLinkConfirmationDialog = MutableStateFlow(false)
     val spaceAccessType = MutableStateFlow<SpaceAccessType?>(null)
     val isMakePrivateEnabled = MutableStateFlow(false)
 
@@ -278,24 +282,31 @@ class ShareSpaceViewModel(
     }
 
     private suspend fun generateInviteLink(
-        inviteType: InviteType? = null,
-        permissions: SpaceMemberPermissions? = null
+        inviteType: InviteType = InviteType.MEMBER,
+        permissions: SpaceMemberPermissions = SpaceMemberPermissions.READER,
+        shareWithinSpace: Boolean = false,
+        isNewLink: Boolean = true
     ) {
         generateSpaceInviteLink.async(
             params = GenerateSpaceInviteLink.Params(
                 space = vmParams.space,
                 inviteType = inviteType,
-                permissions = permissions
+                permissions = permissions,
+                shareWithinSpace = shareWithinSpace
             )
         ).fold(
             onSuccess = { inviteLink ->
                 Timber.d("Successfully generated invite link, link: ${inviteLink.scheme}")
 
-                // Analytics Event #1: ClickShareSpaceNewLink with type property
-                analytics.sendAnalyticsShareSpaceNewLink(
-                    inviteType = inviteType,
-                    permissions = permissions
-                )
+                // Analytics Event #1: ClickShareSpaceNewLink with type property.
+                // Skipped when the call merely re-publishes the existing invite
+                // (share-within-space): same cid, same key — no new link.
+                if (isNewLink) {
+                    analytics.sendAnalyticsShareSpaceNewLink(
+                        inviteType = inviteType,
+                        permissions = permissions
+                    )
+                }
 
                 proceedWithRequestCurrentInviteLink()
                 // Reset loading state and close confirmation dialog after successful generation
@@ -583,6 +594,13 @@ class ShareSpaceViewModel(
     fun onInviteLinkAccessLevelSelected(newLevel: SpaceInviteLinkAccessLevel) {
         val currentLevel = inviteLinkAccessLevel.value
         Timber.d("onInviteLinkAccessLevelSelected, new level: $newLevel, current level: $currentLevel")
+        // A shared invite must not grant editor access without approval — mirror
+        // the middleware's INVITE_NOT_SHAREABLE so the UI never promises what
+        // the server refuses. The selector disables the option; this is a guard.
+        if (newLevel is SpaceInviteLinkAccessLevel.EditorAccess && currentLevel.isSharedWithinSpace) {
+            shareSpaceErrors.value = ShareSpaceErrors.InviteNotShareable
+            return
+        }
         if (currentLevel.needsConfirmationToChangeTo(newLevel)) {
             inviteLinkConfirmationDialog.value = newLevel
         } else {
@@ -697,8 +715,32 @@ class ShareSpaceViewModel(
         inviteLinkAccessLoading.value = true
         val currentLevel = inviteLinkAccessLevel.value
         val space = vmParams.space
+        // Once an invite is shared within the space, regenerations keep it shared —
+        // asking for shareWithinSpace = false on a shared invite is refused by
+        // the middleware (INVITE_ALREADY_SHARED). The only way back is a link reset.
+        val wasShared = currentLevel.isSharedWithinSpace
+
+        // Re-check at execution time (not only at selection time): the invite may
+        // have become shared between selection and confirmation. Bailing out here
+        // prevents revoking a live shared invite only to have the follow-up editor
+        // generate rejected with INVITE_NOT_SHAREABLE — which would leave the space
+        // with no invite at all.
+        if (newLevel is SpaceInviteLinkAccessLevel.EditorAccess && wasShared) {
+            inviteLinkAccessLoading.value = false
+            inviteLinkConfirmationDialog.value = null
+            shareSpaceErrors.value = ShareSpaceErrors.InviteNotShareable
+            return
+        }
 
         when (newLevel) {
+
+            is SpaceInviteLinkAccessLevel.HeldByOwner -> {
+                // Never a selection target — only owners manage the invite,
+                // and on the owner's device the link is always visible.
+                inviteLinkAccessLoading.value = false
+                inviteLinkConfirmationDialog.value = null
+                return
+            }
 
             is SpaceInviteLinkAccessLevel.LinkDisabled -> {
                 revokeSpaceInviteLink.async(space).fold(
@@ -725,8 +767,9 @@ class ShareSpaceViewModel(
                         )
                     }
 
-                    is SpaceInviteLinkAccessLevel.EditorAccess -> {
-                        Timber.d("Invite link already has EDITOR access")
+                    is SpaceInviteLinkAccessLevel.EditorAccess,
+                    is SpaceInviteLinkAccessLevel.HeldByOwner -> {
+                        Timber.d("Invite link already has EDITOR access or is not manageable")
                         inviteLinkAccessLoading.value = false
                         inviteLinkConfirmationDialog.value = null
                         return
@@ -752,9 +795,12 @@ class ShareSpaceViewModel(
                         revokeSpaceInviteLink.async(space).fold(
                             onSuccess = {
                                 Timber.d("Successfully revoked invite link for REQUEST_ACCESS")
+                                // An editor invite can never be shared within the space —
+                                // always regenerate it owner-held.
                                 generateInviteLink(
                                     inviteType = InviteType.WITHOUT_APPROVE,
-                                    permissions = SpaceMemberPermissions.WRITER
+                                    permissions = SpaceMemberPermissions.WRITER,
+                                    shareWithinSpace = false
                                 )
                             },
                             onFailure = {
@@ -792,8 +838,9 @@ class ShareSpaceViewModel(
                         )
                     }
 
-                    is SpaceInviteLinkAccessLevel.ViewerAccess -> {
-                        Timber.d("Invite link already has VIEWER access")
+                    is SpaceInviteLinkAccessLevel.ViewerAccess,
+                    is SpaceInviteLinkAccessLevel.HeldByOwner -> {
+                        Timber.d("Invite link already has VIEWER access or is not manageable")
                         inviteLinkAccessLoading.value = false
                         inviteLinkConfirmationDialog.value = null
                         return
@@ -805,7 +852,8 @@ class ShareSpaceViewModel(
                                 Timber.d("Successfully revoked invite link for REQUEST_ACCESS")
                                 generateInviteLink(
                                     inviteType = InviteType.WITHOUT_APPROVE,
-                                    permissions = SpaceMemberPermissions.READER
+                                    permissions = SpaceMemberPermissions.READER,
+                                    shareWithinSpace = wasShared
                                 )
                             },
                             onFailure = {
@@ -824,16 +872,14 @@ class ShareSpaceViewModel(
                         generateInviteLink()
                     }
 
-                    is SpaceInviteLinkAccessLevel.EditorAccess -> {
-                        generateInviteLink()
-                    }
-
+                    is SpaceInviteLinkAccessLevel.EditorAccess,
                     is SpaceInviteLinkAccessLevel.ViewerAccess -> {
-                        generateInviteLink()
+                        generateInviteLink(shareWithinSpace = wasShared)
                     }
 
-                    is SpaceInviteLinkAccessLevel.RequestAccess -> {
-                        Timber.d("Invite link already has REQUEST_ACCESS")
+                    is SpaceInviteLinkAccessLevel.RequestAccess,
+                    is SpaceInviteLinkAccessLevel.HeldByOwner -> {
+                        Timber.d("Invite link already has REQUEST_ACCESS or is not manageable")
                         inviteLinkAccessLoading.value = false
                         inviteLinkConfirmationDialog.value = null
                         return
@@ -863,6 +909,9 @@ class ShareSpaceViewModel(
                     SpaceMemberPermissions.NO_PERMISSIONS
 
                 is SpaceInviteLinkAccessLevel.RequestAccess ->
+                    SpaceMemberPermissions.NO_PERMISSIONS
+
+                is SpaceInviteLinkAccessLevel.HeldByOwner ->
                     SpaceMemberPermissions.NO_PERMISSIONS
 
                 is SpaceInviteLinkAccessLevel.ViewerAccess ->
@@ -901,6 +950,118 @@ class ShareSpaceViewModel(
     private suspend fun proceedWithRequestCurrentInviteLink() {
         val params = GetCurrentInviteAccessLevel.Params(space = vmParams.space)
         getCurrentInviteAccessLevel.async(params).getOrNull()
+    }
+
+    /**
+     * Owner tapped the "Everyone in the space can share this invite" toggle.
+     * Sharing is one-way and needs an explicit confirmation; a no-approval editor
+     * invite cannot be shared at all (the switch is disabled in the UI).
+     */
+    fun onShareWithinSpaceClicked() {
+        val current = inviteLinkAccessLevel.value
+        Timber.d("onShareWithinSpaceClicked, current level: $current")
+        if (inviteLinkAccessLoading.value) return
+        when {
+            current.isSharedWithinSpace -> {
+                // One-way: a shared invite cannot be taken back — the switch is locked.
+                return
+            }
+            current is SpaceInviteLinkAccessLevel.EditorAccess -> {
+                // Anyone with such a link joins as an editor, without approval —
+                // only the owner may share it. The switch is disabled with a reason.
+                return
+            }
+            current is SpaceInviteLinkAccessLevel.ViewerAccess ||
+                    current is SpaceInviteLinkAccessLevel.RequestAccess -> {
+                shareInviteConfirmationDialog.value = true
+            }
+            else -> return
+        }
+    }
+
+    fun onShareWithinSpaceConfirmed() {
+        val current = inviteLinkAccessLevel.value
+        Timber.d("onShareWithinSpaceConfirmed, current level: $current")
+        val (inviteType, permissions) = when (current) {
+            is SpaceInviteLinkAccessLevel.ViewerAccess ->
+                InviteType.WITHOUT_APPROVE to SpaceMemberPermissions.READER
+            is SpaceInviteLinkAccessLevel.RequestAccess ->
+                InviteType.MEMBER to SpaceMemberPermissions.READER
+            else -> {
+                shareInviteConfirmationDialog.value = false
+                return
+            }
+        }
+        viewModelScope.launch {
+            // Keep the confirmation sheet open with a loading indicator until the
+            // request completes (same pattern as the make-admin confirmation).
+            inviteLinkAccessLoading.value = true
+            // Publishes the very same invite — same cid, same key. No new link is created.
+            generateInviteLink(
+                inviteType = inviteType,
+                permissions = permissions,
+                shareWithinSpace = true,
+                isNewLink = false
+            )
+            shareInviteConfirmationDialog.value = false
+        }
+    }
+
+    fun onShareWithinSpaceCancelled() {
+        shareInviteConfirmationDialog.value = false
+    }
+
+    /**
+     * Reset link: revoke, then generate a new invite of the same type and permissions
+     * with shareWithinSpace = false. The old link stops working for everyone holding it.
+     * This is the only way out of a shared invite.
+     */
+    fun onResetLinkClicked() {
+        Timber.d("onResetLinkClicked")
+        if (inviteLinkAccessLoading.value) return
+        resetLinkConfirmationDialog.value = true
+    }
+
+    fun onResetLinkCancelled() {
+        resetLinkConfirmationDialog.value = false
+    }
+
+    fun onResetLinkConfirmed() {
+        val current = inviteLinkAccessLevel.value
+        Timber.d("onResetLinkConfirmed, current level: $current")
+        val (inviteType, permissions) = when (current) {
+            is SpaceInviteLinkAccessLevel.EditorAccess ->
+                InviteType.WITHOUT_APPROVE to SpaceMemberPermissions.WRITER
+            is SpaceInviteLinkAccessLevel.ViewerAccess ->
+                InviteType.WITHOUT_APPROVE to SpaceMemberPermissions.READER
+            is SpaceInviteLinkAccessLevel.RequestAccess ->
+                InviteType.MEMBER to SpaceMemberPermissions.READER
+            else -> {
+                resetLinkConfirmationDialog.value = false
+                return
+            }
+        }
+        viewModelScope.launch {
+            // Keep the confirmation sheet open with a loading indicator until the
+            // revoke + regenerate round-trip completes.
+            inviteLinkAccessLoading.value = true
+            revokeSpaceInviteLink.async(vmParams.space).fold(
+                onSuccess = {
+                    Timber.d("Successfully revoked invite link on reset")
+                    generateInviteLink(
+                        inviteType = inviteType,
+                        permissions = permissions,
+                        shareWithinSpace = false
+                    )
+                },
+                onFailure = {
+                    Timber.e(it, "Failed to revoke invite link on reset")
+                    inviteLinkAccessLoading.value = false
+                    proceedWithMultiplayerError(it)
+                }
+            )
+            resetLinkConfirmationDialog.value = false
+        }
     }
 
     //endregion
@@ -942,6 +1103,14 @@ class ShareSpaceViewModel(
 
                 is MultiplayerError.Generic.NoSuchSpace -> {
                     shareSpaceErrors.value = ShareSpaceErrors.NoSuchSpace
+                }
+
+                is MultiplayerError.Generic.InviteAlreadyShared -> {
+                    shareSpaceErrors.value = ShareSpaceErrors.InviteAlreadyShared
+                }
+
+                is MultiplayerError.Generic.InviteNotShareable -> {
+                    shareSpaceErrors.value = ShareSpaceErrors.InviteNotShareable
                 }
             }
         } else {
@@ -1353,6 +1522,18 @@ sealed class ShareSpaceErrors {
     data object IncorrectPermissions : ShareSpaceErrors()
     data object NoSuchSpace : ShareSpaceErrors()
     data object MakePrivateFailed : ShareSpaceErrors()
+
+    /**
+     * The current invite is already shared within the space and cannot be taken
+     * back into the owner's account. The only way out is a link reset.
+     */
+    data object InviteAlreadyShared : ShareSpaceErrors()
+
+    /**
+     * The invite lets anyone join with editor access without approval,
+     * so it cannot be shared within the space.
+     */
+    data object InviteNotShareable : ShareSpaceErrors()
     data class Error(val msg: String) : ShareSpaceErrors()
 }
 

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/spaces/CreateSpaceViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/spaces/CreateSpaceViewModel.kt
@@ -494,7 +494,11 @@ class CreateSpaceViewModel(
     )
 
     companion object {
-        private val CHAT_SPACE_INVITE_TYPE = InviteType.WITHOUT_APPROVE
-        private val CHAT_SPACE_DEFAULT_PERMISSIONS = SpaceMemberPermissions.WRITER
+        // Request-to-join is the default everywhere an invite is generated:
+        // members picked during space creation are added directly via
+        // addSpaceMembers and do not need an open invite. The invite left
+        // behind must never be a no-approval editor link.
+        private val CHAT_SPACE_INVITE_TYPE = InviteType.MEMBER
+        private val CHAT_SPACE_DEFAULT_PERMISSIONS = SpaceMemberPermissions.READER
     }
 }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/spaces/SpaceSettingsViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/spaces/SpaceSettingsViewModel.kt
@@ -533,7 +533,10 @@ class SpaceSettingsViewModel(
                                 )
                             }
 
-                            is SpaceInviteLinkAccessLevel.LinkDisabled -> {
+                            is SpaceInviteLinkAccessLevel.LinkDisabled,
+                            is SpaceInviteLinkAccessLevel.HeldByOwner -> {
+                                // Held-by-owner: the invite exists, but this member's
+                                // device has no link to show — same as no link here.
                                 add(UiSpaceSettingsItem.Section.Collaboration)
                                 add(
                                     Members(

--- a/protocol/src/main/proto/commands.proto
+++ b/protocol/src/main/proto/commands.proto
@@ -164,6 +164,7 @@ message Rpc {
                         SPACE_IS_DELETED = 102;
                         REQUEST_FAILED = 103;
                         INCORRECT_PERMISSIONS = 105;
+                        INVITE_NOT_SHAREABLE = 107;
                     }
                 }
             }
@@ -174,6 +175,7 @@ message Rpc {
                 string spaceId = 1;
                 model.InviteType inviteType = 2;
                 model.ParticipantPermissions permissions = 3;
+                bool shareWithinSpace = 4;
             }
 
             message Response {
@@ -197,6 +199,8 @@ message Rpc {
                         REQUEST_FAILED = 103;
                         LIMIT_REACHED = 104;
                         NOT_SHAREABLE = 105;
+                        INVITE_ALREADY_SHARED = 106;
+                        INVITE_NOT_SHAREABLE = 107;
                     }
                 }
             }
@@ -239,6 +243,7 @@ message Rpc {
                 string inviteFileKey = 3;
                 model.InviteType inviteType = 4;
                 model.ParticipantPermissions permissions = 5;
+                bool heldByOwner = 6;
 
                 message Error {
                     Code code = 1;


### PR DESCRIPTION
Implements the mobile side of the invite-sharing redesign (middleware GO-7222, spec: `InviteSharing-mobile.md`; desktop reference: anytype-ts JS-9795). No UI redesign — behavioral and copy changes layered onto the existing invite screens.

## What changed

An invite is now **held by the owner** by default instead of being written into the workspace object. A member's `InviteGetCurrent` succeeds with an **empty cid** and `heldByOwner: true`. Owners opt into the old behavior with the new `shareWithinSpace` flag (one-way; blocked for no-approval editor invites).

### Protocol / data plumbing
- `commands.proto`: `InviteGenerate.Request.shareWithinSpace` (field 4), `InviteGetCurrent.Response.heldByOwner` (field 6), error codes `INVITE_ALREADY_SHARED = 106` / `INVITE_NOT_SHAREABLE = 107` (verified byte-for-byte against anytype-heart `develop`).
- `shareWithinSpace` threaded through `GenerateSpaceInviteLink` → `BlockRepository` → … → `Middleware`; new error codes mapped to `MultiplayerError.Generic.InviteAlreadyShared` / `InviteNotShareable`.

> ⚠️ **Middleware dependency**: GO-7222 is on heart `develop` (nightlies ≥ `v0.50.16-nightly.20260711.1`); the `middlewareVersion` bump lands separately after the next heart release. Everything was compiled and tested against `v0.50.16-nightly.20260716.1` locally. Until the bump, the embedded `v0.50.12` never sets `heldByOwner`, so active invites resolve as **shared** (legacy view): the share toggle renders on+locked and Editor access is not selectable — release only together with the middleware bump.

### Domain
- `SpaceInviteLink` gains `heldByOwner` + `isLinkVisible`; `SpaceInviteLinkAccessLevel` active variants gain `isShared`, plus new `HeldByOwner` variant (member view: invite exists, no link).
- `GetCurrentInviteAccessLevel` maps empty-cid + heldByOwner → `HeldByOwner`; `GetSpaceInviteLink` now fails with `InviteNotActive` when there is no visible link, so no consumer (Home, ObjectMenu, Chat, SpaceSettings) can ever render `https://invite.any.coop/#`.

### Behavior (ShareSpaceViewModel + screens)
- **Request-to-join is the default**: every generate call site sends `MEMBER` + `READER` + `shareWithinSpace: false` (incl. chat-space creation, previously `WITHOUT_APPROVE` + `WRITER`).
- **Share toggle** "Everyone in the space can share this invite" — off by default, confirmation before enabling, locked once shared (points at reset), disabled with a reason for no-approval editor invites. Regenerations preserve the current shared state.
- **Editor access blocked on a shared invite** (selector option disabled + VM guard, mirroring `INVITE_NOT_SHAREABLE`), re-checked at execution time so a live shared invite is never revoked ahead of a doomed editor generate.
- **Reset link** — confirmation, then revoke + regenerate same type/permissions with `shareWithinSpace: false`. The only way out of a shared invite.
- **Member view**: when the invite is held by the owner — no link, no copy/share/QR, message "The invite link is held by the space owner…". Applies to admins too.
- **Tips/warnings** per spec: auto-approval warning, editor-upgrade note, legacy-unsafe-invite warning (shared + anyone-can-join + editor) with Reset link.
- Invite management stays owner-only (gated on `isOwner`, admins keep member management).

### Backward compat
Invites created before this change resolve as shared (`heldByOwner: false`) and keep working; nothing migrates.

## Review
Reviewed by a Fable agent against the spec; fixed: middleware version gap (critical), revoke-before-rejected-generate window on `RequestAccess(shared) → Editor` (major), confirmation-sheet loading/reentrancy, empty-link edge in `linkOrNull`, share-within-space analytics overcount, extra test coverage.

Known limitations (documented, not fixed): share/reset derive type+permissions from the access level (all app-generated invites match; an exotic `WITHOUT_APPROVE`+`ADMIN` invite would reset to `WRITER`); new strings are English-only pending the standard l10n flow.

## Testing
- New unit tests: `GetCurrentInviteAccessLevelTest` (8 cases incl. member/owner × held/shared matrix, legacy-unsafe, GUEST), `GetSpaceInviteLinkTest` (3 cases).
- Full `:domain` suite, `CreateSpaceViewModelTest`, `HomeScreenViewModelTest` green; all affected modules compile (`:protocol` … `:app`).

https://claude.ai/code/session_017EfaZToKK4U21A3m78LQH6