### PR TITLE
DROID-4555 Sets | Fix | Stop reporting expected data view states as errors

### DIFF
--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/BoardColumnQuery.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/BoardColumnQuery.kt
@@ -5,6 +5,21 @@ import com.anytypeio.anytype.core_models.DVFilterCondition
 import com.anytypeio.anytype.core_models.DataViewGroup
 import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.core_models.Key
+import com.anytypeio.anytype.core_models.RelationFormat
+
+/**
+ * The relation formats the backend can build board columns from — the same three [groupValueFilter]
+ * below knows how to turn back into record filters.
+ *
+ * Grouping by anything else fails `ObjectGroupsSubscribe` outright ("get grouper: unsupported
+ * relation format"), so a view carrying such a key — a board configured on another client, or one
+ * whose relation later changed format — has to be caught before the request is issued (DROID-4555).
+ */
+val BOARD_GROUP_BY_FORMATS = setOf(
+    RelationFormat.STATUS,
+    RelationFormat.TAG,
+    RelationFormat.CHECKBOX
+)
 
 /**
  * A single Kanban column's record query: its [columnId] (the backend group id, or the

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
@@ -535,7 +535,7 @@ class ObjectSetViewModel(
                 stateReducer.state,
             ) { viewId, state ->
                 if (viewId != null) {
-                    val dataView = state.dataViewState()
+                    val dataView = state.dataViewStateOrNull()
                     val pair = dataView?.viewerAndIndexById(viewId)
                     if (dataView != null && pair != null) {
                         viewerEditWidgetState.value = pair.first.toViewerEditWidgetState(
@@ -785,7 +785,7 @@ class ObjectSetViewModel(
                     old.second == new.second
                 }
                 .flatMapLatest { (query, _) ->
-                val activeViewer = query.state.dataViewState()?.viewerByIdOrFirst(query.currentViewerId)
+                val activeViewer = query.state.dataViewStateOrNull()?.viewerByIdOrFirst(query.currentViewerId)
                 if (activeViewer?.type == DVViewerType.BOARD && isKanbanEnabled.value) {
                     // An enabled board is driven entirely by per-column record subscriptions
                     // (subscribeToBoardRecords), not the single flat 50-record window. When the
@@ -918,8 +918,16 @@ class ObjectSetViewModel(
             // Wait for the previous stop's backend unsubscribe (same subscription id) before
             // issuing any new subscribe request — see [unsubscribeJob].
             unsubscribeJob?.join()
-            combine(stateReducer.state, session.currentViewerId, isKanbanEnabled) { state, currentViewId, kanbanEnabled ->
-                val dataView = state.dataViewState()
+            combine(
+                stateReducer.state,
+                session.currentViewerId,
+                isKanbanEnabled,
+                // The group relation's format is resolved against storeOfRelations below. A tick on
+                // store changes re-evaluates the params once a format arrives, so a board opened
+                // before the store populated isn't stranded on the first (format-less) verdict.
+                storeOfRelations.trackChanges()
+            ) { state, currentViewId, kanbanEnabled, _ ->
+                val dataView = state.dataViewStateOrNull()
                 val viewer = dataView?.viewerByIdOrFirst(currentViewId)
                 if (kanbanEnabled && dataView != null && viewer != null && viewer.type == DVViewerType.BOARD) {
                     buildBoardGroupParams(dataView, viewer)
@@ -959,6 +967,10 @@ class ObjectSetViewModel(
         viewer: DVViewer
     ): BoardGroupSubscriptionContainer.Params? {
         val relationKey = viewer.groupRelationKey?.takeIf { it.isNotEmpty() } ?: return null
+        // Refuse the request the backend grouper would reject anyway — the failure surfaces as an
+        // opaque subscription error the user can't act on. The render shows the "choose a grouping
+        // property" hint instead (see [isBoardMissingUsableGroupRelation]).
+        if (isGroupRelationUnsupported(relationKey)) return null
         val filters = buildList {
             addAll(viewer.filters.updateFormatForSubscription(storeOfRelations).removeUnsupportedFilters())
             addAll(defaultDataViewFilters())
@@ -1001,7 +1013,7 @@ class ObjectSetViewModel(
             // issuing any new subscribe request — see [unsubscribeJob].
             unsubscribeJob?.join()
             combine(stateReducer.state, session.currentViewerId, boardGroups, isKanbanEnabled) { state, currentViewId, groups, kanbanEnabled ->
-                val dataView = state.dataViewState()
+                val dataView = state.dataViewStateOrNull()
                 val viewer = dataView?.viewerByIdOrFirst(currentViewId)
                 if (kanbanEnabled && dataView != null && viewer != null && viewer.type == DVViewerType.BOARD && !groups.isNullOrEmpty()) {
                     buildBoardRecordsParams(dataView, viewer, groups)
@@ -1113,7 +1125,7 @@ class ObjectSetViewModel(
             // issuing any new subscribe request — see [unsubscribeJob].
             unsubscribeJob?.join()
             combine(stateReducer.state, session.currentViewerId, isKanbanEnabled) { state, currentViewId, kanbanEnabled ->
-                val viewer = state.dataViewState()?.viewerByIdOrFirst(currentViewId)
+                val viewer = state.dataViewStateOrNull()?.viewerByIdOrFirst(currentViewId)
                 if (kanbanEnabled && viewer?.type == DVViewerType.BOARD) {
                     viewer.groupRelationKey?.takeIf { it.isNotEmpty() }
                 } else {
@@ -1172,7 +1184,7 @@ class ObjectSetViewModel(
                 storeOfRelations.trackChanges()
             ) { state, _ -> state }
                 .map { state ->
-                    state.dataViewState()?.dataViewContent?.relationLinks
+                    state.dataViewStateOrNull()?.dataViewContent?.relationLinks
                         ?.mapNotNull { link ->
                             val format = storeOfRelations.getByKey(link.key)?.format
                             if (format == RelationFormat.TAG || format == RelationFormat.STATUS) {
@@ -1316,14 +1328,31 @@ class ObjectSetViewModel(
         viewer is Viewer.Board && boardGroups.value == null
 
     /**
-     * An enabled Board view with no grouping property can never build columns (it has nothing to
-     * group by), so it would otherwise sit in the loading state forever. Detect it so the render
-     * shows an explicit "choose a grouping property" hint instead of an endless spinner.
+     * Whether [key] is known to be ungroupable, i.e. outside [BOARD_GROUP_BY_FORMATS].
+     *
+     * An unresolved format — the relation hasn't reached [storeOfRelations] yet — counts as usable.
+     * This mirrors how the rest of the data view resolves formats optimistically (see
+     * `updateFormatForSubscription`), and refusing on a not-yet-loaded relation would strand a
+     * perfectly valid board. The collectors re-evaluate on store changes, so a genuinely
+     * unsupported relation is caught as soon as its format is known.
      */
