### PR TITLE
DROID-4559 Build | Play Billing 9.1.0 and target Android 16 (API 36)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,18 @@
         android:requestLegacyExternalStorage="true"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+
+        <!--
+            Android 16 (API 36) ignores android:screenOrientation on displays with a smallest
+            width of 600dp or more, which would drop our portrait-only activities into landscape
+            and free-form windows they were never laid out for. This property keeps the manifest
+            restrictions in effect until we ship adaptive layouts. It is a temporary escape hatch:
+            the platform stops honouring it once we target API 37.
+        -->
+        <property
+            android:name="android.window.PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY"
+            android:value="true" />
+
         <activity
             android:name="com.anytypeio.anytype.ui.main.MainActivity"
             android:exported="true"

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ import com.android.build.gradle.LibraryPlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper
 
 // SDK and application configuration from gradle.properties
-ext.compile_sdk = Integer.parseInt(project.findProperty("sdk.compile") ?: "35")
-ext.target_sdk = Integer.parseInt(project.findProperty("sdk.target") ?: "35")
+ext.compile_sdk = Integer.parseInt(project.findProperty("sdk.compile") ?: "36")
+ext.target_sdk = Integer.parseInt(project.findProperty("sdk.target") ?: "36")
 ext.min_sdk = Integer.parseInt(project.findProperty("sdk.min") ?: "26")
 ext.application_id = project.findProperty("app.applicationId") ?: "io.anytype.app"
 ext.test_runner = project.findProperty("app.testRunner") ?: "androidx.test.runner.AndroidJUnitRunner"

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,8 @@ android.nonTransitiveRClass=false
 kotlin.code.style=official
 
 # SDK versions for Android modules
-sdk.compile=35
-sdk.target=35
+sdk.compile=36
+sdk.target=36
 sdk.min=26
 
 # Application configuration

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -164,7 +164,7 @@ sentry = { module = "io.sentry:sentry-android", version.ref = "sentryVersion" }
 sentryTimber = { module = "io.sentry:sentry-android-timber", version.ref = "sentryVersion" }
 navigationCompose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationComposeVersion" }
 composeQrCode = { module = "com.lightspark:compose-qr-code", version.ref = "composeQrCodeVersion" }
-playBilling = { module = "com.android.billingclient:billing", version = "7.1.1" }
+playBilling = { module = "com.android.billingclient:billing", version = "9.1.0" }
 fragmentCompose = { group = "androidx.fragment", name = "fragment-compose", version.ref = "fragmentComposeVersion" }
 firebaseBom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBomVersion" }
 firebaseMessaging = { module = "com.google.firebase:firebase-messaging"}

--- a/payments/src/main/java/com/anytypeio/anytype/payments/playbilling/BillingClientLifecycle.kt
+++ b/payments/src/main/java/com/anytypeio/anytype/payments/playbilling/BillingClientLifecycle.kt
@@ -10,12 +10,14 @@ import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.PendingPurchasesParams
 import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.ProductDetailsResponseListener
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchasesResponseListener
 import com.android.billingclient.api.PurchasesUpdatedListener
 import com.android.billingclient.api.QueryProductDetailsParams
+import com.android.billingclient.api.QueryProductDetailsResult
 import com.android.billingclient.api.QueryPurchasesParams
 import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
 import com.anytypeio.anytype.payments.models.MembershipPurchase
