### PR TITLE
DROID-4554 Properties | Fix | Resolve property type limits before searching objects

### DIFF
--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/relations/ObjectValueCompose.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/relations/ObjectValueCompose.kt
@@ -186,8 +186,18 @@ fun RelationsViewEmpty(
                 title = stringResource(id = R.string.object_values_empty_title),
                 style = BodyCalloutMedium
             )
+            val limitedTo = state.limitedToTypeNames
             AlertDescription(
-                description = stringResource(id = R.string.object_values_empty_description),
+                description = if (limitedTo != null) {
+                    // Name the restriction instead of leaving the user guessing why the
+                    // list is empty (DROID-4554).
+                    stringResource(
+                        id = R.string.object_values_empty_description_limited,
+                        limitedTo
+                    )
+                } else {
+                    stringResource(id = R.string.object_values_empty_description)
+                },
                 style = BodyCalloutMedium
             )
         }

--- a/domain/src/test/java/com/anytypeio/anytype/domain/objects/DefaultStoreOfObjectTypesTest.kt
+++ b/domain/src/test/java/com/anytypeio/anytype/domain/objects/DefaultStoreOfObjectTypesTest.kt
@@ -3,6 +3,8 @@ package com.anytypeio.anytype.domain.objects
 import app.cash.turbine.test
 import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.core_models.Key
+import com.anytypeio.anytype.core_models.ObjectWrapper
+import com.anytypeio.anytype.core_models.RelationFormat
 import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.core_models.Struct
 import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes.TrackedEvent
@@ -171,4 +173,69 @@ class DefaultStoreOfObjectTypesTest {
              cancelAndIgnoreRemainingEvents()
          }
      }
+
+    // --- MAP LIMIT OBJECT TYPES (DROID-4554) ---
+    //
+    // This helper is the single point where a property's configured type ids are reconciled with
+    // the types that actually exist in the space. Both the property-editing UI and the object
+    // value picker depend on it agreeing with itself, so the picker can never enforce a
+    // restriction the settings screen reports as absent.
+
+    private fun objectProperty(limitTypes: List<Id>) = ObjectWrapper.Relation(
+        mapOf(
+            Relations.ID to "rel-connexes",
+            Relations.RELATION_KEY to "connexes",
+            Relations.RELATION_FORMAT to RelationFormat.OBJECT.code.toDouble(),
+            Relations.RELATION_FORMAT_OBJECT_TYPES to limitTypes
+        )
+    )
+
+    @Test
+    fun `mapLimitObjectTypes drops ids with no matching type in the store`() = runTest {
+        val store = newStore()
+        store.set("live", structOfId("live"))
+
+        val result = store.mapLimitObjectTypes(objectProperty(listOf("live", "deleted")))
+
+        assertEquals(listOf("live"), result)
+    }
+
+    @Test
+    fun `mapLimitObjectTypes drops types that are present but invalid`() = runTest {
+        val store = newStore()
+        // No uniqueKey -> ObjectWrapper.Type.isValid == false
+        store.set("half", mapOf(Relations.ID to "half"))
+
+        val result = store.mapLimitObjectTypes(objectProperty(listOf("half")))
+
+        assertEquals(emptyList<Id>(), result)
+    }
+
+    @Test
+    fun `mapLimitObjectTypes returns empty when nothing resolves, signalling no restriction`() =
+        runTest {
+            val store = newStore()
+            store.set("live", structOfId("live"))
+
+            val result = store.mapLimitObjectTypes(objectProperty(listOf("gone-a", "gone-b")))
+
+            assertEquals(emptyList<Id>(), result)
+        }
+
+    @Test
+    fun `mapLimitObjectTypes ignores non-object properties`() = runTest {
+        val store = newStore()
+        store.set("live", structOfId("live"))
+
+        val textProperty = ObjectWrapper.Relation(
+            mapOf(
+                Relations.ID to "rel-text",
+                Relations.RELATION_KEY to "text",
+                Relations.RELATION_FORMAT to RelationFormat.LONG_TEXT.code.toDouble(),
+                Relations.RELATION_FORMAT_OBJECT_TYPES to listOf("live")
+            )
+        )
+
+        assertEquals(emptyList<Id>(), store.mapLimitObjectTypes(textProperty))
+    }
 }