-    private fun isBoardMissingGroupRelation(viewer: DVViewer?): Boolean =
-        isKanbanEnabled.value
-                && viewer?.type == DVViewerType.BOARD
-                && viewer.groupRelationKey.isNullOrEmpty()
+    private suspend fun isGroupRelationUnsupported(key: Key?): Boolean {
+        if (key.isNullOrEmpty()) return false
+        val format = storeOfRelations.getByKey(key)?.format ?: return false
+        return format !in BOARD_GROUP_BY_FORMATS
+    }
+
+    /**
+     * An enabled Board view that can never build columns: it has no grouping property, or one the
+     * backend can't group by. Either way it would otherwise sit in the loading state forever (no
+     * grouping property) or fail its group subscription (unsupported format), so the render shows
+     * an explicit "choose a grouping property" hint instead.
+     */
+    private suspend fun isBoardMissingUsableGroupRelation(viewer: DVViewer?): Boolean {
+        if (!isKanbanEnabled.value || viewer?.type != DVViewerType.BOARD) return false
+        return viewer.groupRelationKey.isNullOrEmpty()
+                || isGroupRelationUnsupported(viewer.groupRelationKey)
+    }
 
     /** An active board whose group/record subscription died renders an explicit error. */
     private fun hasBoardSubscriptionFailed(viewer: DVViewer?): Boolean =
