### PR TITLE
DROID-4557 Editor | Fix | Keep IME composition alive across block-identity swaps

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/editor/EditorFragment.kt
@@ -659,9 +659,14 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
                 // would otherwise read the live instances concurrently.
                 val old = blockAdapter.views.diffSnapshot()
                 val new = update.diffSnapshot()
+                // Read on the main thread, like the snapshots above: a block whose id
+                // changed under the caret (trailing placeholder, identity fork) must diff
+                // as a change of the same row, not remove + insert — removing the focused
+                // row clears its focus and kills IME composition (DROID-4557).
+                val aliases = vm.blockIdAliases
                 val result = withContext(Dispatchers.Default) {
                     DiffUtil.calculateDiff(
-                        BlockViewDiffUtil(old = old, new = new),
+                        BlockViewDiffUtil(old = old, new = new, aliases = aliases),
                         false
                     )
                 }

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/BlockAdapter.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/BlockAdapter.kt
@@ -1888,7 +1888,12 @@ class BlockAdapter(
     // https://code.google.com/p/android/issues/detail?id=208169
     override fun onViewAttachedToWindow(holder: BlockViewHolder) {
         super.onViewAttachedToWindow(holder)
-        if (holder is TextHolder) {
+        // Never toggle a focused widget: setEnabled(false) hides the soft input while it
+        // is active, and setEnabled(true) calls InputMethodManager.restartInput(), which
+        // terminates any in-progress IME composition. A holder coming back from the
+        // recycled-view pool has already had its focus cleared, so the workaround still
+        // applies wherever it was actually needed.
+        if (holder is TextHolder && !holder.content.hasFocus()) {
             holder.content.isEnabled = false
             holder.content.isEnabled = true
         }

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/BlockViewDiffUtil.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/BlockViewDiffUtil.kt
@@ -1,6 +1,7 @@
 package com.anytypeio.anytype.core_ui.features.editor
 
 import androidx.recyclerview.widget.DiffUtil
+import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.presentation.editor.editor.Markup
 import com.anytypeio.anytype.presentation.editor.editor.model.BlockView
 import com.anytypeio.anytype.presentation.editor.editor.model.BlockView.Indentable
@@ -8,10 +9,61 @@ import com.anytypeio.anytype.presentation.editor.editor.model.Focusable
 import com.anytypeio.anytype.presentation.relations.ObjectRelationView
 import timber.log.Timber
 
+/**
+ * @param aliases old id -> new id for blocks whose identity changed between [old] and
+ * [new] while staying the same row on screen (see EditorViewModel.blockIdAliases). Without
+ * them an id swap diffs as remove + insert, and removing the focused row detaches its
+ * View, clears focus and terminates any in-progress IME composition (DROID-4557).
+ */
 class BlockViewDiffUtil(
     private val old: List<BlockView>,
-    private val new: List<BlockView>
+    private val new: List<BlockView>,
+    private val aliases: Map<Id, Id> = emptyMap()
 ) : DiffUtil.Callback() {
+
+    /**
+     * [aliases] narrowed to the entries that actually describe a swap in *this* diff, and
+     * proven injective. DiffUtil requires that each old row match at most one new row and
+     * vice versa; an alias that violated that could corrupt the dispatched updates.
+     *
+     * Aliases outlive the render that swapped the id (the ViewModel also uses them to
+     * redirect events still targeting the pre-swap id), so a stale one must stay inert.
+     */
+    private val resolvedAliases: Map<Id, Id> by lazy(LazyThreadSafetyMode.NONE) {
+        if (aliases.isEmpty()) return@lazy emptyMap()
+        val oldIds = old.mapTo(HashSet(old.size)) { it.id }
+        val newIds = new.mapTo(HashSet(new.size)) { it.id }
+        val resolved = mutableMapOf<Id, Id>()
+        val claimed = mutableSetOf<Id>()
+        val ambiguous = mutableSetOf<Id>()
+        aliases.keys.forEach { source ->
+            // Only rows actually present in the old list can be matched. Intermediate
+            // links of a chain (placeholder -> materialized -> forked) are not sources.
+            if (source !in oldIds) return@forEach
+            // The row still exists under its own id — it matches itself. (The virtual
+            // trailing-placeholder id is reused across placeholder sessions.)
+            if (source in newIds) return@forEach
+            val target = follow(source)
+            // The swap has not reached this list yet, or the target row matches itself.
+            if (target == source || target !in newIds || target in oldIds) return@forEach
+            if (!claimed.add(target)) ambiguous += target
+            resolved[source] = target
+        }
+        // Two old rows resolving onto the same new row: drop them rather than pick one
+        // arbitrarily. Falling back to remove+insert costs an IME composition, never
+        // correctness.
+        if (ambiguous.isEmpty()) resolved else resolved.filterValues { it !in ambiguous }
+    }
+
+    /**
+     * Follows the alias chain — a placeholder can materialize and the materialized block
+     * can later fork — bounded so a cyclic map can never hang the diff.
+     */
+    private fun follow(id: Id): Id {
+        var current = id
+        repeat(MAX_ALIAS_HOPS) { current = aliases[current] ?: return current }
+        return current
+    }
 
     override fun getOldListSize() = old.size
     override fun getNewListSize() = new.size
@@ -19,7 +71,11 @@ class BlockViewDiffUtil(
     override fun areItemsTheSame(
         oldItemPosition: Int,
         newItemPosition: Int
-    ) = new[newItemPosition].id == old[oldItemPosition].id
+    ): Boolean {
+        val oldId = old[oldItemPosition].id
+        val newId = new[newItemPosition].id
+        return oldId == newId || resolvedAliases[oldId] == newId
+    }
 
     override fun areContentsTheSame(
         oldItemPosition: Int,
@@ -294,10 +350,16 @@ class BlockViewDiffUtil(
             }
         }
 
-        return if (changes.isNotEmpty())
-            Payload(changes).also { Timber.d("Returning payload: $it") }
-        else
-            super.getChangePayload(oldItemPosition, newItemPosition)
+        return when {
+            changes.isNotEmpty() -> Payload(changes).also { Timber.d("Returning payload: $it") }
+            // An aliased pair: the only difference is the id, which every holder resolves
+            // by position at call time. Return an empty — but non-null — payload so
+            // RecyclerView rebinds with a payload (a no-op here) instead of taking the
+            // null-payload full-rebind path, which would re-run setText/setSelection on
+            // the focused widget and reset the IME's composing region.
+            resolvedAliases[oldBlock.id] == newBlock.id -> Payload(emptyList())
+            else -> super.getChangePayload(oldItemPosition, newItemPosition)
+        }
     }
 
     /**
@@ -358,6 +420,9 @@ class BlockViewDiffUtil(
     }
 
     companion object {
+        /** Upper bound on alias-chain hops — a safety net against a cyclic alias map. */
+        private const val MAX_ALIAS_HOPS = 8
+
         const val TEXT_CHANGED = 0
         const val MARKUP_CHANGED = 1
         const val FOCUS_CHANGED = 3

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/TextBlockHolder.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/TextBlockHolder.kt
@@ -26,6 +26,7 @@ import com.anytypeio.anytype.core_ui.tools.SlashTextWatcher
 import com.anytypeio.anytype.core_ui.tools.SlashTextWatcherState
 import com.anytypeio.anytype.core_ui.widgets.text.MentionSpan
 import com.anytypeio.anytype.core_utils.clipboard.parseUrlFromClipboard
+import com.anytypeio.anytype.core_utils.ext.isCaretAt
 import com.anytypeio.anytype.core_utils.ext.removeSpans
 import com.anytypeio.anytype.presentation.editor.editor.Markup
 import com.anytypeio.anytype.presentation.editor.editor.listener.ListenerType
@@ -65,7 +66,19 @@ interface TextBlockHolder : TextHolder {
     ) {
         content.applyMovementMethod(markup)
         when (markup.marks.isEmpty()) {
-            true -> content.setText(text)
+            // Re-setting identical text tears down the widget's composing region, which
+            // resets the IME's automaton and breaks Hangul/Kana/Pinyin composition
+            // mid-syllable. Skip when the widget already shows exactly this content and
+            // carries no leftover markup that this (mark-free) update has to clear.
+            true -> {
+                val editable = content.editableText
+                if (editable == null || editable.toString() != text || editable.marks().isNotEmpty()) {
+                    content.setText(text)
+                }
+            }
+            // The spannable path is deliberately left unguarded: [Editable.marks] cannot
+            // round-trip [Markup.Mark] faithfully — every mention subtype collapses to
+            // Mention.Base — so a marks-equality guard here would strand stale markup.
             false -> setBlockSpannableText(markup, clicked, textColor)
         }
     }
@@ -360,7 +373,12 @@ interface TextBlockHolder : TextHolder {
                     val textLength = content.text?.length ?: 0
                     val validCursor = cursor.coerceIn(0, textLength)
                     if (textLength > 0 && validCursor <= textLength) {
-                        content.setSelection(validCursor)
+                        // Moving the caret to where it already is would needlessly notify
+                        // the IME about a selection change while a composition is in
+                        // progress. See [TextHolder.setCursor].
+                        if (!content.isCaretAt(validCursor)) {
+                            content.setSelection(validCursor)
+                        }
                     } else {
                         Timber.w("Invalid cursor position: cursor=$cursor, textLength=$textLength")
                     }

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/holders/interface/TextHolder.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/holders/interface/TextHolder.kt
@@ -5,6 +5,7 @@ import android.view.View
 import com.anytypeio.anytype.core_models.ThemeColor
 import com.anytypeio.anytype.core_ui.extensions.setTextColor
 import com.anytypeio.anytype.core_ui.widgets.text.TextInputWidget
+import com.anytypeio.anytype.core_utils.ext.isCaretAt
 import com.anytypeio.anytype.core_utils.text.BackspaceKeyDetector
 import com.anytypeio.anytype.presentation.editor.editor.model.Alignment
 import com.anytypeio.anytype.presentation.editor.editor.model.BlockView
@@ -36,7 +37,12 @@ interface TextHolder {
             val length = content.text?.length ?: 0
             val validCursor = cursor.coerceIn(0, length)
             if (length > 0 && validCursor <= length) {
-                content.setSelection(validCursor)
+                // Moving the caret to where it already is would notify the IME about a
+                // selection change it did not ask for, which can end an in-progress
+                // composition. Rebinds routinely re-apply an unchanged cursor.
+                if (!content.isCaretAt(validCursor)) {
+                    content.setSelection(validCursor)
+                }
             } else {
                 Timber.w("Invalid cursor position: cursor=$cursor, textLength=$length")
             }

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/holders/other/Code.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/holders/other/Code.kt
@@ -24,6 +24,7 @@ import com.anytypeio.anytype.core_ui.features.editor.provide
 import com.anytypeio.anytype.core_ui.tools.DefaultTextWatcher
 import com.anytypeio.anytype.core_ui.widgets.text.CodeTextInputWidget
 import com.anytypeio.anytype.core_utils.ext.imm
+import com.anytypeio.anytype.core_utils.ext.isCaretAt
 import com.anytypeio.anytype.library_syntax_highlighter.Syntaxes
 import com.anytypeio.anytype.presentation.editor.editor.listener.ListenerType
 import com.anytypeio.anytype.presentation.editor.editor.model.BlockView
@@ -103,7 +104,12 @@ class Code(
 
             content.pauseSelectionWatcher {
                 content.pauseTextWatchers {
-                    content.setText(item.text)
+                    // Skip when the widget already shows this text: re-setting it would
+                    // tear down the composing region and break IME composition
+                    // (Hangul/Kana/Pinyin) mid-syllable.
+                    if (content.text.toString() != item.text) {
+                        content.setText(item.text)
+                    }
                 }
             }
 
@@ -139,9 +145,14 @@ class Code(
         if (payload.textChanged()) {
             content.pauseSelectionWatcher {
                 content.pauseTextWatchers {
-                    content.setText(item.text)
-                    content.clearHighlights()
-                    content.highlight()
+                    // An echo of what the user just typed carries no new text: re-setting
+                    // it would end the IME composition mid-syllable, and the highlights
+                    // already match this text.
+                    if (content.text.toString() != item.text) {
+                        content.setText(item.text)
+                        content.clearHighlights()
+                        content.highlight()
+                    }
                 }
             }
         }
@@ -234,7 +245,7 @@ class Code(
             Timber.d("Setting cursor: $item")
             item.cursor?.let {
                 val length = content.text?.length ?: 0
-                if (it in 0..length) {
+                if (it in 0..length && !content.isCaretAt(it)) {
                     content.setSelection(it)
                 }
             }

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/holders/other/Title.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/holders/other/Title.kt
@@ -87,7 +87,12 @@ sealed class Title(view: View) : BlockViewHolder(view), TextHolder {
             if (!item.hint.isNullOrBlank()) {
                 content.hint = item.hint
             }
-            content.setText(item.text, TextView.BufferType.EDITABLE)
+            // Skip when the widget already shows this text: re-setting it would tear down
+            // the composing region and break IME composition mid-syllable. Same guard as
+            // the TEXT_CHANGED payload path below.
+            if (content.text.toString() != item.text) {
+                content.setText(item.text, TextView.BufferType.EDITABLE)
+            }
         }
         cover?.setOnClickListener { onCoverClicked() }
     }
@@ -641,7 +646,9 @@ sealed class Title(view: View) : BlockViewHolder(view), TextHolder {
                     // Click event intentionally ignored
                 }
             )
-            content.setText(item.text)
+            if (content.text.toString() != item.text) {
+                content.setText(item.text)
+            }
 
             image.setOnClickListener {
                 clicked(ListenerType.Header.Image)
@@ -735,7 +742,9 @@ sealed class Title(view: View) : BlockViewHolder(view), TextHolder {
                 onCoverClicked = {},
                 click = {}
             )
-            content.setText(item.text)
+            if (content.text.toString() != item.text) {
+                content.setText(item.text)
+            }
             setupPreview(onPlayClicked, item.videoUrl)
         }
 

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/holders/text/Description.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/features/editor/holders/text/Description.kt
@@ -8,6 +8,7 @@ import com.anytypeio.anytype.core_ui.features.editor.BlockViewDiffUtil
 import com.anytypeio.anytype.core_ui.features.editor.BlockViewHolder
 import com.anytypeio.anytype.core_ui.widgets.text.TextInputWidget
 import com.anytypeio.anytype.core_utils.ext.dimen
+import com.anytypeio.anytype.core_utils.ext.isCaretAt
 import com.anytypeio.anytype.presentation.editor.editor.model.Alignment
 import com.anytypeio.anytype.presentation.editor.editor.model.BlockView
 import timber.log.Timber
@@ -71,7 +72,9 @@ class Description(val binding: ItemBlockDescriptionBinding) : BlockViewHolder(bi
             try {
                 if (payload.isCursorChanged) {
                     item.cursor?.let {
-                        content.setSelection(it)
+                        if (!content.isCaretAt(it)) {
+                            content.setSelection(it)
+                        }
                     }
                 }
             } catch (e: Throwable) {
@@ -85,7 +88,7 @@ class Description(val binding: ItemBlockDescriptionBinding) : BlockViewHolder(bi
             Timber.d("Setting cursor: $item")
             item.cursor?.let {
                 val length = content.text?.length ?: 0
-                if (it in 0..length) {
+                if (it in 0..length && !content.isCaretAt(it)) {
                     content.setSelection(it)
                 }
             }
@@ -101,7 +104,11 @@ class Description(val binding: ItemBlockDescriptionBinding) : BlockViewHolder(bi
     }
 
     fun setContent(item: BlockView.Description) {
-        content.setText(item.text, TextView.BufferType.EDITABLE)
+        // Skip when the widget already shows this text: re-setting it would tear down the
+        // composing region and break IME composition (Hangul/Kana/Pinyin) mid-syllable.
+        if (content.text.toString() != item.text) {
+            content.setText(item.text, TextView.BufferType.EDITABLE)
+        }
     }
 
     fun enableReadMode() {

--- a/core-ui/src/test/java/com/anytypeio/anytype/core_ui/BlockAdapterTest.kt
+++ b/core-ui/src/test/java/com/anytypeio/anytype/core_ui/BlockAdapterTest.kt
@@ -31,6 +31,7 @@ import com.anytypeio.anytype.core_ui.features.editor.BlockViewDiffUtil.Companion
 import com.anytypeio.anytype.core_ui.features.editor.BlockViewDiffUtil.Companion.TEXT_CHANGED
 import com.anytypeio.anytype.core_ui.features.editor.BlockViewDiffUtil.Companion.TEXT_COLOR_CHANGED
 import com.anytypeio.anytype.core_ui.features.editor.DragAndDropAdapterDelegate
+import com.anytypeio.anytype.core_ui.features.editor.marks
 import com.anytypeio.anytype.core_ui.features.editor.EditorDragAndDropListener
 import com.anytypeio.anytype.core_ui.features.editor.holders.error.FileError
 import com.anytypeio.anytype.core_ui.features.editor.holders.error.PictureError
@@ -60,6 +61,7 @@ import com.anytypeio.anytype.core_ui.features.editor.holders.upload.VideoUpload
 import com.anytypeio.anytype.core_ui.tools.ClipboardInterceptor
 import com.anytypeio.anytype.core_utils.ext.dimen
 import com.anytypeio.anytype.core_utils.ext.hexColorCode
+import com.anytypeio.anytype.presentation.editor.editor.Markup
 import com.anytypeio.anytype.presentation.editor.editor.model.BlockView
 import com.anytypeio.anytype.presentation.editor.editor.model.types.Types
 import com.anytypeio.anytype.presentation.editor.editor.model.types.Types.HOLDER_PARAGRAPH
@@ -2553,6 +2555,142 @@ class BlockAdapterTest {
             actual = focusEvents.toList()
         )
     }
+
+    //region IME composition safety (DROID-4557)
+
+    @Test
+    fun `should not replace the editable when a text payload carries unchanged text`() {
+
+        // Setup
+
+        val paragraph = BlockView.Text.Paragraph(
+            id = MockDataFactory.randomUuid(),
+            text = "한"
+        )
+
+        val adapter = givenAdapter(listOf(paragraph))
+
+        val recycler = RecyclerView(context).apply {
+            layoutManager = LinearLayoutManager(context)
+        }
+
+        val holder = adapter.onCreateViewHolder(recycler, HOLDER_PARAGRAPH)
+
+        adapter.onBindViewHolder(holder, 0)
+
+        check(holder is Paragraph)
+
+        val before = holder.content.text
+
+        // Testing
+
+        holder.processChangePayload(
+            item = paragraph,
+            payloads = listOf(BlockViewDiffUtil.Payload(changes = listOf(TEXT_CHANGED))),
+            clicked = {},
+        )
+
+        // setText swaps in a brand-new Editable, dropping the composing spans the IME
+        // keeps on the old one. An echo of what the user just typed must not do that.
+        assertTrue(
+            before === holder.content.text,
+            "Editable must be left untouched when the incoming text is unchanged"
+        )
+    }
+
+    @Test
+    fun `should still replace the editable when a text payload clears existing markup`() {
+
+        // Setup
+
+        val id = MockDataFactory.randomUuid()
+
+        val marked = BlockView.Text.Paragraph(
+            id = id,
+            text = "한글",
+            marks = listOf(Markup.Mark.Bold(from = 0, to = 2))
+        )
+
+        val cleared = marked.copy(marks = emptyList())
+
+        val adapter = givenAdapter(listOf(marked))
+
+        val recycler = RecyclerView(context).apply {
+            layoutManager = LinearLayoutManager(context)
+        }
+
+        val holder = adapter.onCreateViewHolder(recycler, HOLDER_PARAGRAPH)
+
+        adapter.onBindViewHolder(holder, 0)
+
+        check(holder is Paragraph)
+
+        assertTrue(holder.content.editableText.marks().isNotEmpty())
+
+        // Testing
+
+        holder.processChangePayload(
+            item = cleared,
+            payloads = listOf(BlockViewDiffUtil.Payload(changes = listOf(TEXT_CHANGED))),
+            clicked = {},
+        )
+
+        // The text is identical but the markup is not: the guard must not strand the span.
+        assertEquals(
+            expected = emptyList(),
+            actual = holder.content.editableText.marks()
+        )
+    }
+
+    @Test
+    fun `should not toggle isEnabled on attach when the widget is focused`() {
+
+        // Setup
+
+        val paragraph = BlockView.Text.Paragraph(
+            id = MockDataFactory.randomUuid(),
+            text = "한"
+        )
+
+        val adapter = givenAdapter(listOf(paragraph))
+
+        val recycler = RecyclerView(context).apply {
+            layoutManager = LinearLayoutManager(context)
+        }
+
+        val holder = adapter.onCreateViewHolder(recycler, HOLDER_PARAGRAPH)
+
+        adapter.onBindViewHolder(holder, 0)
+
+        check(holder is Paragraph)
+
+        // Testing: an unfocused widget still gets the AOSP-208169 workaround, so a
+        // disabled one is re-enabled by the toggle.
+        holder.content.clearFocus()
+        holder.content.isEnabled = false
+
+        adapter.onViewAttachedToWindow(holder)
+
+        assertTrue(
+            holder.content.isEnabled,
+            "The attach workaround must still run for an unfocused widget"
+        )
+
+        // A focused widget must be left alone: setEnabled(true) calls
+        // InputMethodManager.restartInput(), which ends any in-progress IME composition,
+        // and setEnabled(false) clears focus on the way there.
+        holder.content.isFocusableInTouchMode = true
+        assertTrue(holder.content.requestFocus(), "Widget must be focusable for this test")
+
+        adapter.onViewAttachedToWindow(holder)
+
+        assertTrue(
+            holder.content.isFocused,
+            "The attach workaround must not disturb a focused widget"
+        )
+    }
+
+    //endregion
 
     private fun givenAdapter(
         views: List<BlockView>,

--- a/core-ui/src/test/java/com/anytypeio/anytype/core_ui/BlockViewDiffUtilTest.kt
+++ b/core-ui/src/test/java/com/anytypeio/anytype/core_ui/BlockViewDiffUtilTest.kt
@@ -1,5 +1,7 @@
 package com.anytypeio.anytype.core_ui
 
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListUpdateCallback
 import com.anytypeio.anytype.core_models.RelationFormat
 import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.core_models.ThemeColor
@@ -1855,4 +1857,260 @@ class BlockViewDiffUtilTest {
         assertEquals(expected = originalText, actual = snapshotCellBlock.text)
         assertEquals(expected = false, actual = snapshotCellBlock.isFocused)
     }
+
+    //region Block-identity aliases (DROID-4557)
+
+    @Test
+    fun `aliased id swap should be treated as the same item`() {
+
+        val oldId = MockDataFactory.randomUuid()
+        val newId = MockDataFactory.randomUuid()
+
+        val oldBlock = BlockView.Text.Paragraph(id = oldId, text = "ㅎ", isFocused = true)
+        val newBlock = oldBlock.copy(id = newId)
+
+        val diff = BlockViewDiffUtil(
+            old = listOf(oldBlock),
+            new = listOf(newBlock),
+            aliases = mapOf(oldId to newId)
+        )
+
+        assertEquals(expected = true, actual = diff.areItemsTheSame(0, 0))
+    }
+
+    @Test
+    fun `aliased pair with no other delta should yield an empty but non-null payload`() {
+
+        val oldId = MockDataFactory.randomUuid()
+        val newId = MockDataFactory.randomUuid()
+
+        val oldBlock = BlockView.Text.Paragraph(id = oldId, text = "ㅎ", isFocused = true)
+        val newBlock = oldBlock.copy(id = newId)
+
+        val diff = BlockViewDiffUtil(
+            old = listOf(oldBlock),
+            new = listOf(newBlock),
+            aliases = mapOf(oldId to newId)
+        )
+
+        // A null payload makes RecyclerView do a full rebind, which re-runs
+        // setText/setSelection on the focused widget and resets the IME composing region.
+        assertEquals(expected = Payload(emptyList()), actual = diff.getChangePayload(0, 0))
+    }
+
+    @Test
+    fun `aliased pair with a text delta should still yield TEXT_CHANGED`() {
+
+        val oldId = MockDataFactory.randomUuid()
+        val newId = MockDataFactory.randomUuid()
+
+        val oldBlock = BlockView.Text.Paragraph(id = oldId, text = "ㅎ")
+        val newBlock = oldBlock.copy(id = newId, text = "한")
+
+        val diff = BlockViewDiffUtil(
+            old = listOf(oldBlock),
+            new = listOf(newBlock),
+            aliases = mapOf(oldId to newId)
+        )
+
+        assertEquals(
+            expected = Payload(listOf(TEXT_CHANGED)),
+            actual = diff.getChangePayload(0, 0)
+        )
+    }
+
+    @Test
+    fun `alias should be inert when the old id is still present in the new list`() {
+
+        // The trailing-placeholder id is reused across placeholder sessions, so its alias
+        // outlives the swap it described.
+        val virtual = "virtual-trailing-block"
+        val materialized = MockDataFactory.randomUuid()
+
+        val existing = BlockView.Text.Paragraph(id = materialized, text = "한글")
+        val placeholder = BlockView.Text.Paragraph(id = virtual, text = "")
+
+        val diff = BlockViewDiffUtil(
+            old = listOf(existing, placeholder),
+            new = listOf(existing, placeholder),
+            aliases = mapOf(virtual to materialized)
+        )
+
+        // Old placeholder must NOT be matched to the pre-existing materialized row.
+        assertEquals(expected = false, actual = diff.areItemsTheSame(1, 0))
+        assertEquals(expected = true, actual = diff.areItemsTheSame(1, 1))
+    }
+
+    @Test
+    fun `alias should resolve transitively across a chain`() {
+
+        val virtual = "virtual-trailing-block"
+        val materialized = MockDataFactory.randomUuid()
+        val forked = MockDataFactory.randomUuid()
+
+        val oldBlock = BlockView.Text.Paragraph(id = virtual, text = "ㅎ")
+        val newBlock = oldBlock.copy(id = forked)
+
+        val diff = BlockViewDiffUtil(
+            old = listOf(oldBlock),
+            new = listOf(newBlock),
+            aliases = mapOf(virtual to materialized, materialized to forked)
+        )
+
+        assertEquals(expected = true, actual = diff.areItemsTheSame(0, 0))
+    }
+
+    @Test
+    fun `alias should be dropped when two old rows resolve onto the same new row`() {
+
+        // A chain plus a live placeholder can make both the virtual id and the
+        // materialized id resolve to the same forked id. Matching both to one new row
+        // would break DiffUtil's contract, so neither alias may apply.
+        val virtual = "virtual-trailing-block"
+        val materialized = MockDataFactory.randomUuid()
+        val forked = MockDataFactory.randomUuid()
+
+        val oldPlaceholder = BlockView.Text.Paragraph(id = virtual, text = "")
+        val oldMaterialized = BlockView.Text.Paragraph(id = materialized, text = "ㅎ")
+        val newForked = BlockView.Text.Paragraph(id = forked, text = "ㅎ")
+
+        val diff = BlockViewDiffUtil(
+            old = listOf(oldMaterialized, oldPlaceholder),
+            new = listOf(newForked),
+            aliases = mapOf(virtual to materialized, materialized to forked)
+        )
+
+        assertEquals(expected = false, actual = diff.areItemsTheSame(0, 0))
+        assertEquals(expected = false, actual = diff.areItemsTheSame(1, 0))
+    }
+
+    @Test
+    fun `alias should be inert when the target has not arrived in the new list`() {
+
+        val oldId = MockDataFactory.randomUuid()
+        val newId = MockDataFactory.randomUuid()
+        val unrelated = MockDataFactory.randomUuid()
+
+        val oldBlock = BlockView.Text.Paragraph(id = oldId, text = "ㅎ")
+        val newBlock = BlockView.Text.Paragraph(id = unrelated, text = "ㅎ")
+
+        val diff = BlockViewDiffUtil(
+            old = listOf(oldBlock),
+            new = listOf(newBlock),
+            aliases = mapOf(oldId to newId)
+        )
+
+        assertEquals(expected = false, actual = diff.areItemsTheSame(0, 0))
+    }
+
+    @Test
+    fun `aliased swap should dispatch a change and never a remove plus insert`() {
+
+        // This is the mechanism behind DROID-4557: a remove makes RecyclerView detach the
+        // focused row's View, and ViewGroup.removeDetachedView clears its focus, which
+        // ends the IME composition mid-syllable.
+        val oldId = MockDataFactory.randomUuid()
+        val newId = MockDataFactory.randomUuid()
+        val untouched = BlockView.Text.Paragraph(id = MockDataFactory.randomUuid(), text = "a")
+
+        val oldBlock = BlockView.Text.Paragraph(id = oldId, text = "ㅎ", isFocused = true)
+        val newBlock = oldBlock.copy(id = newId)
+
+        val recorded = mutableListOf<String>()
+        val callback = object : ListUpdateCallback {
+            override fun onInserted(position: Int, count: Int) {
+                recorded += "inserted($position,$count)"
+            }
+
+            override fun onRemoved(position: Int, count: Int) {
+                recorded += "removed($position,$count)"
+            }
+
+            override fun onMoved(fromPosition: Int, toPosition: Int) {
+                recorded += "moved($fromPosition,$toPosition)"
+            }
+
+            override fun onChanged(position: Int, count: Int, payload: Any?) {
+                recorded += "changed($position,$count,$payload)"
+            }
+        }
+
+        DiffUtil
+            .calculateDiff(
+                BlockViewDiffUtil(
+                    old = listOf(untouched, oldBlock),
+                    new = listOf(untouched, newBlock),
+                    aliases = mapOf(oldId to newId)
+                )
+            )
+            .dispatchUpdatesTo(callback)
+
+        assertEquals(
+            expected = listOf("changed(1,1,${Payload(emptyList())})"),
+            actual = recorded
+        )
+    }
+
+    @Test
+    fun `an unaliased swap should dispatch a remove plus insert`() {
+
+        // Baseline: without the alias the same swap tears the focused row down. Guards
+        // against the alias silently becoming a no-op.
+        val untouched = BlockView.Text.Paragraph(id = MockDataFactory.randomUuid(), text = "a")
+        val oldBlock = BlockView.Text.Paragraph(
+            id = MockDataFactory.randomUuid(),
+            text = "ㅎ",
+            isFocused = true
+        )
+        val newBlock = oldBlock.copy(id = MockDataFactory.randomUuid())
+
+        val recorded = mutableListOf<String>()
+        val callback = object : ListUpdateCallback {
+            override fun onInserted(position: Int, count: Int) {
+                recorded += "inserted"
+            }
+
+            override fun onRemoved(position: Int, count: Int) {
+                recorded += "removed"
+            }
+
+            override fun onMoved(fromPosition: Int, toPosition: Int) {
+                recorded += "moved"
+            }
+
+            override fun onChanged(position: Int, count: Int, payload: Any?) {
+                recorded += "changed"
+            }
+        }
+
+        DiffUtil
+            .calculateDiff(
+                BlockViewDiffUtil(
+                    old = listOf(untouched, oldBlock),
+                    new = listOf(untouched, newBlock)
+                )
+            )
+            .dispatchUpdatesTo(callback)
+
+        assertEquals(expected = listOf("removed", "inserted"), actual = recorded)
+    }
+
+    @Test
+    fun `an empty alias map should preserve the default id-only behaviour`() {
+
+        val oldBlock = BlockView.Text.Paragraph(
+            id = MockDataFactory.randomUuid(),
+            text = MockDataFactory.randomString()
+        )
+
+        val newBlock = oldBlock.copy(id = MockDataFactory.randomUuid())
+
+        val diff = BlockViewDiffUtil(old = listOf(oldBlock), new = listOf(newBlock))
+
+        assertEquals(expected = false, actual = diff.areItemsTheSame(0, 0))
+        // Non-aliased pairs must keep the null-payload full-rebind safety net.
+        assertNull(diff.getChangePayload(0, 0))
+    }
+
+    //endregion
 }

--- a/core-utils/src/main/java/com/anytypeio/anytype/core_utils/ext/ViewExtensions.kt
+++ b/core-utils/src/main/java/com/anytypeio/anytype/core_utils/ext/ViewExtensions.kt
@@ -116,6 +116,15 @@ val Activity.statusBarHeight: Int
         return rectangle.top
     }
 
+/**
+ * True when the caret is already collapsed at [position]. Callers use this to skip a
+ * redundant [EditText.setSelection]: re-setting the same selection notifies the IME about
+ * a caret move it did not ask for, which can terminate an in-progress composition
+ * (Hangul/Kana/Pinyin) mid-syllable.
+ */
+fun EditText.isCaretAt(position: Int): Boolean =
+    selectionStart == position && selectionEnd == position
+
 fun EditText.showKeyboard() {
     post {
         this.apply {

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
@@ -406,6 +406,29 @@ class EditorViewModel(
 
     val views: List<BlockView> get() = orchestrator.stores.views.current()
 
+    /**
+     * Old id -> new id for blocks whose identity changed under the caret: trailing
+     * placeholder materialization ([lastMaterializedTrailingBlock]) and the empty-block
+     * identity fork ([lastForkedBlock]).
+     *
+     * Read by the view layer so DiffUtil treats such a swap as a change of the same row
+     * rather than remove + insert. Removing the focused row detaches its View, which
+     * clears focus and terminates any in-progress IME composition — that is what split
+     * the first Hangul syllable into bare jamo (DROID-4557).
+     *
+     * These fields outlive the swap render (they are also used to redirect events that
+     * still target the pre-swap id), so consumers must ignore an entry whose key is still
+     * present in the new list — VIRTUAL_TRAILING_BLOCK_ID in particular is reused across
+     * placeholder sessions.
+     *
+     * Written on the main thread; read there too (see EditorFragment's diff loop).
+     */
+    val blockIdAliases: Map<Id, Id>
+        get() = buildMap {
+            lastMaterializedTrailingBlock?.let { put(VIRTUAL_TRAILING_BLOCK_ID, it) }
+            lastForkedBlock?.let { (old, new) -> put(old, new) }
+        }
+
     val restore: Queue<Restore> = LinkedList()
 
     private val jobs = mutableListOf<Job>()

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorEmptySpaceInteractionTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorEmptySpaceInteractionTest.kt
@@ -475,6 +475,14 @@ class EditorEmptySpaceInteractionTest : EditorPresentationTestSetup() {
 
         // The block was created already carrying the text — no follow-up set-text needed.
         verifyNoInteractions(updateText)
+
+        // The view layer needs the virtual -> created mapping to diff the swap as a change
+        // of the same row: removing the focused row would clear its focus and kill the IME
+        // composition (DROID-4557).
+        assertEquals(
+            expected = mapOf(VIRTUAL_TRAILING_BLOCK_ID to created.id),
+            actual = vm.blockIdAliases
+        )
     }
 
     @Test

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorIdentityForkTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/editor/editor/EditorIdentityForkTest.kt
@@ -347,6 +347,50 @@ class EditorIdentityForkTest : EditorPresentationTestSetup() {
 
         // The block was replaced already carrying the text — no set-text needed.
         verifyNoInteractions(updateText)
+
+        // The view layer needs the old -> new mapping to diff the swap as a change of the
+        // same row: removing the focused row would clear its focus and kill the IME
+        // composition (DROID-4557).
+        assertEquals(
+            expected = mapOf(empty.id to forked.id),
+            actual = vm.blockIdAliases
+        )
+    }
+
+    @Test
+    fun `should not expose any block id alias when typing into a non-empty block`() = runTest {
+
+        // SETUP
+
+        val block = StubParagraph(text = "한")
+
+        stubInterceptEvents()
+        stubOpenDocument(givenDocument(block))
+        stubUpdateText()
+
+        val vm = buildViewModel()
+
+        vm.onStart(id = root, space = defaultSpace)
+
+        advanceUntilIdle()
+
+        // TESTING
+
+        vm.onBlockFocusChanged(id = block.id, hasFocus = true)
+
+        vm.onTextBlockTextChanged(
+            BlockView.Text.Paragraph(
+                id = block.id,
+                text = "한글"
+            )
+        )
+
+        advanceUntilIdle()
+
+        // A non-empty block never forks, so its id is stable and the view layer has
+        // nothing to re-map. A leaked alias here would make DiffUtil match unrelated rows.
+        assertTrue(vm.blockIdAliases.isEmpty())
+        verifyNoInteractions(replaceBlock)
     }
 
     @Test


### PR DESCRIPTION
## Problem

[DROID-4557](https://linear.app/anytype/issue/DROID-4557/korean-ime-composition-is-broken-after-the-update) — typing Korean (`ㅎㅏㄴㄱㅡㄹ…`) into an **empty** text block yields `ㅎㅏㄴ글한글` instead of `한글한글`: the first syllable's jamo are committed separately instead of composing. Regression since 0.48.6.

## Root cause

DROID-4538 made the first keystroke into an empty block change the block's **id** (identity fork / trailing-placeholder materialization). `BlockViewDiffUtil.areItemsTheSame` keys rows purely on `id`, so the swap diffed as **remove + insert**. RecyclerView removes the focused row → `ViewGroup.removeDetachedView` calls `clearFocus()` → `TextView.onFocusChanged(false)` → `finishComposingText()` → the IME's Hangul automaton resets. The ~3 renders around the swap explain the exactly-three broken jamo in the report.

## Fix

**Root cause (Layer 2):** expose the old→new id mappings the ViewModel already tracks (`EditorViewModel.blockIdAliases` from `lastForkedBlock` / `lastMaterializedTrailingBlock`) and pass them into `BlockViewDiffUtil`, which now:
- matches an aliased pair as the *same row* (`areItemsTheSame`), with the alias map narrowed per-diff, proven **injective**, and guarded against stale entries (`virtual-trailing-block` is reused across placeholder sessions);
- returns a **non-null empty payload** for the aliased pair — a null payload would make RecyclerView do a full rebind (`setText`/`setSelection` on the focused widget), killing the composition anyway.

Safe because every holder listener resolves the block id by adapter position at call time — no stale id can be captured.

**Hardening (Layer 1):** idempotent text/cursor application so echo re-renders can't break composition either:
- `TextBlockHolder.setBlockText` skips `setText` when the widget already shows the same mark-free content (spannable path deliberately unguarded — see code comment on `Editable.marks()` round-trip);
- `setSelection` skipped when the caret is already at the target (`EditText.isCaretAt`), in paragraph/code/description holders;
- `BlockAdapter.onViewAttachedToWindow` no longer runs the AOSP-208169 `isEnabled` toggle on a **focused** widget (`setEnabled(true)` calls `imm.restartInput()`);
- same `setText` equality guard in `Code`, `Title` (bind paths) and `Description`.

## Verification

**Unit tests** — 14 new tests; suites green: core-ui 466, presentation 1315, app 103, plus `make test_debug_all`. Two key guards were proven non-vacuous by temporarily reverting them (tests fail without the fix).

**On-device A/B** (same emulator, same page, same input `gksrmfgksrmf` @130ms/key, Gboard Korean 2-Beolsik):

| Build | Result | IME restarts |
|---|---|---|
| without fix (HEAD) | `ㅎㅏㄴ글한글` — char-for-char the reported bug | 1 |
| with fix | `한글한글` | 0 |

Logcat confirms the id swap happens identically in both runs — only composition survival differs. Trailing-placeholder path (tap below content) also verified PASS; Latin typing, empty-block fork included, unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)