--- a/localization/src/main/res/values/strings.xml
+++ b/localization/src/main/res/values/strings.xml
@@ -1466,6 +1466,7 @@
     <string name="options_delete_description">The option will be permanently removed from your space</string>
 
     <string name="object_values_empty_description">Objects not found</string>
+    <string name="object_values_empty_description_limited">Objects not found. This property only accepts: %1$s</string>
     <string name="object_values_empty_title">No values</string>
     <string name="object_values_empty_not_editable">The property is empty</string>
     <string name="object_values_delete_title">Are you sure?</string>

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
@@ -9064,7 +9064,11 @@ class EditorViewModel(
                         target = context,
                         relationKey = relation.key,
                         isReadOnlyValue = isReadOnlyValue(restrictions),
-                        space = requireNotNull(relation.spaceId)
+                        // The edited object's space, not the relation object's. The value
+                        // screen scopes its search by this twice (RPC + spaceId filter), so
+                        // any drift silently returns zero candidates (DROID-4554). Matches
+                        // ObjectFieldsFragment and ObjectSetFragment, which pass their own space.
+                        space = vmParams.space.id
                     )
                 )
             }
@@ -9075,7 +9079,9 @@ class EditorViewModel(
                         target = context,
                         relationKey = relation.key,
                         isReadOnlyValue = isReadOnlyValue(restrictions),
-                        space = requireNotNull(relation.spaceId)
+                        // See the TagOrStatus branch above: the edited object's space, so the
+                        // candidate search is scoped where the objects actually live.
+                        space = vmParams.space.id
                     )
                 )
             }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
@@ -9029,7 +9029,9 @@ class EditorViewModel(
                         target = context,
                         relationKey = relation.key,
                         isReadOnlyValue = isReadOnlyValue(restrictions),
-                        space = requireNotNull(relation.spaceId)
+                        // See the TagOrStatus branch below: the edited object's space, not the
+                        // relation object's (DROID-4554).
+                        space = vmParams.space.id
                     )
                 )
             }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/object/ObjectValueViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/object/ObjectValueViewModel.kt
@@ -22,6 +22,7 @@ import com.anytypeio.anytype.domain.`object`.UpdateDetail
 import com.anytypeio.anytype.domain.objects.SetObjectListIsArchived
 import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
 import com.anytypeio.anytype.domain.objects.StoreOfRelations
+import com.anytypeio.anytype.domain.objects.mapLimitObjectTypes
 import com.anytypeio.anytype.domain.primitives.FieldParser
 import com.anytypeio.anytype.domain.search.SearchObjects
 import com.anytypeio.anytype.domain.workspace.SpaceManager
@@ -114,20 +115,26 @@ class ObjectValueViewModel(
                         emitCommand(Command.Expand)
                     }
                 }
