### PR TITLE
DROID-4365 Sets | Fix | Use theme-aware text colors in grid object cells

### DIFF
--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/widgets/GridCellObjectItem.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/widgets/GridCellObjectItem.kt
@@ -1,13 +1,13 @@
 package com.anytypeio.anytype.core_ui.widgets
 
 import android.content.Context
-import android.graphics.Color
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
 import androidx.core.view.updateLayoutParams
 import com.anytypeio.anytype.core_ui.R
 import com.anytypeio.anytype.core_ui.databinding.WidgetDvGridObjectBinding
+import com.anytypeio.anytype.core_ui.extensions.color
 import com.anytypeio.anytype.core_utils.ext.gone
 import com.anytypeio.anytype.core_utils.ext.visible
 import com.anytypeio.anytype.core_models.ui.ObjectIcon
@@ -23,7 +23,7 @@ class GridCellObjectItem @JvmOverloads constructor(
     fun setup(name: String, icon: ObjectIcon) = with(binding) {
         tvName.visible()
         tvName.text = name
-        tvName.setTextColor(context.getColor(R.color.black))
+        tvName.setTextColor(context.color(R.color.text_primary))
         when (icon) {
             ObjectIcon.None -> {
                 objectIcon.gone()
@@ -44,7 +44,7 @@ class GridCellObjectItem @JvmOverloads constructor(
     fun setupAsNonExistent() = with(binding) {
         tvName.visible()
         tvName.setText(R.string.non_existent_object)
-        tvName.setTextColor(Color.parseColor("#CBC9BD"))
+        tvName.setTextColor(context.color(R.color.text_tertiary))
         objectIcon.setNonExistentIcon()
     }
 }

--- a/core-ui/src/test/java/com/anytypeio/anytype/core_ui/widgets/GridCellObjectItemTest.kt
+++ b/core-ui/src/test/java/com/anytypeio/anytype/core_ui/widgets/GridCellObjectItemTest.kt
@@ -1,0 +1,79 @@
+package com.anytypeio.anytype.core_ui.widgets
+
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import com.anytypeio.anytype.core_models.ui.ObjectIcon
+import com.anytypeio.anytype.core_ui.R
+import kotlin.test.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+class GridCellObjectItemTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun before() {
+        context.setTheme(R.style.Theme_MaterialComponents)
+    }
+
+    @Test
+    @Config(qualifiers = "night")
+    fun `object name is rendered with primary text color in dark mode`() {
+        val item = GridCellObjectItem(context)
+
+        item.setup(name = "Page", icon = ObjectIcon.None)
+
+        // @color/black is #2C2B27 in every configuration, so in dark mode it was
+        // almost indistinguishable from the background of a set or collection row.
+        assertEquals(
+            context.getColor(R.color.text_primary),
+            item.binding.tvName.currentTextColor
+        )
+    }
+
+    @Test
+    fun `object name is rendered with primary text color in light mode`() {
+        val item = GridCellObjectItem(context)
+
+        item.setup(name = "Page", icon = ObjectIcon.None)
+
+        assertEquals(
+            context.getColor(R.color.text_primary),
+            item.binding.tvName.currentTextColor
+        )
+    }
+
+    @Test
+    @Config(qualifiers = "night")
+    fun `non existent object is rendered with tertiary text color in dark mode`() {
+        val item = GridCellObjectItem(context)
+
+        item.setupAsNonExistent()
+
+        assertEquals(
+            context.getColor(R.color.text_tertiary),
+            item.binding.tvName.currentTextColor
+        )
+    }
+
+    @Test
+    @Config(qualifiers = "night")
+    fun `recycled non existent cell is restored to primary text color`() {
+        val item = GridCellObjectItem(context)
+
+        item.setupAsNonExistent()
+        item.setup(name = "Page", icon = ObjectIcon.None)
+
+        assertEquals(
+            context.getColor(R.color.text_primary),
+            item.binding.tvName.currentTextColor
+        )
+    }
+}


### PR DESCRIPTION
## Problem

In **Sets / Collections → Table (grid) view** in **dark mode**, object titles inside object-relation cells were almost invisible.

`GridCellObjectItem.setup()` overrode its XML style with a hardcoded color:

```kotlin
tvName.setTextColor(context.getColor(R.color.black))
```

`@color/black` is `#2C2B27` and — despite the name — has **no `values-night/colors.xml` override**. Against dark-mode `background_primary` (`#000000`) that is roughly **1.5:1** contrast; WCAG minimum for body text is 4.5:1.

The XML was never at fault: `item_viewer_grid_cell_object.xml` → `GridCellDateTextStyle` → `BaseTextView` already applies `@color/text_primary`, which *is* DayNight-aware (`#252525` / `#F3F3F3`). The programmatic call clobbered it.

## Why the call wasn't simply deleted

`DVGridCellObjectHolder` reuses four fixed child views (`object0..object3`) across every grid row. `setupAsNonExistent()` paints the label gray, so without a color reset in `setup()` a recycled view would render a *real* object name in that leftover gray.

The `setTextColor` call is load-bearing — the defect was the constant, not the call. Swapped the constants and added a recycling regression test that would catch a naive deletion.

## Changes

`core-ui/.../widgets/GridCellObjectItem.kt`

| | before | after |
|---|---|---|
| `setup()` | `@color/black` (`#2C2B27`, no night variant) | `@color/text_primary` (`#252525` / `#F3F3F3`) |
| `setupAsNonExistent()` | `Color.parseColor("#CBC9BD")` | `@color/text_tertiary` (`#BFBFBF` / `#646464`) |

The second row was a separate hardcoded literal with the inverse problem — `#CBC9BD` is near-invisible on white in *light* mode.

Contrast on `#000000` goes from **1.5:1 → 18.9:1**. This mirrors the existing `RelationObjectItem`, which already renders the same concept correctly.

## Tests

New `GridCellObjectItemTest` (Robolectric, `@Config(qualifiers = "night")` for dark mode):

- object name uses `text_primary` in dark mode
- object name uses `text_primary` in light mode
- non-existent object uses `text_tertiary`
- recycled non-existent cell is restored to `text_primary`

All **4 fail on `main`**, all pass with this change. Full `:core-ui:testDebugUnitTest` suite passes — no regressions.

## Scope notes

- Repo-wide sweep: **zero** remaining programmatic `R.color.black` uses in production Kotlin — this was the last one. Status / Tag / Date / Number cells were already correct (`DVGridCellStatusHolder` uses `R.color.text_primary`).
- **Not** included: `ListViewRelationObjectValueView.kt:42` (the **List** view) has the same `#CBC9BD` literal and never resets it in `setup()`, so a recycled row can show a real object name in stale gray. Same defect class, different view and different symptom — left out to keep this PR scoped to the reported Table issue. Happy to fold it in or file separately.

## QA

Open a Set or Collection in dark mode, switch to Table view, and check a column holding an object relation — titles should now be light and legible. Verify light mode is unchanged, and scroll to confirm no stale gray on recycled rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)