@@ -79,7 +81,16 @@ class BillingClientLifecycle(
         // after ending the previous connection to the Google Play Store in onDestroy().
         billingClient = BillingClient.newBuilder(applicationContext)
             .setListener(this)
-            .enablePendingPurchases() // Not used for subscriptions.
+            // GPBL 8.0.0 removed the no-argument overload: pending purchases are now opted into
+            // per product kind. The old call covered one-time products only, so this preserves
+            // the previous behaviour. It deliberately leaves prepaid plans out -- those are the
+            // only subscriptions that can report PENDING, and enabling them would change which
+            // purchases we surface.
+            .enablePendingPurchases(
+                PendingPurchasesParams.newBuilder()
+                    .enableOneTimeProducts()
+                    .build()
+            )
             .build()
         if (!billingClient.isReady) {
             Timber.d("BillingClient: Start connection...")
@@ -172,21 +183,27 @@ class BillingClientLifecycle(
     /**
      * Receives the result from [querySubscriptionProductDetails].
      *
-     * Store the ProductDetails and post them in the [explorerSubProductWithProductDetails] and
-     * [builderSubProductWithProductDetails]. This allows other parts of the app to use the
-     *  [ProductDetails] to show product information and make purchases.
+     * Store the ProductDetails and post them in the [builderSubProductWithProductDetails].
+     * This allows other parts of the app to use the [ProductDetails] to show product information
+     * and make purchases.
      *
-     * onProductDetailsResponse() uses method calls from GPBL 5.0.0. PBL5, released in May 2022,
-     * is backwards compatible with previous versions.
-     * To learn more about this you can read:
-     * https://developer.android.com/google/play/billing/compatibility
+     * Since GPBL 8.0.0 the callback delivers a [QueryProductDetailsResult], which also carries the
+     * products Google Play could not resolve, so a partial answer is no longer indistinguishable
+     * from an empty one.
      */
     override fun onProductDetailsResponse(
         billingResult: BillingResult,
-        productDetailsList: MutableList<ProductDetails>
+        result: QueryProductDetailsResult
     ) {
         if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
+            val productDetailsList = result.productDetailsList
             Timber.d("onProductDetailsResponse: ${productDetailsList.size} product(s)")
+            result.unfetchedProductList.forEach { unfetched ->
+                Timber.w(
+                    "onProductDetailsResponse: unfetched product ${unfetched.productId}, " +
+                            "status code ${unfetched.statusCode}"
+                )
+            }
             processProductDetails(productDetailsList)
         } else {
             Timber.w("onProductDetailsResponse: ${billingResult.responseCode}")
@@ -203,7 +220,7 @@ class BillingClientLifecycle(
      * @param productDetailsList The list of product details.
      *
      */
-    private fun processProductDetails(productDetailsList: MutableList<ProductDetails>) {
+    private fun processProductDetails(productDetailsList: List<ProductDetails>) {
         val expectedProductDetailsCount = subscriptionIds.size
         if (productDetailsList.isEmpty()) {
             Timber.e("Expected ${expectedProductDetailsCount}, Found null ProductDetails.")

--- a/payments/src/main/java/com/anytypeio/anytype/payments/playbilling/BillingClientLifecycle.kt
+++ b/payments/src/main/java/com/anytypeio/anytype/payments/playbilling/BillingClientLifecycle.kt
@@ -83,9 +83,8 @@ class BillingClientLifecycle(
             .setListener(this)
             // GPBL 8.0.0 removed the no-argument overload: pending purchases are now opted into
             // per product kind. The old call covered one-time products only, so this preserves
-            // the previous behaviour. It deliberately leaves prepaid plans out -- those are the
-            // only subscriptions that can report PENDING, and enabling them would change which
-            // purchases we surface.
+            // the previous behaviour. We sell subscriptions exclusively, so the call is inert
+            // today and kept only so a future one-time product does not have to rediscover it.
             .enablePendingPurchases(
                 PendingPurchasesParams.newBuilder()
                     .enableOneTimeProducts()

--- a/payments/src/test/java/com/anytypeio/anytype/payments/BillingProductDetailsResponseTest.kt
+++ b/payments/src/test/java/com/anytypeio/anytype/payments/BillingProductDetailsResponseTest.kt
@@ -1,0 +1,150 @@
+package com.anytypeio.anytype.payments
+
+import android.content.Context
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.QueryProductDetailsResult
+import com.android.billingclient.api.UnfetchedProduct
+import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
+import com.anytypeio.anytype.payments.playbilling.BillingClientLifecycle
+import com.anytypeio.anytype.payments.playbilling.BillingClientState
+import junit.framework.TestCase.assertEquals
+import kotlin.test.assertIs
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import net.bytebuddy.utility.RandomString
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+/**
+ * Covers [BillingClientLifecycle.onProductDetailsResponse], whose signature changed in GPBL 8.0.0
+ * from a plain product list to a [QueryProductDetailsResult] carrying unfetched products too.
+ *
+ * The callback is synchronous -- it only reads the configured subscription ids and writes to
+ * [BillingClientLifecycle.builderSubProductWithProductDetails] -- so it can be driven directly,
+ * without connecting a BillingClient.
+ */
+class BillingProductDetailsResponseTest {
+
+    private val dispatcher = StandardTestDispatcher(TestCoroutineScheduler())
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val dispatchers = AppCoroutineDispatchers(
+        io = dispatcher,
+        main = dispatcher,
+        computation = dispatcher
+    )
+
+    private lateinit var billing: BillingClientLifecycle
+
+    private val subscriptionId = "io.anytype.builder.${RandomString.make()}"
+
+    @Before
+    fun setUp() {
+        billing = BillingClientLifecycle(
+            dispatchers = dispatchers,
+            applicationContext = mock<Context>(),
+            scope = CoroutineScope(dispatcher)
+        )
+        billing.setupSubIds(listOf(subscriptionId))
+    }
+
+    @Test
+    fun `starts out loading, so the assertions below are not vacuous`() {
+        assertIs<BillingClientState.Loading>(billing.builderSubProductWithProductDetails.value)
+    }
+
+    @Test
+    fun `resolved subscription is published as connected`() {
+        val product = subscriptionProduct(subscriptionId)
+
+        billing.onProductDetailsResponse(
+            billingResult(BillingClient.BillingResponseCode.OK),
+            queryResult(productDetails = listOf(product))
+        )
+
+        val state = assertIs<BillingClientState.Connected>(
+            billing.builderSubProductWithProductDetails.value
+        )
+        assertEquals(listOf(product), state.productDetails)
+    }
+
+    /**
+     * The case the unfetched list exists for: Google Play answered OK but could only resolve part
+     * of what we asked for. The resolved subscription must still reach the UI.
+     */
+    @Test
+    fun `partially resolved response still connects with the products that came back`() {
+        val resolved = subscriptionProduct(subscriptionId)
+
+        billing.onProductDetailsResponse(
+            billingResult(BillingClient.BillingResponseCode.OK),
+            queryResult(
+                productDetails = listOf(resolved),
+                unfetched = listOf(unfetchedProduct("io.anytype.co-creator"))
+            )
+        )
+
+        val state = assertIs<BillingClientState.Connected>(
+            billing.builderSubProductWithProductDetails.value
+        )
+        assertEquals(listOf(resolved), state.productDetails)
+    }
+
+    /**
+     * Documents current behaviour rather than endorsing it: an OK response that resolves nothing
+     * is reported as an error, so a single bad product id yields an error screen.
+     */
+    @Test
+    fun `ok response that resolves nothing is reported as an error`() {
+        billing.onProductDetailsResponse(
+            billingResult(BillingClient.BillingResponseCode.OK),
+            queryResult(unfetched = listOf(unfetchedProduct(subscriptionId)))
+        )
+
+        assertIs<BillingClientState.Error>(billing.builderSubProductWithProductDetails.value)
+    }
+
+    @Test
+    fun `products outside the configured subscription ids are discarded`() {
+        billing.onProductDetailsResponse(
+            billingResult(BillingClient.BillingResponseCode.OK),
+            queryResult(productDetails = listOf(subscriptionProduct("io.anytype.some.other.plan")))
+        )
+
+        assertIs<BillingClientState.Error>(billing.builderSubProductWithProductDetails.value)
+    }
+
+    @Test
+    fun `failed response is reported as an error even when products are attached`() {
+        billing.onProductDetailsResponse(
+            billingResult(BillingClient.BillingResponseCode.NETWORK_ERROR),
+            queryResult(productDetails = listOf(subscriptionProduct(subscriptionId)))
+        )
+
+        assertIs<BillingClientState.Error>(billing.builderSubProductWithProductDetails.value)
+    }
+
+    private fun billingResult(responseCode: Int): BillingResult =
+        BillingResult.newBuilder().setResponseCode(responseCode).build()
+
+    private fun queryResult(
+        productDetails: List<ProductDetails> = emptyList(),
+        unfetched: List<UnfetchedProduct> = emptyList()
+    ): QueryProductDetailsResult = QueryProductDetailsResult.create(productDetails, unfetched)
+
+    private fun subscriptionProduct(productId: String): ProductDetails = mock {
+        on { getProductId() } doReturn productId
+        on { getProductType() } doReturn BillingClient.ProductType.SUBS
+    }
+
+    private fun unfetchedProduct(productId: String): UnfetchedProduct = mock {
+        on { getProductId() } doReturn productId
+        on { getStatusCode() } doReturn BillingClient.BillingResponseCode.ITEM_UNAVAILABLE
+    }
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -7,16 +7,18 @@ plugins {
 }
 
 android {
-    compileSdk = 35
+    def config = rootProject.ext
+
+    compileSdk = config.compile_sdk
 
     defaultConfig {
         applicationId = "com.anytypeio.anytype.sample"
-        minSdk = 26
-        targetSdk = 35
+        minSdk = config.min_sdk
+        targetSdk = config.target_sdk
         versionCode = 1
         versionName = "1.0"
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = config.test_runner
     }
 
     buildTypes {


### PR DESCRIPTION
---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/open/blob/main/templates/CLA.md)

---

### Description

Google Play requires Play Billing 8.0.0+ and targetSdk 36 by **Aug 31, 2026**, or app updates get rejected. This PR does both.

**Play Billing 7.1.1 → 9.1.0** (v9 is the recommended line)

Only two call sites actually break in v8+, both in `BillingClientLifecycle`:

1. **`enablePendingPurchases()` lost its no-argument overload.** Pending purchases are now opted into per product kind via `PendingPurchasesParams`. Scoped to `enableOneTimeProducts()`, which is exactly what the old no-arg call covered, so behaviour is unchanged. Since we sell subscriptions exclusively the call is inert either way — `MembershipPurchase.PurchaseState.PENDING` is never read, as `MembershipExt` only ever compares against `PURCHASED` — so it's kept purely so a future one-time product doesn't have to rediscover it.
2. **`onProductDetailsResponse` now delivers `QueryProductDetailsResult`** instead of `MutableList<ProductDetails>`. I also log its `unfetchedProductList`, because that list is the answer to the `"No product details found for subscriptionIds"` error this class already reports — previously a partial response and an empty one were indistinguishable in logs.

Everything else we touch survived the major bumps (`ProductDetails`, `AccountIdentifiers`, `BillingFlowParams`, and every `BillingResponseCode` constant we branch on), verified against the 9.1.0 AAR rather than the migration guide.

The ticket also asks about third-party SDKs bundling Play Billing: **there are none.** `billing` resolves exactly once at 9.1.0 on `releaseRuntimeClasspath`, reached only through `:app` and `:payments`. No transitive copy from Amplitude/Sentry/Firebase, nothing pinning an older version.

**compileSdk/targetSdk 35 → 36**

One behaviour change needed a decision. At API 36 Android ignores `android:screenOrientation` on displays ≥600dp, which would drop our portrait-only activities (`MainActivity`, `SettingsActivity`, `QrScannerActivity`) into landscape and free-form windows they were never laid out for. The options were a one-line opt-out or making the app adaptive; the latter is plainly its own project, so this opts out via `PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY`. **That escape hatch stops working at API 37** — noted in a manifest comment and in the follow-up ticket.

Everything else on the API 36 list is a no-op for us, checked rather than assumed: no `windowOptOutEdgeToEdgeEnforcement` (already edge-to-edge), no `elegantTextHeight`, no `scheduleAtFixedRate`, no `Activity.onBackPressed()` overrides, no `setRequestedOrientation`, no `MediaStore#getVersion`.

The `sample` module had its SDK levels hardcoded and had already drifted to 35 (the root `subprojects` block only injects config into `LibraryPlugin` modules). It now reads `rootProject.ext` like `:app` does, so the next bump can't miss it.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

- Closes [DROID-4559](https://linear.app/anytype/issue/DROID-4559/meet-google-play-requirements-for-billing-v8-and-api-36)
- Follow-up: [DROID-4560](https://linear.app/anytype/issue/DROID-4560/request-access-local-network-for-p2plan-sync-before-targeting-api-37) — `ACCESS_LOCAL_NETWORK` for P2P/LAN sync, required before we can target API 37
- [Play Billing 8.0.0 migration](https://developer.android.com/google/play/billing/release-notes)
- [Behaviour changes: apps targeting Android 16](https://developer.android.com/about/versions/16/behavior-changes-16)

### Mobile & Desktop Screenshots/Recordings

No visual changes.

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

`BillingProductDetailsResponseTest` covers `onProductDetailsResponse`, the callback whose signature changed in GPBL 8.0.0. `QueryProductDetailsResult.create()` is public precisely so this callback can be driven from a test, and the callback is synchronous — it only reads the configured subscription ids and writes a `StateFlow` — so no `BillingClient` connection is needed.

Six cases: initial `Loading` state (so the rest aren't vacuous), a resolved subscription, a partially resolved response, an OK response that resolves nothing, a product outside the configured ids, and a failed response code. The partial-response case is what the new unfetched-product logging exists for; the resolves-nothing case documents that an OK response with no resolved products still surfaces as `BillingClientState.Error` — worth knowing, since one bad product id therefore yields an error screen rather than a partial catalogue.

I mutation-tested them rather than trusting the green tick: replacing `result.productDetailsList` with `emptyList()` fails 2 tests, and dropping the response-code check fails 1. `:payments` is at 59 tests, all passing.

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### Verification

| Check | Result |
|---|---|
| `:app:assembleDebug` / `:app:assembleRelease` (R8 + resource shrinking) | pass, no missing-rules report |
| Release APK badging | `targetSdkVersion=36`, `compileSdkVersion=36`, billing meta `9.1.0` |
| `:app:licenseeAndroidRelease` | pass — billing 9's new transitive deps need no new allowlist entries |
| `compileDebugAndroidTestSources` | pass |
| Unit tests, all modules | **2706 tests, 0 failures** (2245 Android + 461 JVM) |
| Billing on release classpath | resolves once at 9.1.0, only via `:app` + `:payments` |
| Merged manifest | no new permissions from billing's `play-services-location` dep; `com.android.vending.BILLING` + `<queries>` merged |
| 16 KB page size | all 9 `.so` files at `LOAD align = 0x4000`; `zipalign -c -P 16` verifies |

Two notes on the test suite, since they affect how much the green tick is worth:

`make test_debug_all` only ran `core-models`, `data`, `domain` — the pure-JVM modules. The root `build.gradle` tries to wire Android modules in from inside `tasks.configureEach`, which lands too late in the task graph, so `:app`, `:presentation`, `:payments` are silently skipped. I ran `testDebugUnitTest` explicitly to cover them (that's the 2245, including the 6 new ones). Worth fixing separately — CI as configured cannot catch a regression in this PR, and `check.yml` triggers on `types: [opened]` only, so it did not re-run for the follow-up commit either.

That mattered here because **Robolectric derives its emulated SDK from `targetSdkVersion`**, and 4.11.1 predates API 36 — exactly the kind of break the default gate would hide. Every Robolectric test in the repo either pins `@Config(sdk = …)` or falls under `core-ui`'s `robolectric.properties`, so nothing resolves the SDK from the manifest. The bump is genuinely safe, not accidentally so.

### [optional] Are there any post-deployment tasks we need to perform?

- **Publish to the actively used tracks** — the remaining DROID-4559 item, a release-process step rather than a code change.
- **Smoke-test the purchase flow against a real Play account.** Billing 9 is wired here but the actual subscription flow (product details → offer token → `launchBillingFlow` → `PurchasesUpdated`) can only be confirmed on a device with a licensed tester.
- **Check back navigation on a device.** Predictive back is on by default at target 36 (it needed opt-in at 35). The app uses `onBackPressedDispatcher` throughout with no `Activity.onBackPressed()` overrides, so this should be transparent — but `TextInputWidget.onKeyPreIme` handles IME back in the editor and deserves one pass. Separately, `EditorFragment` and `ObjectSetFragment` register permanently-enabled `OnBackPressedCallback`s, so those screens get no predictive back-to-home animation. Pre-existing and cosmetic, out of scope here.