-                Pair(
-                    ids, getSearchParams(
+                // Resolved once per emission and reused for both the search filter and the
+                // header/empty-state labels, so the query and the UI can never disagree about
+                // which types this property actually accepts.
+                val limitObjectTypes = storeOfObjectTypes.mapLimitObjectTypes(relation)
+                Triple(
+                    ids, limitObjectTypes, getSearchParams(
                         relation = relation,
                         query = query,
-                        ids = ids
+                        ids = ids,
+                        limitObjectTypes = limitObjectTypes
                     )
                 )
-            }.onEach { (ids, searchParams) ->
+            }.onEach { (ids, limitObjectTypes, searchParams) ->
                 objectSearch(params = searchParams).proceed(
                     success = { objects ->
                         initViewState(
                             relation = relation,
                             ids = ids,
                             objects = objects,
+                            limitObjectTypes = limitObjectTypes
                         )
                     },
                     failure = { Timber.e(it, "Error while searching objects") }
@@ -139,7 +146,8 @@ class ObjectValueViewModel(
     private fun getSearchParams(
         relation: ObjectWrapper.Relation,
         query: String,
-        ids: List<Id>
+        ids: List<Id>,
+        limitObjectTypes: List<Id>
     ): SearchObjects.Params {
         val isFileRelation = relation.format == FILE
         val searchKeys =
@@ -158,9 +166,14 @@ class ObjectValueViewModel(
             else -> {
                 if (isEditableRelation) {
                     val isOneToOneSpace = spaceViews.get(viewModelParams.space)?.isOneToOneSpace == true
+                    // Deliberately the resolved list, not relation.relationFormatObjectTypes:
+                    // ids that no longer exist as types in this space (deleted/recreated types,
+                    // ids carried in from another space) would otherwise produce
+                    // `type IN [<dead ids>]`, which matches nothing while every other screen
+                    // reports the property as unrestricted (DROID-4554).
                     ObjectSearchConstants.filterAddObjectToRelation(
                         space = viewModelParams.space.id,
-                        targetTypes = relation.relationFormatObjectTypes,
+                        targetTypes = limitObjectTypes,
                         isOneToOneSpace = isOneToOneSpace
                     )
                 } else {
@@ -205,15 +218,16 @@ class ObjectValueViewModel(
         relation: ObjectWrapper.Relation,
         ids: List<Id>,
         objects: List<ObjectWrapper.Basic>,
+        limitObjectTypes: List<Id>,
         query: String = ""
     ) {
         val views = mapObjects(ids, objects, query, fieldParser, storeOfObjectTypes)
+        val objectTypeNames = getFormatObjectTypeNames(relation, limitObjectTypes)
         viewState.value = if (views.isNotEmpty()) {
             ObjectValueViewState.Content(
                 isEditableRelation = isEditableRelation,
                 title = relation.name.orEmpty(),
                 items = buildList {
-                    val objectTypeNames = getFormatObjectTypeNames(relation)
                     if (isEditableRelation) add(ObjectValueItem.ObjectType(name = objectTypeNames))
                     addAll(views)
                 }
@@ -222,18 +236,25 @@ class ObjectValueViewModel(
             ObjectValueViewState.Empty(
                 isEditableRelation = isEditableRelation,
                 title = relation.name.orEmpty(),
+                // Non-null only when the property genuinely restricts to types that still
+                // exist, so the empty screen can say why nothing is listed instead of the
+                // bare "Objects not found".
+                limitedToTypeNames = objectTypeNames.takeIf { it.isNotBlank() }
             )
         }
     }
 
-    private suspend fun getFormatObjectTypeNames(relation: ObjectWrapper.Relation): String {
+    private suspend fun getFormatObjectTypeNames(
+        relation: ObjectWrapper.Relation,
+        limitObjectTypes: List<Id>
+    ): String {
         val objectTypeKeys =
             if (relation.format == FILE) {
                 ObjectTypeIds.getFileTypes().mapNotNull { key ->
                     storeOfObjectTypes.getByKey(key)?.name?.takeIf { it.isNotBlank() }
                 }
             } else {
-                relation.relationFormatObjectTypes.mapNotNull { id ->
+                limitObjectTypes.mapNotNull { id ->
                     storeOfObjectTypes.get(id)?.name?.takeIf { it.isNotBlank() }
                 }
             }
@@ -477,7 +498,12 @@ sealed class ObjectValueViewState {
 
     data class Empty(
         val title: String,
-        override val isEditableRelation: Boolean
+        override val isEditableRelation: Boolean,
+        /**
+         * Comma-separated names of the object types this property is limited to, or null when
+         * the property accepts anything. Drives the explanatory empty state (DROID-4554).
+         */
+        val limitedToTypeNames: String? = null
     ) : ObjectValueViewState()
 
     data class Content(

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/filter/FilterViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/filter/FilterViewModel.kt
@@ -23,6 +23,7 @@ import com.anytypeio.anytype.domain.dataview.interactor.UpdateDataViewViewer
 import com.anytypeio.anytype.core_models.UrlBuilder
 import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
 import com.anytypeio.anytype.domain.objects.StoreOfRelations
+import com.anytypeio.anytype.domain.objects.mapLimitObjectTypes
 import com.anytypeio.anytype.domain.objects.options.GetOptions
 import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
 import com.anytypeio.anytype.domain.primitives.FieldParser
@@ -313,11 +314,10 @@ open class FilterViewModel(
         }
         Relation.Format.OBJECT -> {
             val ids = filter?.value as? List<*>
-            val limitObjectTypes = buildList {
-                if (relation.relationFormatObjectTypes.isNotEmpty()) {
-                    addAll(relation.relationFormatObjectTypes)
-                }
-            }
+            // Resolved against the type store rather than used raw: ids for types that no
+            // longer exist in this space would otherwise filter every candidate out
+            // (DROID-4554).
+            val limitObjectTypes = storeOfObjectTypes.mapLimitObjectTypes(relation)
             proceedWithSearchObjects(
                 ids = ids,
                 objectTypes = storeOfObjectTypes.getAll(),

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/object/ObjectValueViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/object/ObjectValueViewModelTest.kt
@@ -1,0 +1,271 @@
+package com.anytypeio.anytype.presentation.relations.value.`object`
+
+import com.anytypeio.anytype.analytics.base.Analytics
+import com.anytypeio.anytype.core_models.DVFilter
+import com.anytypeio.anytype.core_models.DVFilterCondition
+import com.anytypeio.anytype.core_models.Id
+import com.anytypeio.anytype.core_models.ObjectWrapper
+import com.anytypeio.anytype.core_models.Payload
+import com.anytypeio.anytype.core_models.RelationFormat
+import com.anytypeio.anytype.core_models.Relations
+import com.anytypeio.anytype.core_models.UrlBuilder
+import com.anytypeio.anytype.core_models.primitives.SpaceId
+import com.anytypeio.anytype.domain.base.Either
+import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
+import com.anytypeio.anytype.domain.`object`.DuplicateObject
+import com.anytypeio.anytype.domain.`object`.UpdateDetail
+import com.anytypeio.anytype.domain.objects.DefaultStoreOfObjectTypes
+import com.anytypeio.anytype.domain.objects.DefaultStoreOfRelations
+import com.anytypeio.anytype.domain.objects.SetObjectListIsArchived
+import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
+import com.anytypeio.anytype.domain.objects.StoreOfRelations
+import com.anytypeio.anytype.domain.primitives.FieldParser
+import com.anytypeio.anytype.domain.search.SearchObjects
+import com.anytypeio.anytype.domain.workspace.SpaceManager
+import com.anytypeio.anytype.presentation.analytics.AnalyticSpaceHelperDelegate
+import com.anytypeio.anytype.presentation.relations.providers.FakeObjectValueProvider
+import com.anytypeio.anytype.presentation.relations.value.tagstatus.RelationContext
+import com.anytypeio.anytype.presentation.util.DefaultCoroutineTestRule
+import com.anytypeio.anytype.presentation.util.Dispatcher
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.whenever
+
+/**
+ * Regression coverage for DROID-4554.
+ *
+ * The picker used to feed the raw `relationFormatObjectTypes` into the search filter, while every
+ * other screen reading that field resolves it against the type store first and drops ids that no
+ * longer exist. A property limited to a deleted type therefore produced `type IN [<dead ids>]`
+ * — matching nothing — while Space settings reported the very same property as "Limit objects: All".
+ *
+ * These tests assert on the filters actually handed to [SearchObjects], since that is where the
+ * two readers diverged.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ObjectValueViewModelTest {
+
+    @get:Rule
+    val coroutineTestRule = DefaultCoroutineTestRule()
+
+    @Mock
+    lateinit var dispatcher: Dispatcher<Payload>
+
+    @Mock
+    lateinit var setObjectDetails: UpdateDetail
+
+    @Mock
+    lateinit var analytics: Analytics
+
+    @Mock
+    lateinit var spaceManager: SpaceManager
+
+    @Mock
+    lateinit var objectSearch: SearchObjects
+
+    @Mock
+    lateinit var urlBuilder: UrlBuilder
+
+    @Mock
+    lateinit var objectListIsArchived: SetObjectListIsArchived
+
+    @Mock
+    lateinit var duplicateObject: DuplicateObject
+
+    @Mock
+    lateinit var analyticSpaceHelperDelegate: AnalyticSpaceHelperDelegate
+
+    @Mock
+    lateinit var fieldParser: FieldParser
+
+    @Mock
+    lateinit var spaceViews: SpaceViewSubscriptionContainer
+
+    private lateinit var storeOfRelations: StoreOfRelations
+    private lateinit var storeOfObjectTypes: StoreOfObjectTypes
+
+    private val ctx: Id = "ctx-id"
+    private val objectId: Id = "object-id"
+    private val space = SpaceId("space-id")
+    private val relationKey = "connexes"
+
+    private val liveTypeId: Id = "type-live"
+    private val staleTypeId: Id = "type-deleted"
+    private val otherStaleTypeId: Id = "type-from-another-space"
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        storeOfRelations = DefaultStoreOfRelations()
+        storeOfObjectTypes = DefaultStoreOfObjectTypes()
+        whenever(analyticSpaceHelperDelegate.provideParams(any()))
+            .thenReturn(AnalyticSpaceHelperDelegate.Params.EMPTY)
+        whenever(spaceViews.get(space)).thenReturn(null)
+        objectSearch.stub {
+            onBlocking { invoke(any()) } doReturn Either.Right(emptyList())
+        }
+    }
+
+    // region helpers
+
+    private fun objectRelation(limitTypes: List<Id>) = ObjectWrapper.Relation(
+        buildMap {
+            put(Relations.ID, "rel-$relationKey")
+            put(Relations.RELATION_KEY, relationKey)
+            put(Relations.NAME, "Connexes")
+            put(Relations.RELATION_FORMAT, RelationFormat.OBJECT.code.toDouble())
+            if (limitTypes.isNotEmpty()) {
+                put(Relations.RELATION_FORMAT_OBJECT_TYPES, limitTypes)
+            }
+        }
+    )
+
+    /** A type as the store holds it — [Relations.UNIQUE_KEY] is what makes it `isValid`. */
+    private fun type(id: Id, name: String) = ObjectWrapper.Type(
+        mapOf(
+            Relations.ID to id,
+            Relations.UNIQUE_KEY to "ot-$id",
+            Relations.NAME to name
+        )
+    )
+
+    /** A type row missing its uniqueKey, i.e. present but `isValid == false`. */
+    private fun invalidType(id: Id) = ObjectWrapper.Type(mapOf(Relations.ID to id))
+
+    private suspend fun buildViewModel(relation: ObjectWrapper.Relation): ObjectValueViewModel {
+        storeOfRelations.merge(listOf(relation))
+        return ObjectValueViewModel(
+            viewModelParams = ObjectValueViewModel.ViewModelParams(
+                ctx = ctx,
+                space = space,
+                objectId = objectId,
+                relationKey = relationKey,
+                isLocked = false,
+                relationContext = RelationContext.OBJECT
+            ),
+            values = FakeObjectValueProvider(
+                values = mapOf(objectId to mapOf(relationKey to emptyList<Id>()))
+            ),
+            dispatcher = dispatcher,
+            setObjectDetails = setObjectDetails,
+            analytics = analytics,
+            spaceManager = spaceManager,
+            objectSearch = objectSearch,
+            urlBuilder = urlBuilder,
+            storeOfObjectTypes = storeOfObjectTypes,
+            objectListIsArchived = objectListIsArchived,
+            duplicateObject = duplicateObject,
+            analyticSpaceHelperDelegate = analyticSpaceHelperDelegate,
+            storeOfRelations = storeOfRelations,
+            fieldParser = fieldParser,
+            spaceViews = spaceViews
+        )
+    }
+
+    private fun capturedFilters(): List<DVFilter> {
+        val captor = argumentCaptor<SearchObjects.Params>()
+        verifyBlocking(objectSearch) { invoke(captor.capture()) }
+        return captor.lastValue.filters
+    }
+
+    private fun List<DVFilter>.typeFilter() = firstOrNull { it.relation == Relations.TYPE }
+    private fun List<DVFilter>.layoutFilter() = firstOrNull { it.relation == Relations.LAYOUT }
+
+    // endregion
+
+    @Test
+    fun `drops type ids that no longer resolve and falls back to the layout filter`() = runTest {
+        // The reported state: the property still references types that were deleted, so the
+        // store resolves none of them.
+        storeOfObjectTypes.merge(listOf(type(liveTypeId, "Task")))
+
+        buildViewModel(objectRelation(listOf(staleTypeId, otherStaleTypeId)))
+        advanceUntilIdle()
+
+        val filters = capturedFilters()
+        assertNull(
+            filters.typeFilter(),
+            "A restriction made entirely of dead ids must not be sent — it can never match."
+        )
+        val layout = requireNotNull(filters.layoutFilter())
+        assertEquals(DVFilterCondition.IN, layout.condition)
+        assertTrue((layout.value as List<*>).isNotEmpty())
+    }
+
+    @Test
+    fun `keeps only the resolvable ids when a restriction is partly stale`() = runTest {
+        storeOfObjectTypes.merge(listOf(type(liveTypeId, "Task")))
+
+        buildViewModel(objectRelation(listOf(staleTypeId, liveTypeId)))
+        advanceUntilIdle()
+
+        val filters = capturedFilters()
+        val typeFilter = requireNotNull(filters.typeFilter())
+        assertEquals(DVFilterCondition.IN, typeFilter.condition)
+        assertEquals(listOf(liveTypeId), typeFilter.value)
+        assertNull(filters.layoutFilter(), "A real restriction replaces the layout fallback.")
+    }
+
+    @Test
+    fun `drops ids whose type row is present but invalid`() = runTest {
+        storeOfObjectTypes.merge(listOf(invalidType(staleTypeId)))
+
+        buildViewModel(objectRelation(listOf(staleTypeId)))
+        advanceUntilIdle()
+
+        val filters = capturedFilters()
+        assertNull(filters.typeFilter())
+        assertTrue(filters.layoutFilter() != null)
+    }
+
+    @Test
+    fun `an unrestricted property still uses the layout filter`() = runTest {
+        storeOfObjectTypes.merge(listOf(type(liveTypeId, "Task")))
+
+        buildViewModel(objectRelation(emptyList()))
+        advanceUntilIdle()
+
+        val filters = capturedFilters()
+        assertNull(filters.typeFilter())
+        assertTrue(filters.layoutFilter() != null)
+    }
+
+    @Test
+    fun `empty state names the types when the restriction is real`() = runTest {
+        storeOfObjectTypes.merge(listOf(type(liveTypeId, "Task")))
+
+        val vm = buildViewModel(objectRelation(listOf(liveTypeId)))
+        advanceUntilIdle()
+
+        val state = vm.viewState.value as ObjectValueViewState.Empty
+        assertEquals("Task", state.limitedToTypeNames)
+    }
+
+    @Test
+    fun `empty state claims no restriction when every id is stale`() = runTest {
+        storeOfObjectTypes.merge(listOf(type(liveTypeId, "Task")))
+
+        val vm = buildViewModel(objectRelation(listOf(staleTypeId)))
+        advanceUntilIdle()
+
+        val state = vm.viewState.value as ObjectValueViewState.Empty
+        assertNull(
+            state.limitedToTypeNames,
+            "Must agree with Space settings, which reports this property as unrestricted."
+        )
+    }
+}


### PR DESCRIPTION
Fixes [DROID-4554](https://linear.app/anytype/issue/DROID-4554/objects-not-found-in-property-object) — [community report](https://community.anytype.io/t/no-object-found-within-property-object-on-android-app/31078).

## Problem

Tapping an Object-format property showed an empty picker — "Objects not found" — even though the space was full of objects. The same property worked on desktop.

The reporter's two screenshots are what pin it down, because they appear to contradict each other:

| | shows |
|---|---|
| **Android** — Space settings → Properties → Connexes | `Limit objects: All` |
| **Desktop** — same property | `Object Types` empty, `Objects 100` |

So the property is *not* restricted, yet Android's picker returns nothing.

## Root cause

Two screens read `relationFormatObjectTypes` differently:

| Screen | Reads | Result |
|---|---|---|
| Space settings → property | `StoreOfObjectTypes.mapLimitObjectTypes` — resolves ids, drops misses | empty list → renders "Limit objects: **All**" |
| Object value picker | `relation.relationFormatObjectTypes` — raw | `type IN [<dead ids>]` → **zero rows** |

`StoreOfObjectTypes` is populated by a subscription filtering `IS_DELETED != true` and `UNIQUE_KEY NOT_EMPTY`, so a **deleted or recreated type** is exactly the kind of id that survives in the relation but resolves to nothing. The app ends up telling the user there is no restriction while the picker enforces an unsatisfiable one.

The deduction, since we can't inspect the reporter's data:

1. They saw "Objects not found" (`object_values_empty_description`), which only renders when `isEditableRelation == true` → the filter was `filterAddObjectToRelation`.
2. That function branches on `targetTypes.isEmpty()`: empty → broad `resolvedLayout IN [BASIC, TODO, NOTE, …]` (would have matched); non-empty → `type IN [ids]`.
3. Empty result → `targetTypes` was **non-empty**.
4. Yet settings showed "All" → `mapLimitObjectTypes` returned empty → **none of those ids resolve**.

**Desktop is the reference contract:** `menu/dataview/object/list.tsx` `getTypes()` maps each id through `S.Record.getTypeById` and `.filter(it => it)`, then pushes the type filter only `if (types && types.length)`. When nothing survives it omits the restriction and searches unrestricted — which is why its list populates.

## Fix

Route the picker through the helper it was bypassing. When nothing resolves, the existing `targetTypes.isEmpty()` branch applies the broad layout filter, matching desktop. No change to `ObjectSearchConstants` was needed.

- **`ObjectValueViewModel`** — `targetTypes` resolved via `mapLimitObjectTypes`; the resolved list is computed once per emission and reused for the header and empty state, so query and UI cannot disagree.
- **`FilterViewModel:317`** — same latent bug in the Set/Collection filter-value picker.
- **Empty state** — now names the restriction instead of a bare "Objects not found", so this class of report is self-diagnosing. Only reachable for a *real* restriction; a stale one now resolves to unrestricted.
- **`EditorViewModel`** (×2) — opens the value screen with the edited object's space rather than `requireNotNull(relation.spaceId)`. That space is applied twice downstream (search RPC scope *and* the `SPACE_ID` filter), so drift produced this same empty state through a separate route. Every other entry point (`ObjectFieldsFragment`, `ObjectSetFragment`) already passes its own space. Also removes a `requireNotNull` crash path.

## Testing

- **New:** `ObjectValueViewModelTest` (6 cases) — stale ids, partly stale, present-but-invalid, no restriction, and both empty-state variants. Asserts on the filters actually handed to `SearchObjects`, which is where the two readers diverged.
- **New:** 4 cases for `mapLimitObjectTypes` in `DefaultStoreOfObjectTypesTest`.
- Verified the new tests bite: reverting just `targetTypes = limitObjectTypes` fails 3 of the 6.
- `:presentation:testDebugUnitTest` — 1315 tests, 0 failures. `:domain:test` — 381 tests, 0 failures. `:app` and `:core-ui` compile.

**Manual repro:** create a custom type → create an Object property limited to it → confirm the picker lists those objects → delete the type → reopen the property. Before: "Objects not found". After: the picker lists the space's objects, consistent with the "All" the app reports.

## Notes for review

- Kept Android's `type IN [resolved ids]` rather than adopting desktop's `type.uniqueKey IN [...]`. After resolution the ids are already local type ids, so they're equivalent, and this confines the diff to one argument.
- Side-effect: a File property's empty state now reads "…only accepts: File, Image, Video, Audio, PDF". Accurate, but a user-visible change beyond object properties — easy to scope to `OBJECT` only if preferred.
- `Value.Text` was moved onto the editor's space too, for consistency. `Value.Date` is now the only dispatch site still on `relation.spaceId` — it runs no candidate search, so the bug class doesn't reach it, but it is the last inconsistent one if we want them uniform.
- The root cause is inferred from the screenshots plus branch logic, not confirmed against the reporter's data. The `ObjectValueViewModel` and `EditorViewModel` changes close both known routes to this empty state, so the fix doesn't depend on which one they hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
