### PR TITLE
DROID-4551 Editor | Fix | Make URL-paste action-mode paths placeholder/fork-aware

### DIFF
--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
@@ -766,8 +766,16 @@ class EditorViewModel(
     private fun applyLinkMarkup(
         blockId: String, link: String, range: IntRange
     ) {
-        val targetBlock = blocks.first { it.id == blockId }
-        val targetContent = targetBlock.content as Content.Text
+        val targetBlock = blocks.find { it.id == blockId }
+        if (targetBlock == null) {
+            Timber.w("Can't find target block to apply link markup: $blockId")
+            return
+        }
+        val targetContent = targetBlock.content as? Content.Text
+        if (targetContent == null) {
+            Timber.w("Can't apply link markup to a non-text block: $blockId")
+            return
+        }
         val linkMark = Content.Text.Mark(
             type = Content.Text.Mark.Type.LINK,
             range = IntRange(start = range.first, endInclusive = range.last.inc()),
@@ -4887,6 +4895,17 @@ class EditorViewModel(
             }
             focused = lastMaterializedTrailingBlock ?: return
         }
+        val fork = identityFork
+        if (fork != null && focused == fork.oldId) {
+            // Replace in flight — replay the paste against the forked block.
+            fork.onForked += { onPaste(range) }
+            return
+        }
+        val redirected = focused?.let { forkRedirectOrNull(it) }
+        if (redirected != null) {
+            // Dispatched against the pre-fork id after the swap — retarget.
+            focused = redirected
+        }
         viewModelScope.launch {
             orchestrator.proxies.intents.send(
                 Intent.Clipboard.Paste(
@@ -5056,13 +5075,23 @@ class EditorViewModel(
 
     fun onBookmarkPasted(url: Url) {
         Timber.d("onBookmarkPasted $url")
+        // The virtual placeholder and a block whose identity fork is in flight
+        // are unknown to the middleware — settle the identity first, then
+        // create the bookmark against the real block id.
+        if (deferUntilBlockIdentitySettled { onBookmarkPasted(url) }) return
         val focus = orchestrator.stores.focus.current()
         if (!focus.isEmpty) {
+            val focused = focus.requireTarget()
+            val target = if (focused == VIRTUAL_TRAILING_BLOCK_ID) {
+                lastMaterializedTrailingBlock ?: return
+            } else {
+                forkRedirectOrNull(focused) ?: focused
+            }
             viewModelScope.launch {
                 orchestrator.proxies.intents.send(
                     Intent.Bookmark.CreateBookmark(
                         context = context,
-                        target = focus.requireTarget(),
+                        target = target,
                         position = Position.TOP,
                         url = url
                     )
@@ -8169,9 +8198,20 @@ class EditorViewModel(
 
     fun proceedToAddUriToTextAsLink(uri: String) {
         Timber.d("proceedToAddUriToTextAsLink, uri:[$uri]")
+        // "Paste link" first inserts the uri into the block, which starts the
+        // placeholder materialization (or the identity fork) for an empty
+        // block. The link mark must then be applied to the real block once the
+        // identity settles — the old id write would race the in-flight
+        // create/replace and lose the mark.
+        if (deferUntilBlockIdentitySettled { proceedToAddUriToTextAsLink(uri) }) return
         val range = orchestrator.stores.textSelection.current().selection
         if (range != null) {
-            val target = orchestrator.stores.focus.current().targetOrNull()
+            val focused = orchestrator.stores.focus.current().targetOrNull()
+            val target = when {
+                focused == null -> null
+                focused == VIRTUAL_TRAILING_BLOCK_ID -> lastMaterializedTrailingBlock
+                else -> forkRedirectOrNull(focused) ?: focused
+            }
             if (target != null) {
                 applyLinkMarkup(
                     blockId = target,

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorEmptySpaceInteractionTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorEmptySpaceInteractionTest.kt
@@ -13,8 +13,12 @@ import com.anytypeio.anytype.core_models.StubSmartBlock
 import com.anytypeio.anytype.core_models.StubTable
 import com.anytypeio.anytype.core_models.StubTitle
 import com.anytypeio.anytype.core_models.restrictions.ObjectRestriction
+import com.anytypeio.anytype.domain.base.Either
 import com.anytypeio.anytype.domain.base.Resultat
 import com.anytypeio.anytype.domain.block.interactor.CreateBlock
+import com.anytypeio.anytype.domain.block.interactor.UpdateLinkMarks
+import com.anytypeio.anytype.domain.block.interactor.UpdateText
+import com.anytypeio.anytype.domain.page.bookmark.CreateBookmarkBlock
 import com.anytypeio.anytype.presentation.MockBlockFactory
 import com.anytypeio.anytype.presentation.editor.EditorViewModel.Companion.VIRTUAL_TRAILING_BLOCK_ID
 import com.anytypeio.anytype.presentation.editor.editor.model.BlockView
@@ -30,6 +34,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.stub
@@ -652,6 +657,195 @@ class EditorEmptySpaceInteractionTest : EditorPresentationTestSetup() {
                         prototype = Block.Prototype.Text(
                             style = Block.Content.Text.Style.P,
                             text = ""
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `should materialize the placeholder before creating a bookmark from a pasted url`() = runTest {
+
+        // SETUP
+
+        val block = StubParagraph(text = MockDataFactory.randomString())
+
+        val page = Block(
+            id = root,
+            fields = Block.Fields(emptyMap()),
+            content = Block.Content.Smart,
+            children = listOf(header.id, block.id)
+        )
+
+        val doc = listOf(page, header, title, block)
+
+        val created = StubParagraph(text = "")
+
+        val url = "https://anytype.io"
+
+        stubInterceptEvents()
+        stubOpenDocument(doc)
+
+        createBlock.stub {
+            onBlocking { async(any()) } doReturn Resultat.success(
+                Pair(
+                    created.id,
+                    Payload(
+                        context = root,
+                        events = listOf(
+                            Event.Command.AddBlock(
+                                context = root,
+                                blocks = listOf(created)
+                            ),
+                            Event.Command.UpdateStructure(
+                                context = root,
+                                id = root,
+                                children = listOf(header.id, block.id, created.id)
+                            )
+                        )
+                    )
+                )
+            )
+        }
+
+        createBookmarkBlock.stub {
+            onBlocking { invoke(any()) } doReturn Either.Right(
+                Payload(context = root, events = emptyList())
+            )
+        }
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onOutsideClicked()
+
+        advanceUntilIdle()
+
+        vm.onBookmarkPasted(url)
+
+        advanceUntilIdle()
+
+        // The bookmark is created against the materialized block — never the
+        // virtual id, which the middleware knows nothing about.
+        verifyBlocking(createBookmarkBlock, times(1)) {
+            invoke(
+                params = eq(
+                    CreateBookmarkBlock.Params(
+                        context = root,
+                        target = created.id,
+                        url = url,
+                        position = Position.TOP
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `should defer link paste until the placeholder materializes and apply the mark to the created block`() = runTest {
+
+        // SETUP
+
+        val block = StubParagraph(text = MockDataFactory.randomString())
+
+        val page = Block(
+            id = root,
+            fields = Block.Fields(emptyMap()),
+            content = Block.Content.Smart,
+            children = listOf(header.id, block.id)
+        )
+
+        val doc = listOf(page, header, title, block)
+
+        val url = "https://anytype.io"
+
+        val created = StubParagraph(text = url)
+
+        stubInterceptEvents()
+        stubOpenDocument(doc)
+        stubUpdateText()
+
+        createBlock.stub {
+            onBlocking { async(any()) } doReturn Resultat.success(
+                Pair(
+                    created.id,
+                    Payload(
+                        context = root,
+                        events = listOf(
+                            Event.Command.AddBlock(
+                                context = root,
+                                blocks = listOf(created)
+                            ),
+                            Event.Command.UpdateStructure(
+                                context = root,
+                                id = root,
+                                children = listOf(header.id, block.id, created.id)
+                            )
+                        )
+                    )
+                )
+            )
+        }
+
+        updateLinkMark.stub {
+            on { invoke(any(), any(), any()) } doAnswer { invocation ->
+                val params = invocation.getArgument<UpdateLinkMarks.Params>(1)
+                val onResult = invocation
+                    .getArgument<(Either<Throwable, List<Block.Content.Text.Mark>>) -> Unit>(2)
+                onResult(Either.Right(params.marks + params.newMark))
+            }
+        }
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onOutsideClicked()
+
+        advanceUntilIdle()
+
+        // The UI reports the selection covering the pasted url.
+        vm.onSelectionChanged(
+            id = VIRTUAL_TRAILING_BLOCK_ID,
+            selection = 0..url.length
+        )
+
+        advanceUntilIdle()
+
+        val placeholder = trailingPlaceholderOrNull(vm)!!
+
+        // "Paste link" inserts the url into the block (materialization starts)...
+        vm.onTextBlockTextChanged(placeholder.copy(text = url))
+
+        // ...and applies the link mark while the create request is still in flight.
+        vm.proceedToAddUriToTextAsLink(url)
+
+        advanceUntilIdle()
+
+        // The mark is applied to the created block — never the virtual id.
+        verifyBlocking(updateText, times(1)) {
+            invoke(
+                params = eq(
+                    UpdateText.Params(
+                        context = root,
+                        target = created.id,
+                        text = url,
+                        marks = listOf(
+                            Block.Content.Text.Mark(
+                                range = 0..url.length,
+                                type = Block.Content.Text.Mark.Type.LINK,
+                                param = url
+                            )
                         )
                     )
                 )

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorIdentityForkTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorIdentityForkTest.kt
@@ -9,6 +9,9 @@ import com.anytypeio.anytype.core_models.StubTitle
 import com.anytypeio.anytype.core_models.StubHeader
 import com.anytypeio.anytype.domain.base.Either
 import com.anytypeio.anytype.domain.block.interactor.ReplaceBlock
+import com.anytypeio.anytype.domain.block.interactor.UpdateLinkMarks
+import com.anytypeio.anytype.domain.block.interactor.UpdateText
+import com.anytypeio.anytype.domain.clipboard.Paste
 import com.anytypeio.anytype.presentation.editor.editor.model.BlockView
 import com.anytypeio.anytype.presentation.util.DefaultCoroutineTestRule
 import com.anytypeio.anytype.test_utils.MockDataFactory
@@ -22,6 +25,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.stub
@@ -377,5 +381,159 @@ class EditorIdentityForkTest : EditorPresentationTestSetup() {
         // No change — no last-writer-wins write that could stomp a peer edit.
         verifyNoInteractions(updateText)
         verifyNoInteractions(replaceBlock)
+    }
+
+    private fun stubReplaceBlockWithSwap(empty: Block, forked: Block) {
+        replaceBlock.stub {
+            onBlocking { invoke(any()) } doReturn Either.Right(
+                Pair(
+                    forked.id,
+                    Payload(
+                        context = root,
+                        events = listOf(
+                            Event.Command.UpdateStructure(
+                                context = root,
+                                id = root,
+                                children = listOf(header.id, forked.id)
+                            ),
+                            Event.Command.AddBlock(
+                                context = root,
+                                blocks = listOf(forked)
+                            ),
+                            Event.Command.DeleteBlock(
+                                context = root,
+                                targets = listOf(empty.id)
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `should defer link paste while the fork is in flight and apply the mark to the forked block`() = runTest {
+
+        // SETUP
+
+        val empty = StubParagraph(text = "")
+        val url = "https://anytype.io"
+        val forked = StubParagraph(text = url)
+
+        stubInterceptEvents()
+        stubOpenDocument(givenDocument(empty))
+        stubUpdateText()
+        stubReplaceBlockWithSwap(empty, forked)
+
+        updateLinkMark.stub {
+            on { invoke(any(), any(), any()) } doAnswer { invocation ->
+                val params = invocation.getArgument<UpdateLinkMarks.Params>(1)
+                val onResult = invocation
+                    .getArgument<(Either<Throwable, List<Block.Content.Text.Mark>>) -> Unit>(2)
+                onResult(Either.Right(params.marks + params.newMark))
+            }
+        }
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onBlockFocusChanged(id = empty.id, hasFocus = true)
+        vm.onSelectionChanged(id = empty.id, selection = 0..url.length)
+
+        advanceUntilIdle()
+
+        // "Paste link" inserts the url into the block (the identity fork starts)...
+        vm.onTextBlockTextChanged(
+            BlockView.Text.Paragraph(
+                id = empty.id,
+                text = url
+            )
+        )
+
+        // ...and applies the link mark while the replace is still in flight.
+        vm.proceedToAddUriToTextAsLink(url)
+
+        advanceUntilIdle()
+
+        // The mark reaches the middleware against the forked id carrying the url
+        // text — never as an empty-text write racing the in-flight replace.
+        verifyBlocking(updateText, times(1)) {
+            invoke(
+                params = eq(
+                    UpdateText.Params(
+                        context = root,
+                        target = forked.id,
+                        text = url,
+                        marks = listOf(
+                            Block.Content.Text.Mark(
+                                range = 0..url.length,
+                                type = Block.Content.Text.Mark.Type.LINK,
+                                param = url
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `should defer paste while the fork is in flight and replay it against the forked block`() = runTest {
+
+        // SETUP
+
+        val empty = StubParagraph(text = "")
+        val forked = StubParagraph(text = "h")
+
+        stubInterceptEvents()
+        stubOpenDocument(givenDocument(empty))
+        stubPaste()
+        stubReplaceBlockWithSwap(empty, forked)
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onBlockFocusChanged(id = empty.id, hasFocus = true)
+
+        advanceUntilIdle()
+
+        // Typing starts the fork...
+        vm.onTextBlockTextChanged(
+            BlockView.Text.Paragraph(
+                id = empty.id,
+                text = "h"
+            )
+        )
+
+        // ...and the paste arrives while the replace is still in flight.
+        vm.onPaste(range = 1..1)
+
+        advanceUntilIdle()
+
+        // The paste is replayed against the forked block — never the old id,
+        // which the replace removes.
+        verifyBlocking(paste, times(1)) {
+            invoke(
+                params = eq(
+                    Paste.Params(
+                        context = root,
+                        focus = forked.id,
+                        range = 1..1,
+                        selected = emptyList(),
+                        isPartOfBlock = null
+                    )
+                )
+            )
+        }
     }
 }


### PR DESCRIPTION
Follow-up to DROID-4538 (#3293). The virtual trailing placeholder and the empty-block identity fork were wired into most write paths, but the URL-paste action-mode paths were missed. Four bugs in `EditorViewModel`:

1. **HIGH — Bookmark-paste onto the virtual placeholder silently lost.** `onBookmarkPasted` sent `Intent.Bookmark.CreateBookmark(target = focus.requireTarget())` with no guard: with focus on `virtual-trailing-block` the middleware got a nonexistent id — error, URL silently lost.
2. **HIGH (crash) — Link-paste onto the virtual placeholder threw.** `proceedToAddUriToTextAsLink` read the still-virtual focus id and `applyLinkMarkup` did `blocks.first { it.id == blockId }` — `NoSuchElementException` on the main thread; link mark lost.
3. **MEDIUM — Link-paste into an existing empty block lost the link mark.** The inserted URL starts the identity fork (`BlockReplace` carrying `text = url, marks = []`); `applyLinkMarkup` then read the still-empty block from the store and sent `UpdateText(target = OLD id, text = "", marks = [linkMark])` racing the in-flight replace — either ordering loses the mark.
4. **LOW — `onPaste` was placeholder-aware but not fork-aware.** Pasting while a fork was in flight sent BlockPaste against the old id being removed by the replace.

## Fix

- `onBookmarkPasted` and `proceedToAddUriToTextAsLink` now settle the block identity first via the existing `deferUntilBlockIdentitySettled` replay mechanism (placeholder → `state.onMaterialized` + materialize; fork → `fork.onForked`), and consult `lastMaterializedTrailingBlock` / `forkRedirectOrNull` for post-swap dispatches against stale ids.
- `applyLinkMarkup` is null-safe (`find` + warning log instead of `first`) so no path can throw.
- `onPaste` mirrors `onEnterKeyClicked`: defers via `fork.onForked` while the replace is in flight and remaps post-swap old-id dispatches via `forkRedirectOrNull`.

## Tests

- `EditorEmptySpaceInteractionTest`
  - `should materialize the placeholder before creating a bookmark from a pasted url`
  - `should defer link paste until the placeholder materializes and apply the mark to the created block`
- `EditorIdentityForkTest`
  - `should defer link paste while the fork is in flight and apply the mark to the forked block`
  - `should defer paste while the fork is in flight and replay it against the forked block`

All four failed before the fix for the audited reasons (wrong/virtual target id; `NoSuchElementException` for the link-paste-on-placeholder case). Full `:presentation:testDebugUnitTest` suite: 1309 tests, 0 failures.

Linear: DROID-4551