@@ -1365,17 +1394,19 @@ class ObjectSetViewModel(
                     storeOfRelations.getByKey(it.key)
                 }
                 val viewer = renderViewer(objectState, dataViewState, dvViewer, relations)
+                val missingGroupBy = isBoardMissingUsableGroupRelation(dvViewer)
 
                 when {
                     viewer == null -> DataViewViewState.Collection.NoView(
                         isCreateObjectAllowed = permission?.isOwnerOrEditor() == true,
                         isEditingViewAllowed = permission?.isOwnerOrEditor() == true
                     )
-                    hasBoardSubscriptionFailed(dvViewer) -> DataViewViewState.Error(
+                    // A board with no usable grouping property never had a working subscription, so
+                    // prefer the actionable hint over an error it may have produced on the way here.
+                    !missingGroupBy && hasBoardSubscriptionFailed(dvViewer) -> DataViewViewState.Error(
                         msg = BOARD_SUBSCRIPTION_ERROR_MSG
                     )
                     viewer.isEmpty() -> {
-                        val missingGroupBy = isBoardMissingGroupRelation(dvViewer)
                         if (!missingGroupBy && isBoardAwaitingGroups(viewer)) return DataViewViewState.Init
                         val isCreateObjectAllowed = objectState.isCreateObjectAllowed() && permission?.isOwnerOrEditor() == true
                         DataViewViewState.Collection.NoItems(
@@ -1455,6 +1486,8 @@ class ObjectSetViewModel(
                     kanbanEnabled = isKanbanEnabled.value
                 )
 
+                val missingGroupBy = isBoardMissingUsableGroupRelation(viewer)
+
                 when {
                     query.isEmpty() || setOfValue.isEmpty() -> DataViewViewState.Set.NoQuery(
                         isCreateObjectAllowed = permission?.isOwnerOrEditor() == true,
@@ -1464,11 +1497,12 @@ class ObjectSetViewModel(
                         isCreateObjectAllowed = permission?.isOwnerOrEditor() == true,
                         isEditingViewAllowed = permission?.isOwnerOrEditor() == true
                     )
-                    hasBoardSubscriptionFailed(viewer) -> DataViewViewState.Error(
+                    // A board with no usable grouping property never had a working subscription, so
+                    // prefer the actionable hint over an error it may have produced on the way here.
+                    !missingGroupBy && hasBoardSubscriptionFailed(viewer) -> DataViewViewState.Error(
                         msg = BOARD_SUBSCRIPTION_ERROR_MSG
                     )
                     render.isEmpty() -> {
-                        val missingGroupBy = isBoardMissingGroupRelation(viewer)
                         if (!missingGroupBy && isBoardAwaitingGroups(render)) return DataViewViewState.Init
                         val (defType, _) = objectState.getActiveViewTypeAndTemplate(
                             vmParams.ctx, viewer, storeOfObjectTypes
@@ -1546,15 +1580,18 @@ class ObjectSetViewModel(
                     kanbanEnabled = isKanbanEnabled.value
                 )
 
+                val missingGroupBy = isBoardMissingUsableGroupRelation(viewer)
+
                 when {
                     render == null || query.isEmpty() || setOfValue.isEmpty() -> DataViewViewState.TypeSet.Error(
                         msg = "Error while rendering viewer",
                     )
-                    hasBoardSubscriptionFailed(viewer) -> DataViewViewState.TypeSet.Error(
+                    // A board with no usable grouping property never had a working subscription, so
+                    // prefer the actionable hint over an error it may have produced on the way here.
+                    !missingGroupBy && hasBoardSubscriptionFailed(viewer) -> DataViewViewState.TypeSet.Error(
                         msg = BOARD_SUBSCRIPTION_ERROR_MSG
                     )
                     render.isEmpty() -> {
-                        val missingGroupBy = isBoardMissingGroupRelation(viewer)
                         if (!missingGroupBy && isBoardAwaitingGroups(render)) return DataViewViewState.Init
                         val (defType, _) = objectState.getActiveViewTypeAndTemplate(
                             vmParams.ctx, viewer, storeOfObjectTypes

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/SetsExtension.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/SetsExtension.kt
@@ -374,11 +374,29 @@ fun Any?.filterIdsById(filter: Id): List<Id> {
     return remaining.toList()
 }
 
+/**
+ * The data view state, or null while the object is still opening.
+ *
+ * Silent by design, for reactive collectors: they subscribe to the state reducer before the object
+ * is opened, so they are guaranteed to observe [ObjectState.Init] first. That is an ordinary step
+ * of opening a set, not a fault to report (DROID-4555).
+ */
+fun ObjectState.dataViewStateOrNull(): ObjectState.DataView? =
+    (this as? ObjectState.DataView)?.takeIf { it.isInitialized }
+
+/**
+ * As [dataViewStateOrNull], but logs when the state isn't ready. For one-shot handlers, where an
+ * uninitialized state means the user acted before the object finished opening.
+ *
+ * Deliberately WARN, not ERROR: `Timber.e` is forwarded to crash reporting as an issue
+ * (`SentryTimberIntegration(minEventLevel = ERROR)`), and this message carries no context — no
+ * object id, no call site — to act on. WARN still clears the breadcrumb threshold, so the trail
+ * survives for any real crash that follows.
+ */
 fun ObjectState.dataViewState(): ObjectState.DataView? {
-    val state = this as? ObjectState.DataView
-    if (state == null || !state.isInitialized) {
-        Timber.e("State was not initialized or null")
-        return null
+    val state = dataViewStateOrNull()
+    if (state == null) {
+        Timber.w("State was not initialized or null")
     }
     return state
 }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ViewerLayoutWidgetUi.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ViewerLayoutWidgetUi.kt
@@ -152,19 +152,13 @@ suspend fun ViewerLayoutWidgetUi.updateState(
     )
 }
 
-private val GROUP_BY_FORMATS = setOf(
-    RelationFormat.STATUS,
-    RelationFormat.TAG,
-    RelationFormat.CHECKBOX
-)
-
 private suspend fun DVViewer.getGroupByItems(
     storeOfRelations: StoreOfRelations,
     relationLinks: List<RelationLink>
 ): List<ViewerLayoutWidgetUi.State.GroupBy> {
     val selectedGroupKey = groupRelationKey
     return relationLinks
-        .filter { it.format in GROUP_BY_FORMATS }
+        .filter { it.format in BOARD_GROUP_BY_FORMATS }
         .mapNotNull { storeOfRelations.getByKey(it.key) }
         .filter { relation ->
             relation.isValid && relation.isHidden != true && relation.isArchived != true &&

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/main/ObjectSetBoardSubscriptionTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/main/ObjectSetBoardSubscriptionTest.kt
@@ -7,8 +7,10 @@ import com.anytypeio.anytype.core_models.ObjectType
 import com.anytypeio.anytype.core_models.ObjectViewDetails
 import com.anytypeio.anytype.core_models.ObjectWrapper
 import com.anytypeio.anytype.core_models.Payload
+import com.anytypeio.anytype.core_models.RelationFormat
 import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.core_models.StubDataView
+import com.anytypeio.anytype.core_models.StubRelationObject
 import com.anytypeio.anytype.core_models.StubTitle
 import com.anytypeio.anytype.domain.base.Either
 import com.anytypeio.anytype.domain.base.Resultat
@@ -389,4 +391,74 @@ class ObjectSetBoardSubscriptionTest : ObjectSetViewModelTestSetup() {
         // Relation move + an order write that places the card at the drop position.
         verifyBlocking(setDataViewObjectOrder) { async(any()) }
     }
+
+    //region DROID-4555: grouping properties the backend cannot group by
+
+    /** Merges the board's grouping property into the relation store with [format]. */
+    private suspend fun givenGroupRelationFormat(format: RelationFormat) {
+        storeOfRelations.merge(
+            listOf(StubRelationObject(key = groupRelationKey, format = format))
+        )
+    }
+
+    @Test
+    fun `does not ask the backend to group by a property it cannot group by`() = runTest {
+        stubBoardCollection()
+        // A board configured on another client can carry any relation as its grouping property,
+        // but the backend grouper only handles Status/Tag/Checkbox and rejects the rest with
+        // "get grouper: unsupported relation format".
+        givenGroupRelationFormat(RelationFormat.NUMBER)
+
+        val vm = givenViewModel()
+        vm.onStart(view = boardViewerId)
+        advanceUntilIdle()
+
+        verify(boardGroupSubscriptionContainer, never()).observe(any())
+    }
+
+    @Test
+    fun `board grouped by an ungroupable property asks for a grouping property`() = runTest {
+        stubBoardCollection()
+        givenGroupRelationFormat(RelationFormat.NUMBER)
+
+        val vm = givenViewModel()
+        vm.onStart(view = boardViewerId)
+        advanceUntilIdle()
+
+        // The actionable hint, not the opaque subscription error the refused request would leave.
+        val state = vm.currentViewer.value
+        assertTrue(
+            state is DataViewViewState.Collection.NoItems && state.isBoardGroupByRequired,
+            "Expected Collection.NoItems(isBoardGroupByRequired=true) but was $state"
+        )
+    }
+
+    @Test
+    fun `still groups by a supported property`() = runTest {
+        stubBoardCollection()
+        givenGroupRelationFormat(RelationFormat.TAG)
+        boardGroupSubscriptionContainer.stub { on { observe(any()) } doReturn flowOf(emptyList()) }
+
+        val vm = givenViewModel()
+        vm.onStart(view = boardViewerId)
+        advanceUntilIdle()
+
+        verify(boardGroupSubscriptionContainer, atLeastOnce()).observe(any())
+    }
+
+    @Test
+    fun `groups optimistically while the property's format is still unknown`() = runTest {
+        stubBoardCollection()
+        // storeOfRelations deliberately left empty: the format resolves asynchronously, and
+        // refusing on an unresolved one would strand a perfectly valid board on the first verdict.
+        boardGroupSubscriptionContainer.stub { on { observe(any()) } doReturn flowOf(emptyList()) }
+
+        val vm = givenViewModel()
+        vm.onStart(view = boardViewerId)
+        advanceUntilIdle()
+
+        verify(boardGroupSubscriptionContainer, atLeastOnce()).observe(any())
+    }
+
+    //endregion
 }

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/main/ObjectSetInitializationTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/main/ObjectSetInitializationTest.kt
@@ -1,14 +1,18 @@
 package com.anytypeio.anytype.presentation.sets.main
 
+import android.util.Log
 import com.anytypeio.anytype.presentation.collections.MockSet
 import com.anytypeio.anytype.presentation.sets.ObjectSetViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.verifyNoInteractions
+import timber.log.Timber
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ObjectSetInitializationTest : ObjectSetViewModelTestSetup() {
@@ -47,7 +51,47 @@ class ObjectSetInitializationTest : ObjectSetViewModelTestSetup() {
         verifyNoInteractions(createObject)
     }
 
+    @Test
+    fun `should not report the not-yet-initialized state at error level`() = runTest {
+        // SETUP
+        // ERROR is the level SentryTimberIntegration forwards as a reported issue, so anything
+        // logged at it during a routine open becomes noise in crash reporting (DROID-4555).
+        val reportedAtErrorLevel = mutableListOf<String>()
+        val tree = object : Timber.Tree() {
+            override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+                if (priority >= Log.ERROR) reportedAtErrorLevel.add(message)
+            }
+        }
+        Timber.plant(tree)
+        stubSpaceManager(mockObjectSet.spaceId)
+        // No data view block: the state stays uninitialized for the whole test, which is what the
+        // collectors started in onStart observe before the object finishes opening.
+        stubOpenObject(
+            doc = listOf(mockObjectSet.header, mockObjectSet.title),
+            details = mockObjectSet.details
+        )
+
+        // TESTING
+        try {
+            proceedWithStartingViewModel()
+            advanceUntilIdle()
+        } finally {
+            Timber.uproot(tree)
+        }
+
+        // ASSERT
+        assertTrue(
+            reportedAtErrorLevel.none { it.contains(UNINITIALIZED_STATE_MESSAGE) },
+            "Observing the not-yet-initialized state is an expected step of opening a set, " +
+                    "but it was reported at ERROR: $reportedAtErrorLevel"
+        )
+    }
+
     private fun proceedWithStartingViewModel() {
         viewModel.onStart()
+    }
+
+    companion object {
+        private const val UNINITIALIZED_STATE_MESSAGE = "State was not initialized or null"
     }
 }


### PR DESCRIPTION
### Description

Two Sentry issues that surfaced on 0.48.9, both reported as crashes. Neither is a crash — and one isn't a defect at all, just a log level.

**1. `ObjectSetViewModel: State was not initialized or null` (~150 events / 13 users)**

`dataViewState()` logs at ERROR whenever the state isn't an initialized data view, and `SentryTimberIntegration(minEventLevel = ERROR)` turns every `Timber.e` into a reported issue. Six always-on collectors read that state on every emission, and `onStart()` launches all of them *before* `proceedWithOpeningCurrentObject`:

```kotlin
subscribeToObjectState()              // 737
subscribeToBoardGroupOptions()        // 738
subscribeToDataViewRelationOptions()  // 739
subscribeToBoardGroups()              // 740
subscribeToBoardRecords()             // 741
proceedWithOpeningCurrentObject(...)  // 742  ← only now does the state get populated
```

`MutableStateFlow` always replays its current value, so every fresh `ObjectSetViewModel` deterministically reported six errors for a state the app is designed to pass through. The five distinct collector stack traces are why the issue arrived split across five Sentry groups.

Fixed by splitting the accessor — `dataViewStateOrNull()` is silent, for reactive collectors; the logging `dataViewState()` stays for one-shot handlers, downgraded to WARN (the message carries no object id or call site to act on, and WARN still clears the breadcrumb threshold).

**Not a regression in 0.48.9.** Four of the six call sites came from DROID-4529 (Kanban) and one from DROID-4542, both shipped in **0.48.4**. The `release` tag reflects rollout, not the change point.

**2. `get grouper: unsupported relation format` (4 events / 1 user)**

`buildBoardGroupParams` passed any persisted `groupRelationKey` to the backend with only an `isNotEmpty()` check. The picker already restricts to Status/Tag/Checkbox, but a board configured on another client (or whose relation changed format) reaches the middleware with an ungroupable key, fails the subscription, and lands in a generic error state instead of the existing "choose a grouping property" hint.

Fixed by sharing `BOARD_GROUP_BY_FORMATS` between picker and subscription, refusing the request the backend would reject, and broadening the missing-group-relation predicate to cover it. Formats resolve **optimistically** — an unresolved format counts as usable, and the collector re-evaluates on `storeOfRelations.trackChanges()` — so a board whose relation hasn't loaded yet is never stranded. The render also prefers the actionable hint over `hasBoardSubscriptionFailed`, which is sticky until `onStop`.

### What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

### Related Tickets & Documents

DROID-4555 · Sentry [ANDROID-QFV] and https://sentry.anytype.io/organizations/anytype/issues/105360/

### Mobile & Desktop Screenshots/Recordings

No visual change for issue 1. For issue 2, an affected board now shows the existing "choose a grouping property" empty state instead of the generic error.

### Added tests?

- [x] 👍 yes

`ObjectSetInitializationTest` plants a `Timber.Tree` and asserts nothing crosses the ERROR threshold during a routine open — it captured **6** events before the fix, 0 after. Testing the observable contract with Sentry rather than which helper gets called means it keeps holding if a seventh collector is added later.

`ObjectSetBoardSubscriptionTest` gains 4 cases: the subscription is refused for an ungroupable format, the render shows the hint, and — the no-regression side — a supported format and a not-yet-resolved format both still subscribe. Each of the first two was verified to fail when its own mechanism is disabled.

Full `:presentation` suite: **1314 tests, 0 failures**. `:app:compileDebugKotlin` passes.

### Added to documentation?

- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

Both Sentry issues should stop accruing events on the next release. If `State was not initialized or null` reappears at ERROR, a new call site is using the logging accessor from a reactive path.

One known limitation on issue 2: on a cold open where the relation format resolves *after* the first evaluation, a single backend error can still fire before the collector re-evaluates and drops the subscription. That's the deliberate trade for never blocking a valid board on an unresolved format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
