### PR TITLE
DROID-4553 Sharing | Fix | Make share success banner "Open" action open the object

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/main/MainActivity.kt
@@ -1001,8 +1001,13 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), AppNavigation.Pr
                         findViewById<android.view.View>(android.R.id.content)?.showSnackbar(
                             msg = message,
                             length = Snackbar.LENGTH_INDEFINITE,
-                            actionMessage = getString(R.string.button_ok),
+                            actionMessage = getString(R.string.sharing_menu_btn_open),
                             action = {
+                                vm.onOpenSharedObject(
+                                    objectId = command.objectId,
+                                    spaceId = command.spaceId,
+                                    isChat = command.isChat
+                                )
                                 onDismiss()
                             }
                         )

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/main/MainViewModel.kt
@@ -833,6 +833,53 @@ class MainViewModel(
         }
     }
 
+    /**
+     * Opens an object (or chat) that was just created/modified via the "Share to Anytype"
+     * flow, when the user taps "Open" on the success banner. Reuses the same machinery as
+     * the OS-widget / deep-link paths: fetches the object, switches space if needed, and
+     * emits an existing navigation command handled by MainActivity.
+     */
+    fun onOpenSharedObject(objectId: Id, spaceId: Id, isChat: Boolean) {
+        Timber.d("onOpenSharedObject: obj=$objectId, space=$spaceId, isChat=$isChat")
+        if (isChat) {
+            onOpenChatTriggeredByPush(chatId = objectId, spaceId = spaceId)
+            return
+        }
+        viewModelScope.launch {
+            val result = deepLinkToObjectDelegate.onDeepLinkToObject(
+                obj = objectId,
+                space = SpaceId(spaceId),
+                switchSpaceIfObjectFound = true
+            )
+            when (result) {
+                is DeepLinkToObjectDelegate.Result.Success -> {
+                    val navigation = result.obj.navigation()
+                    Timber.d("Shared object navigation determined: $navigation")
+                    commandsChannel.send(
+                        Command.Deeplink.DeepLinkToObjectFromWidget(
+                            space = spaceId,
+                            obj = objectId,
+                            navigation = navigation,
+                            openTargetDirectly = hasExplicitObjectHomepage(SpaceId(spaceId))
+                        )
+                    )
+                }
+                is DeepLinkToObjectDelegate.Result.Error.ObjectNotFound -> {
+                    Timber.w("Shared object open: object not found: $objectId")
+                    toastsChannel.send("Object not found")
+                }
+                is DeepLinkToObjectDelegate.Result.Error.PermissionNeeded -> {
+                    Timber.w("Shared object open: permission needed to access object: $objectId")
+                    toastsChannel.send("Permission needed")
+                }
+                is DeepLinkToObjectDelegate.Result.Error.CouldNotOpenSpace -> {
+                    Timber.w("Shared object open: could not open space: $spaceId")
+                    toastsChannel.send("Could not open space")
+                }
+            }
+        }
+    }
+
     private suspend fun proceedWithSpaceSwitchDueToDeepLinkToObject(
         targetSpace: Id,
         deeplink: DeepLinkResolver.Action.DeepLinkToObject,


### PR DESCRIPTION
## What & Why

When sharing content into Anytype via Android's system share sheet, the success banner at the bottom previously showed a **dismiss-only "OK"** button — users had no way to open the object they'd just created or modified. To add a tag like "read later" they had to navigate to the object manually.

The "Open" affordance was already half-built: the `SharingCommand.ShowSnackbarWithOpenAction` command already carried `objectId`/`spaceId`/`isChat`, and a localized `R.string.sharing_menu_btn_open` ("Open") string already existed. It was simply never wired to navigation.

## Changes

- **`MainViewModel`** — added `onOpenSharedObject(objectId, spaceId, isChat)`. Reuses the existing OS-widget/deep-link machinery: `deepLinkToObjectDelegate.onDeepLinkToObject(...)` fetches the object and switches space if needed, then emits the existing `Command.Deeplink.DeepLinkToObjectFromWidget` navigation command (already handled by `MainActivity.proceedWithOpenObjectNavigation`). Chat destinations reuse the existing `onOpenChatTriggeredByPush(...)`.
- **`MainActivity`** — the sharing success snackbar action changed from dismiss-only "OK" to **"Open"**, which calls `vm.onOpenSharedObject(...)` with the IDs the command already carried.

No new navigation plumbing — it rides on commands and a string that already existed. All share variants (new object, link-to-existing, collection, chat) get a working Open.

## Verification

- ✅ `:app:compileDebugKotlin` builds successfully.
- Manual (recommended before merge): share text/URL → tap **Open** on the banner → object opens in the editor; verify cross-space (switches space), collection, and chat destinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)