### PR TITLE
DROID-4556 Chats | Fix | Recover new messages stranded by a detached chat window

### DIFF
--- a/domain/src/main/java/com/anytypeio/anytype/domain/chats/ChatContainer.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/chats/ChatContainer.kt
@@ -238,6 +238,11 @@ class ChatContainer @Inject constructor(
             // empty round-trips when the user keeps bouncing off the top of the chat.
             var noMoreMessagesBeforeOrder: Id? = null
 
+            // The newest message the UI last reported as visible, or null while no visible
+            // range has been reported yet. Scoped to this collection so it resets on
+            // re-subscription and can never leak between chats.
+            var newestVisibleMessageId: Id? = null
+
             val initial = buildList {
                 if (initialState.hasUnReadMessages && !initialState.oldestMessageOrderId.isNullOrEmpty()) {
                     val lastUnreadMessage = response.messages.find { it.order == initialState.oldestMessageOrderId }
@@ -301,8 +306,13 @@ class ChatContainer @Inject constructor(
                                 if (previousPage != null && previousPage.isEmpty() && first != null) {
                                     noMoreMessagesBeforeOrder = first.order
                                 }
+                                // See loadTheNextPage: overlapping pages must not produce
+                                // duplicate ids in the window.
+                                val known = state.messages.mapTo(HashSet()) { it.id }
                                 ChatStreamState(
-                                    messages = (previousPage.orEmpty() + state.messages).trimKeepingOldest(),
+                                    messages = (
+                                            previousPage.orEmpty().filter { known.add(it.id) } + state.messages
+                                            ).trimKeepingOldest(),
                                     intent = Intent.None,
                                     state = state.state,
                                     initialUnreadSectionMessageId = state.initialUnreadSectionMessageId
@@ -314,7 +324,11 @@ class ChatContainer @Inject constructor(
                                 messages = loadTheNextPage(state.messages, chat).trimKeepingNewest(),
                                 intent = Intent.None,
                                 state = state.state,
-                                initialUnreadSectionMessageId = null
+                                // Preserved, mirroring LoadPrevious: the first forward page is
+                                // precisely where the unread messages are. The divider clears
+                                // itself once its anchor leaves the window, since the view model
+                                // only renders it for a message the window still holds.
+                                initialUnreadSectionMessageId = state.initialUnreadSectionMessageId
                             )
                         }
                         is Transformation.Commands.LoadAround -> {
@@ -469,6 +483,9 @@ class ChatContainer @Inject constructor(
                             )
                         }
                         is Transformation.Commands.UpdateVisibleRange -> {
+                            // [from] is the NEWEST visible message: the UI list is reversed,
+                            // so the lowest visible index is the most recent message.
+                            newestVisibleMessageId = transform.from
                             val counterState = state.state
                             val bottomVisibleMessage = state.messages.find { it.id == transform.from }
                             if (bottomVisibleMessage != null) {
@@ -480,7 +497,42 @@ class ChatContainer @Inject constructor(
                             state
                         }
                         is Transformation.Events.Payload -> {
-                            state.reduce(transform.events)
+                            var strandedTailMessage = false
+                            val reduced = state.reduce(transform.events) {
+                                strandedTailMessage = true
+                            }
+                            if (strandedTailMessage &&
+                                isParkedAtWindowTail(reduced.messages, newestVisibleMessageId)
+                            ) {
+                                // DROID-4556: the user is parked at the newest edge of a window
+                                // detached from the chat tail. Nothing is below them to scroll
+                                // into and the window size never changes, so the UI's
+                                // bottom-reach detector never re-arms and the stranded message
+                                // can never enter the window through user-driven LoadNext
+                                // paging — the chat looks frozen until the user scrolls up and
+                                // back down.
+                                //
+                                // Extend the window forward here, through the same contiguous
+                                // paging path LoadNext uses, so no range is skipped.
+                                //
+                                // Exactly ONE page: a successful extension moves the window
+                                // tail past [newestVisibleMessageId], so a burst of stranded
+                                // messages cannot cascade into a round-trip per event, and the
+                                // size change re-arms the UI detector — handing paging back to
+                                // the user. Looping until attached would instead block the fold
+                                // on N round-trips and let trimKeepingNewest evict the history
+                                // under the user's scroll anchor.
+                                val extended = loadTheNextPage(reduced.messages, chat)
+                                if (extended.size != reduced.messages.size) {
+                                    reduced.copy(messages = extended.trimKeepingNewest())
+                                } else {
+                                    // Empty page or a failed round-trip: the window tail has not
+                                    // moved, so the next incoming message retries.
+                                    reduced
+                                }
+                            } else {
+                                reduced
+                            }
                         }
                     }
                 }.onEach {
@@ -657,7 +709,11 @@ class ChatContainer @Inject constructor(
                     limit = DEFAULT_CHAT_PAGING_SIZE
                 )
             )
-            state + next.messages
+            // The window is rendered by a LazyColumn keyed on message id, and duplicate
+            // keys throw — so a page overlapping the window (e.g. one echoing the boundary
+            // message) must never introduce a duplicate.
+            val known = state.mapTo(HashSet()) { it.id }
+            state + next.messages.filter { known.add(it.id) }
         } else {
             state.also {
                 logger.logWarning("DROID-2966 The last message not found in chat")
@@ -723,6 +779,23 @@ class ChatContainer @Inject constructor(
         return window.any { it.id == newestKnown.id }
     }
 
+    /**
+     * Whether the user is parked at the newest edge of [window] — with nothing below them
+     * left to scroll into.
+     *
+     * Conservative by design: while no visible range has been reported (the chat has just
+     * opened, or an initial scroll intent is still being applied) [newestVisibleMessageId]
+     * is null and the window is never auto-extended. A user reading old history is therefore
+     * never yanked by [trimKeepingNewest] evicting the messages under their scroll anchor.
+     */
+    private fun isParkedAtWindowTail(
+        window: List<Chat.Message>,
+        newestVisibleMessageId: Id?
+    ): Boolean {
+        if (newestVisibleMessageId == null || window.isEmpty()) return false
+        return window.last().id == newestVisibleMessageId
+    }
+
     @Throws
     private suspend fun loadToEnd(chat: Id): List<Chat.Message> {
         return repo.getChatMessages(
@@ -739,8 +812,14 @@ class ChatContainer @Inject constructor(
         payloads.emit(events)
     }
 
+    /**
+     * @param onTailMessageStranded invoked when a newly added message could not enter the
+     * window because the window is detached from the chat tail. The caller decides how to
+     * recover — see DROID-4556.
+     */
     fun ChatStreamState.reduce(
-        events: List<Event.Command.Chats>
+        events: List<Event.Command.Chats>,
+        onTailMessageStranded: () -> Unit = {}
     ): ChatStreamState {
         val messageList = this.messages.toMutableList()
         var countersState = this.state
@@ -753,15 +832,20 @@ class ChatContainer @Inject constructor(
                             messageList.add(insertIndex, event.message)
                         } else if (isWindowAttachedToChatTail(messageList)) {
                             messageList.add(event.message)
+                        } else {
+                            // The window is detached from the chat tail (older history is
+                            // being browsed after the newest edge was trimmed or the window was
+                            // replaced by a jump-to-message). Appending here would render the new
+                            // message right after a much older one, hiding the not-yet-loaded
+                            // range between them — and LoadNext would then paginate from the
+                            // appended message, permanently skipping that range. The message is
+                            // still tracked in [lastMessages] and will enter the window through
+                            // contiguous LoadNext paging or a LoadEnd reload of the tail.
+                            //
+                            // Neither of those is dispatched while the user sits at the window's
+                            // newest edge, so the caller is told the tail was stranded.
+                            onTailMessageStranded()
                         }
-                        // else: the window is detached from the chat tail (older history is
-                        // being browsed after the newest edge was trimmed or the window was
-                        // replaced by a jump-to-message). Appending here would render the new
-                        // message right after a much older one, hiding the not-yet-loaded
-                        // range between them — and LoadNext would then paginate from the
-                        // appended message, permanently skipping that range. The message is
-                        // still tracked in [lastMessages] and will enter the window through
-                        // contiguous LoadNext paging or a LoadEnd reload of the tail.
                     }
                     // A (re)added message is fetchable again: clear any tombstone so
                     // fetchReplies may resolve it as a reply target.

--- a/domain/src/test/java/com/anytypeio/anytype/domain/chats/ChatContainerTest.kt
+++ b/domain/src/test/java/com/anytypeio/anytype/domain/chats/ChatContainerTest.kt
@@ -1003,9 +1003,14 @@ class ChatContainerTest {
         }
     }
 
+    /**
+     * While no visible range has been reported the container does not know where the user is
+     * looking, so it must not extend the window forward on its own (see DROID-4556) — the
+     * stranded message is only reachable through explicit paging.
+     */
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun `should not append incoming message when window is detached from the chat tail`() = runTest {
+    fun `should not append incoming message when window is detached and no visible range was reported`() = runTest {
 
         val container = ChatContainer(
             repo = repo,
@@ -1135,6 +1140,689 @@ class ChatContainerTest {
             assertEquals(
                 expected = listOf(older, anchor, middle),
                 actual = paged.messages
+            )
+        }
+    }
+
+    /**
+     * DROID-4556. A message arriving while the window is detached from the chat tail is
+     * dropped from the window (see the test above). When the user is parked at the newest
+     * edge of that window, there is nothing below them to scroll into and the window size
+     * never changes — so the UI's bottom-reach detector never re-arms and no LoadNext is
+     * ever dispatched. The chat looks frozen until the user scrolls up and back down.
+     *
+     * The container must therefore extend the window forward itself, through the same
+     * contiguous paging path LoadNext uses.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `should load the next page when a message arrives while the user is parked at the tail of a detached window`() = runTest {
+
+        val container = ChatContainer(
+            repo = repo,
+            channel = channel,
+            logger = logger,
+            subscription = storelessSubscriptionContainer
+        )
+
+        val older = StubChatMessage(order = "A")
+        val anchor = StubChatMessage(order = "B")
+        val middle = StubChatMessage(order = "C")
+        val tail = StubChatMessage(order = "T")
+        val incoming = StubChatMessage(order = "Z")
+
+        repo.stub {
+            onBlocking {
+                subscribeLastChatMessages(
+                    Command.ChatCommand.SubscribeLastMessages(
+                        chat = givenChatID,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE
+                    )
+                )
+            } doReturn Command.ChatCommand.SubscribeLastMessages.Response(
+                messages = listOf(tail),
+                messageCountBefore = 0
+            )
+
+            onBlocking {
+                getChatMessagesByIds(
+                    Command.ChatCommand.GetMessagesByIds(
+                        chat = givenChatID,
+                        messages = listOf(anchor.id)
+                    )
+                )
+            } doReturn listOf(anchor)
+
+            onBlocking {
+                getChatMessages(
+                    Command.ChatCommand.GetMessages(
+                        chat = givenChatID,
+                        beforeOrderId = anchor.order,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE / 2
+                    )
+                )
+            } doReturn Command.ChatCommand.GetMessages.Response(
+                messages = listOf(older)
+            )
+
+            onBlocking {
+                getChatMessages(
+                    Command.ChatCommand.GetMessages(
+                        chat = givenChatID,
+                        afterOrderId = anchor.order,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE / 2
+                    )
+                )
+            } doReturn Command.ChatCommand.GetMessages.Response(
+                messages = emptyList()
+            )
+
+            // The next contiguous page after the detached window: it carries both the
+            // not-yet-loaded range and the message that was just dropped.
+            onBlocking {
+                getChatMessages(
+                    Command.ChatCommand.GetMessages(
+                        chat = givenChatID,
+                        afterOrderId = anchor.order,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE
+                    )
+                )
+            } doReturn Command.ChatCommand.GetMessages.Response(
+                messages = listOf(middle, incoming)
+            )
+        }
+
+        channel.stub {
+            on { observe(chat = givenChatID) } doReturn emptyFlow()
+        }
+
+        container.watch(givenChatID).test {
+            val initial = awaitItem()
+            assertEquals(
+                expected = listOf(tail),
+                actual = initial.messages
+            )
+
+            // Jump to a message far away from the tail — the window no longer contains the tail.
+            container.onLoadToReply(anchor.id)
+            advanceUntilIdle()
+
+            val jumped = awaitItem()
+            assertEquals(
+                expected = listOf(older, anchor),
+                actual = jumped.messages
+            )
+
+            // The user is parked at the newest edge of the window: the newest visible
+            // message is the newest message the window holds.
+            container.onVisibleRangeChanged(from = anchor.id, to = older.id)
+            advanceUntilIdle()
+
+            container.onPayload(
+                listOf(
+                    Event.Command.Chats.Add(
+                        context = givenChatID,
+                        message = incoming,
+                        id = incoming.id,
+                        order = incoming.order,
+                        spaceId = SpaceId(MockDataFactory.randomUuid())
+                    )
+                )
+            )
+            advanceUntilIdle()
+
+            // [middle] proves the intervening range was fetched rather than skipped, and
+            // [incoming] proves the stranded message became reachable — had it simply been
+            // appended, [middle] would be missing and the gap would be hidden.
+            val healed = awaitItem()
+            assertEquals(
+                expected = listOf(older, anchor, middle, incoming),
+                actual = healed.messages
+            )
+        }
+    }
+
+    /**
+     * DROID-4556. The forward extension must be gated on the user actually sitting at the
+     * newest edge of the window. A user reading old history is far from it, and extending
+     * forward on every incoming message would let [trimKeepingNewest] evict the history
+     * under their scroll anchor.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `should not extend the window forward when the user is parked away from the window tail`() = runTest {
+
+        val container = ChatContainer(
+            repo = repo,
+            channel = channel,
+            logger = logger,
+            subscription = storelessSubscriptionContainer
+        )
+
+        val older = StubChatMessage(order = "A")
+        val anchor = StubChatMessage(order = "B")
+        val tail = StubChatMessage(order = "T")
+        val incoming = StubChatMessage(order = "Z")
+
+        repo.stub {
+            onBlocking {
+                subscribeLastChatMessages(
+                    Command.ChatCommand.SubscribeLastMessages(
+                        chat = givenChatID,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE
+                    )
+                )
+            } doReturn Command.ChatCommand.SubscribeLastMessages.Response(
+                messages = listOf(tail),
+                messageCountBefore = 0
+            )
+
+            onBlocking {
+                getChatMessagesByIds(
+                    Command.ChatCommand.GetMessagesByIds(
+                        chat = givenChatID,
+                        messages = listOf(anchor.id)
+                    )
+                )
+            } doReturn listOf(anchor)
+
+            onBlocking {
+                getChatMessages(
+                    Command.ChatCommand.GetMessages(
+                        chat = givenChatID,
+                        beforeOrderId = anchor.order,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE / 2
+                    )
+                )
+            } doReturn Command.ChatCommand.GetMessages.Response(
+                messages = listOf(older)
+            )
+
+            onBlocking {
+                getChatMessages(
+                    Command.ChatCommand.GetMessages(
+                        chat = givenChatID,
+                        afterOrderId = anchor.order,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE / 2
+                    )
+                )
+            } doReturn Command.ChatCommand.GetMessages.Response(
+                messages = emptyList()
+            )
+        }
+
+        channel.stub {
+            on { observe(chat = givenChatID) } doReturn emptyFlow()
+        }
+
+        container.watch(givenChatID).test {
+            awaitItem()
+
+            container.onLoadToReply(anchor.id)
+            advanceUntilIdle()
+
+            assertEquals(
+                expected = listOf(older, anchor),
+                actual = awaitItem().messages
+            )
+
+            // The user is reading old history: the newest visible message is the OLDEST
+            // message of the window, not its tail.
+            container.onVisibleRangeChanged(from = older.id, to = older.id)
+            advanceUntilIdle()
+
+            container.onPayload(
+                listOf(
+                    Event.Command.Chats.Add(
+                        context = givenChatID,
+                        message = incoming,
+                        id = incoming.id,
+                        order = incoming.order,
+                        spaceId = SpaceId(MockDataFactory.randomUuid())
+                    )
+                )
+            )
+            advanceUntilIdle()
+
+            assertEquals(
+                expected = listOf(older, anchor),
+                actual = awaitItem().messages
+            )
+        }
+
+        // Explicit verification is required: an unstubbed getChatMessages returns null,
+        // which loadTheNextPage swallows in its catch block — the window would look
+        // unchanged even if the gate were broken.
+        verify(repo, never()).getChatMessages(
+            Command.ChatCommand.GetMessages(
+                chat = givenChatID,
+                afterOrderId = anchor.order,
+                limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE
+            )
+        )
+    }
+
+    /**
+     * DROID-4556. When the window still holds the chat tail, an incoming message is appended
+     * normally and no forward page must be fetched.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `should not fetch a forward page when the window is attached to the chat tail`() = runTest {
+
+        val container = ChatContainer(
+            repo = repo,
+            channel = channel,
+            logger = logger,
+            subscription = storelessSubscriptionContainer
+        )
+
+        val tail = StubChatMessage(order = "T")
+        val incoming = StubChatMessage(order = "Z")
+
+        repo.stub {
+            onBlocking {
+                subscribeLastChatMessages(
+                    Command.ChatCommand.SubscribeLastMessages(
+                        chat = givenChatID,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE
+                    )
+                )
+            } doReturn Command.ChatCommand.SubscribeLastMessages.Response(
+                messages = listOf(tail),
+                messageCountBefore = 0
+            )
+        }
+
+        channel.stub {
+            on { observe(chat = givenChatID) } doReturn emptyFlow()
+        }
+
+        container.watch(givenChatID).test {
+            assertEquals(
+                expected = listOf(tail),
+                actual = awaitItem().messages
+            )
+
+            container.onVisibleRangeChanged(from = tail.id, to = tail.id)
+            advanceUntilIdle()
+
+            container.onPayload(
+                listOf(
+                    Event.Command.Chats.Add(
+                        context = givenChatID,
+                        message = incoming,
+                        id = incoming.id,
+                        order = incoming.order,
+                        spaceId = SpaceId(MockDataFactory.randomUuid())
+                    )
+                )
+            )
+            advanceUntilIdle()
+
+            assertEquals(
+                expected = listOf(tail, incoming),
+                actual = awaitItem().messages
+            )
+        }
+
+        verify(repo, never()).getChatMessages(any())
+    }
+
+    /**
+     * DROID-4556. The forward extension is self-limiting: one successful extension moves the
+     * window tail past the message the user is looking at, so a burst of stranded messages
+     * cannot cascade into a round-trip per event. Paging is handed back to the user, whose
+     * next scroll reports a new visible range.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `should load at most one forward page while the reported visible range is unchanged`() = runTest {
+
+        val container = ChatContainer(
+            repo = repo,
+            channel = channel,
+            logger = logger,
+            subscription = storelessSubscriptionContainer
+        )
+
+        val older = StubChatMessage(order = "A")
+        val anchor = StubChatMessage(order = "B")
+        val middle = StubChatMessage(order = "C")
+        val tail = StubChatMessage(order = "T")
+        val incoming = StubChatMessage(order = "Y")
+        val incomingAgain = StubChatMessage(order = "Z")
+
+        repo.stub {
+            onBlocking {
+                subscribeLastChatMessages(
+                    Command.ChatCommand.SubscribeLastMessages(
+                        chat = givenChatID,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE
+                    )
+                )
+            } doReturn Command.ChatCommand.SubscribeLastMessages.Response(
+                messages = listOf(tail),
+                messageCountBefore = 0
+            )
+
+            onBlocking {
+                getChatMessagesByIds(
+                    Command.ChatCommand.GetMessagesByIds(
+                        chat = givenChatID,
+                        messages = listOf(anchor.id)
+                    )
+                )
+            } doReturn listOf(anchor)
+
+            onBlocking {
+                getChatMessages(
+                    Command.ChatCommand.GetMessages(
+                        chat = givenChatID,
+                        beforeOrderId = anchor.order,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE / 2
+                    )
+                )
+            } doReturn Command.ChatCommand.GetMessages.Response(
+                messages = listOf(older)
+            )
+
+            onBlocking {
+                getChatMessages(
+                    Command.ChatCommand.GetMessages(
+                        chat = givenChatID,
+                        afterOrderId = anchor.order,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE / 2
+                    )
+                )
+            } doReturn Command.ChatCommand.GetMessages.Response(
+                messages = emptyList()
+            )
+
+            // Leaves the window still detached from the chat tail.
+            onBlocking {
+                getChatMessages(
+                    Command.ChatCommand.GetMessages(
+                        chat = givenChatID,
+                        afterOrderId = anchor.order,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE
+                    )
+                )
+            } doReturn Command.ChatCommand.GetMessages.Response(
+                messages = listOf(middle)
+            )
+        }
+
+        channel.stub {
+            on { observe(chat = givenChatID) } doReturn emptyFlow()
+        }
+
+        container.watch(givenChatID).test {
+            awaitItem()
+
+            container.onLoadToReply(anchor.id)
+            advanceUntilIdle()
+            awaitItem()
+
+            container.onVisibleRangeChanged(from = anchor.id, to = older.id)
+            advanceUntilIdle()
+
+            container.onPayload(
+                listOf(
+                    Event.Command.Chats.Add(
+                        context = givenChatID,
+                        message = incoming,
+                        id = incoming.id,
+                        order = incoming.order,
+                        spaceId = SpaceId(MockDataFactory.randomUuid())
+                    )
+                )
+            )
+            advanceUntilIdle()
+
+            assertEquals(
+                expected = listOf(older, anchor, middle),
+                actual = awaitItem().messages
+            )
+
+            // The window tail has moved past the message the user reported: a second
+            // stranded message must not trigger another round-trip.
+            container.onPayload(
+                listOf(
+                    Event.Command.Chats.Add(
+                        context = givenChatID,
+                        message = incomingAgain,
+                        id = incomingAgain.id,
+                        order = incomingAgain.order,
+                        spaceId = SpaceId(MockDataFactory.randomUuid())
+                    )
+                )
+            )
+            advanceUntilIdle()
+
+            expectNoEvents()
+        }
+
+        verify(repo, times(1)).getChatMessages(
+            Command.ChatCommand.GetMessages(
+                chat = givenChatID,
+                afterOrderId = anchor.order,
+                limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE
+            )
+        )
+        verify(repo, never()).getChatMessages(
+            Command.ChatCommand.GetMessages(
+                chat = givenChatID,
+                afterOrderId = middle.order,
+                limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE
+            )
+        )
+    }
+
+    /**
+     * The message window feeds a LazyColumn keyed on message id, and duplicate keys throw.
+     * A page that overlaps the window — e.g. a middleware echoing the boundary message —
+     * must therefore never introduce a duplicate.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `should not duplicate messages already present in the window when loading the next page`() = runTest {
+
+        val container = ChatContainer(
+            repo = repo,
+            channel = channel,
+            logger = logger,
+            subscription = storelessSubscriptionContainer
+        )
+
+        val first = StubChatMessage(order = "A")
+        val second = StubChatMessage(order = "B")
+        val third = StubChatMessage(order = "C")
+
+        repo.stub {
+            onBlocking {
+                subscribeLastChatMessages(
+                    Command.ChatCommand.SubscribeLastMessages(
+                        chat = givenChatID,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE
+                    )
+                )
+            } doReturn Command.ChatCommand.SubscribeLastMessages.Response(
+                messages = listOf(first, second),
+                messageCountBefore = 0
+            )
+
+            // The boundary message comes back with the page.
+            onBlocking {
+                getChatMessages(
+                    Command.ChatCommand.GetMessages(
+                        chat = givenChatID,
+                        afterOrderId = second.order,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE
+                    )
+                )
+            } doReturn Command.ChatCommand.GetMessages.Response(
+                messages = listOf(second, third)
+            )
+        }
+
+        channel.stub {
+            on { observe(chat = givenChatID) } doReturn emptyFlow()
+        }
+
+        container.watch(givenChatID).test {
+            assertEquals(
+                expected = listOf(first, second),
+                actual = awaitItem().messages
+            )
+
+            container.onLoadNext()
+            advanceUntilIdle()
+
+            assertEquals(
+                expected = listOf(first, second, third),
+                actual = awaitItem().messages
+            )
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `should not duplicate messages already present in the window when loading the previous page`() = runTest {
+
+        val container = ChatContainer(
+            repo = repo,
+            channel = channel,
+            logger = logger,
+            subscription = storelessSubscriptionContainer
+        )
+
+        val first = StubChatMessage(order = "A")
+        val second = StubChatMessage(order = "B")
+        val third = StubChatMessage(order = "C")
+
+        repo.stub {
+            onBlocking {
+                subscribeLastChatMessages(
+                    Command.ChatCommand.SubscribeLastMessages(
+                        chat = givenChatID,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE
+                    )
+                )
+            } doReturn Command.ChatCommand.SubscribeLastMessages.Response(
+                messages = listOf(second, third),
+                messageCountBefore = 0
+            )
+
+            // The boundary message comes back with the page.
+            onBlocking {
+                getChatMessages(
+                    Command.ChatCommand.GetMessages(
+                        chat = givenChatID,
+                        beforeOrderId = second.order,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE
+                    )
+                )
+            } doReturn Command.ChatCommand.GetMessages.Response(
+                messages = listOf(first, second)
+            )
+        }
+
+        channel.stub {
+            on { observe(chat = givenChatID) } doReturn emptyFlow()
+        }
+
+        container.watch(givenChatID).test {
+            assertEquals(
+                expected = listOf(second, third),
+                actual = awaitItem().messages
+            )
+
+            container.onLoadPrevious()
+            advanceUntilIdle()
+
+            assertEquals(
+                expected = listOf(first, second, third),
+                actual = awaitItem().messages
+            )
+        }
+    }
+
+    /**
+     * The "New messages" divider is anchored on [ChatStreamState.initialUnreadSectionMessageId].
+     * LoadPrevious and the event fold both preserve it; LoadNext must too, since the first
+     * forward page is precisely where the unread messages are. Note LoadNext also fires when
+     * the user merely bounces off the bottom of an already-complete window, which would
+     * otherwise destroy the divider without any forward navigation having happened.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `should keep the new-messages divider when loading the next page`() = runTest {
+
+        val container = ChatContainer(
+            repo = repo,
+            channel = channel,
+            logger = logger,
+            subscription = storelessSubscriptionContainer
+        )
+
+        val read = StubChatMessage(order = "A")
+        val oldestUnread = StubChatMessage(order = "B")
+        val next = StubChatMessage(order = "C")
+
+        repo.stub {
+            onBlocking {
+                subscribeLastChatMessages(
+                    Command.ChatCommand.SubscribeLastMessages(
+                        chat = givenChatID,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE
+                    )
+                )
+            } doReturn Command.ChatCommand.SubscribeLastMessages.Response(
+                messages = listOf(read, oldestUnread),
+                messageCountBefore = 0,
+                chatState = Chat.State(
+                    unreadMessages = Chat.State.UnreadState(
+                        counter = 1,
+                        olderOrderId = oldestUnread.order
+                    )
+                )
+            )
+
+            onBlocking {
+                getChatMessages(
+                    Command.ChatCommand.GetMessages(
+                        chat = givenChatID,
+                        afterOrderId = oldestUnread.order,
+                        limit = ChatContainer.DEFAULT_CHAT_PAGING_SIZE
+                    )
+                )
+            } doReturn Command.ChatCommand.GetMessages.Response(
+                messages = listOf(next)
+            )
+        }
+
+        channel.stub {
+            on { observe(chat = givenChatID) } doReturn emptyFlow()
+        }
+
+        container.watch(givenChatID).test {
+            assertEquals(
+                expected = oldestUnread.id,
+                actual = awaitItem().initialUnreadSectionMessageId
+            )
+
+            container.onLoadNext()
+            advanceUntilIdle()
+
+            val paged = awaitItem()
+            assertEquals(
+                expected = listOf(read, oldestUnread, next),
+                actual = paged.messages
+            )
+            assertEquals(
+                expected = oldestUnread.id,
+                actual = paged.initialUnreadSectionMessageId
             )
         }
     }

--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/ChatScreen.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/ChatScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -403,6 +404,38 @@ private fun LazyListState.OnBottomReachedSafely(
 }
 
 /**
+ * Whether the chat should follow its tail — scroll to the newest message — after the item
+ * count changed.
+ *
+ * [wasAtBottom] is deliberately the value captured before the layout pass: the effect that
+ * consumes this runs in the frame callback, before measure, and once an item has been added
+ * at index 0 the live "is at bottom" reading is already false. Following the tail therefore
+ * has to be decided from the pre-change position.
+ *
+ * The item count alone cannot tell an arriving message from a page load: the list is
+ * reversed, so both land at index 0. It is the *size of the change* that distinguishes them
+ * — if fewer items arrived than fit on screen, following the tail keeps the user's context;
+ * if more arrived, following it would teleport the user past everything that just loaded.
+ * That is DROID-4556: a forward page fetched because the user scrolled down to read new
+ * messages must not immediately scroll them past those messages.
+ */
+internal fun shouldFollowChatTail(
+    wasAtBottom: Boolean,
+    isPerformingScrollIntent: Boolean,
+    previousItemCount: Int,
+    newItemCount: Int,
+    viewportItemCount: Int
+): Boolean {
+    if (!wasAtBottom || isPerformingScrollIntent) return false
+    // First population of the list.
+    if (previousItemCount == 0) return true
+    val appended = newItemCount - previousItemCount
+    // Deletion, or a window trim: not a new-message arrival.
+    if (appended <= 0) return true
+    return appended <= maxOf(viewportItemCount, 1)
+}
+
+/**
  * TODO: do date formating before rendering?
  */
 @Composable
@@ -640,12 +673,25 @@ fun ChatScreen(
             }
     }
 
+    // Item count of the previous emission — used to tell a live tail append (follow it)
+    // from a page that landed below the viewport (stay put — DROID-4556).
+    var previousItemCount by remember { mutableIntStateOf(0) }
+
     // Scrolling to bottom when list size changes and we are at the bottom of the list
     LaunchedEffect(messages.size) {
-        if (wasAtBottom && !isPerformingScrollIntent.value) {
+        val previous = previousItemCount
+        previousItemCount = messages.size
+        val shouldFollow = shouldFollowChatTail(
+            wasAtBottom = wasAtBottom,
+            isPerformingScrollIntent = isPerformingScrollIntent.value,
+            previousItemCount = previous,
+            newItemCount = messages.size,
+            viewportItemCount = lazyListState.layoutInfo.visibleItemsInfo.size
+        )
+        if (shouldFollow) {
             lazyListState.animateScrollToItem(0)
         } else {
-            Timber.d("DROID-2966 Skipping auto-scroll")
+            Timber.d("DROID-2966 Skipping auto-scroll: $previous -> ${messages.size}")
         }
     }
 

--- a/feature-chats/src/test/java/com/anytypeio/anytype/feature_chats/ui/ChatTailFollowTest.kt
+++ b/feature-chats/src/test/java/com/anytypeio/anytype/feature_chats/ui/ChatTailFollowTest.kt
@@ -1,0 +1,146 @@
+package com.anytypeio.anytype.feature_chats.ui
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+/**
+ * DROID-4556. The chat list is reversed, so an arriving message and a freshly loaded page of
+ * older-than-newest messages both land at index 0. Only the size of the change tells them
+ * apart, and following the tail after a page load would scroll the user past the very
+ * messages they scrolled down to read.
+ */
+class ChatTailFollowTest {
+
+    private val viewport = 12
+
+    @Test
+    fun `should follow the tail when a single message arrives`() {
+        assertTrue(
+            shouldFollowChatTail(
+                wasAtBottom = true,
+                isPerformingScrollIntent = false,
+                previousItemCount = 40,
+                newItemCount = 41,
+                viewportItemCount = viewport
+            )
+        )
+    }
+
+    @Test
+    fun `should follow the tail when a message arrives together with a date section`() {
+        assertTrue(
+            shouldFollowChatTail(
+                wasAtBottom = true,
+                isPerformingScrollIntent = false,
+                previousItemCount = 40,
+                newItemCount = 42,
+                viewportItemCount = viewport
+            )
+        )
+    }
+
+    @Test
+    fun `should follow the tail when a small burst of messages arrives`() {
+        assertTrue(
+            shouldFollowChatTail(
+                wasAtBottom = true,
+                isPerformingScrollIntent = false,
+                previousItemCount = 40,
+                newItemCount = 44,
+                viewportItemCount = viewport
+            )
+        )
+    }
+
+    @Test
+    fun `should not follow the tail when a whole page is loaded`() {
+        assertFalse(
+            shouldFollowChatTail(
+                wasAtBottom = true,
+                isPerformingScrollIntent = false,
+                previousItemCount = 40,
+                newItemCount = 140,
+                viewportItemCount = viewport
+            )
+        )
+    }
+
+    @Test
+    fun `should not follow the tail when more messages arrive than fit on screen`() {
+        assertFalse(
+            shouldFollowChatTail(
+                wasAtBottom = true,
+                isPerformingScrollIntent = false,
+                previousItemCount = 40,
+                newItemCount = 40 + viewport + 1,
+                viewportItemCount = viewport
+            )
+        )
+    }
+
+    @Test
+    fun `should follow the tail on the first population of the list`() {
+        assertTrue(
+            shouldFollowChatTail(
+                wasAtBottom = true,
+                isPerformingScrollIntent = false,
+                previousItemCount = 0,
+                newItemCount = 100,
+                viewportItemCount = 0
+            )
+        )
+    }
+
+    @Test
+    fun `should follow the tail when the window shrank`() {
+        assertTrue(
+            shouldFollowChatTail(
+                wasAtBottom = true,
+                isPerformingScrollIntent = false,
+                previousItemCount = 40,
+                newItemCount = 39,
+                viewportItemCount = viewport
+            )
+        )
+    }
+
+    @Test
+    fun `should not follow the tail when the user was not at the bottom`() {
+        assertFalse(
+            shouldFollowChatTail(
+                wasAtBottom = false,
+                isPerformingScrollIntent = false,
+                previousItemCount = 40,
+                newItemCount = 41,
+                viewportItemCount = viewport
+            )
+        )
+    }
+
+    @Test
+    fun `should not follow the tail while a scroll intent is being performed`() {
+        assertFalse(
+            shouldFollowChatTail(
+                wasAtBottom = true,
+                isPerformingScrollIntent = true,
+                previousItemCount = 40,
+                newItemCount = 41,
+                viewportItemCount = viewport
+            )
+        )
+    }
+
+    @Test
+    fun `should follow the tail when the viewport has not been measured yet`() {
+        assertTrue(
+            shouldFollowChatTail(
+                wasAtBottom = true,
+                isPerformingScrollIntent = false,
+                previousItemCount = 40,
+                newItemCount = 41,
+                viewportItemCount = 0
+            )
+        )
+    }
+}


### PR DESCRIPTION
Fixes [DROID-4556](https://linear.app/anytype/issue/DROID-4556/chat-scroll-to-read-new-messages-blocked).

## Problem

A community user on 0.48.9 reported that after a chat syncs and the unread badge appears, scrolling down becomes impossible until they first scroll up — and then far more messages than the badge indicated turn up below.

`ChatContainer.reduce` drops an incoming `Chats.Add` while the message window is detached from the chat tail, so a new message is never rendered straight after much older history with the not-yet-loaded range hidden in between. Its comment promises the message "will enter the window through contiguous LoadNext paging".

**Nothing dispatches that LoadNext.** The only caller is `OnBottomReachedSafely`, which is edge-triggered — `distinctUntilChanged()` on the visible item index, re-armed only when `messages.size` changes. Dropping an `Add` leaves the size unchanged, so the recovery path has no caller and the list has nothing below index 0 left to scroll to. Scrolling up and back is the only way to push a new index through that `distinctUntilChanged()`.

Regression from `62d0f4a38` (DROID-4540), which introduced the drop; it ships in 0.48.6–0.48.9. Before that commit `Add` always appended, so the size always changed and the trigger always re-armed.

The window is detached from frame one in exactly the reported scenario: with >100 unread the oldest unread order falls outside the 100-message subscribe response, so the initial window is built by `loadAroundMessageOrder` (50 before / 50 after) and excludes the tail.

## Fix

`ChatContainer` now recovers on its own instead of waiting for a gesture:

- Records the newest visible message reported through `UpdateVisibleRange` (previously discarded).
- When a message is stranded **and** the user is parked at the window's newest edge, extends the window forward through the same contiguous paging path `LoadNext` uses — so no range is skipped and the no-hidden-gap invariant DROID-4540 protects still holds.
- Exactly one page. A successful extension moves the window tail past the reported position, so a burst of stranded messages cannot cascade into a round-trip per event, and the size change re-arms the UI detector.
- Gating on `isParkedAtWindowTail` is what keeps `trimKeepingNewest` from evicting the history under the scroll anchor of someone deliberately browsing old messages. While no visible range has been reported the window is never auto-extended.

Three adjacent defects in the same path:

- `LoadNext` no longer clears `initialUnreadSectionMessageId`, mirroring `LoadPrevious`. Merely bouncing off the bottom of an already-complete window fires `LoadNext`, which destroyed the "New messages" divider without any forward navigation having happened.
- `loadTheNextPage` and the `LoadPrevious` prepend dedupe against the window. `MessageList` keys its `LazyColumn` on message id and duplicate keys throw.
- `ChatScreen` no longer follows the chat tail after a page load. The list is reversed, so an arriving message and a freshly loaded page both land at index 0; following the latter scrolled the user straight past the messages they had just unlocked. `shouldFollowChatTail` distinguishes them by comparing the item-count delta against the viewport.

## Notes for review

- **The RPC in the fold** is the change most likely to draw attention. It matches what the existing `LoadPrevious`/`LoadNext` branches already do, is bounded to one page per stranded message, and is self-limiting; the rationale is written into the code comment.
- **`wasAtBottom` stays pre-layout on purpose.** `LaunchedEffect` bodies are dispatched in the frame callback before measure, so reading a "live" `isAtBottom` would be equally stale — and since an append at index 0 makes the live value false, using it would break pin-to-bottom outright. The staleness isn't the bug; failing to tell one appended message from a page of 100 is.
- **Trade-off:** a single payload delivering more items than fit on screen while parked at the true chat tail no longer auto-follows. That needs ~10+ simultaneous `Add` events, and the jump-to-bottom FAB covers it. First population, deletions, trims and normal appends are preserved bit-for-bit.
- **Deliberately not included:** a prefetch margin on `OnBottomReachedSafely` (`thresholdItems > 0` is not a drop-in — `distinctUntilChanged()` sits on the raw index, so threshold N fires once per distinct index in `0..N`; it needs a boolean edge first), and a symmetric self-heal trigger on `UpdateVisibleRange`.

## Testing

`ChatContainerTest` — 7 new cases:

| Test | Before |
|---|---|
| loads the next page when a message arrives while parked at the tail of a detached window | **fails** — neither the stranded message nor the intervening range enters the window |
| does not extend forward when parked away from the window tail | passes (guards the trim-yank regression) |
| does not fetch a forward page when the window is attached | passes |
| loads at most one forward page while the reported visible range is unchanged | **fails** |
| keeps the new-messages divider when loading the next page | **fails** |
| no duplicates when loading the next page / the previous page | **fails** |

The pre-existing `should not append incoming message when window is detached…` test is unchanged apart from a rename and a strengthening `verify(never())` — it never reports a visible range, so the conservative gate leaves it green.

`ChatTailFollowTest` (new) table-tests `shouldFollowChatTail`. Verified it has teeth: temporarily restoring the old behaviour reds exactly the 2 page-load cases while the 8 preserve-existing-behaviour cases stay green.

`:domain`, `:feature-chats`, `:presentation` and `:feature-discussions` suites all pass. Note `make test_debug_all` only covers the pure-JVM modules — configuration-on-demand means Android modules' `testDebugUnitTest` never gets attached to `testDebugAll`, so those were run explicitly.

**Not covered by tests:** the Compose scroll path itself — `feature-chats` has no `androidTest` source set or Compose test dependency. On-device the fixed build was exercised through open-with-unread, the divider, forward paging (`101 → 164` items), auto-scroll suppression after a page load, and jump-to-bottom, with no regressions; the stall itself is race-dependent (it needs `LoadNext` to come back empty while the window is detached) and was not reproduced by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)