### PR TITLE
DROID-4562 Editor | Fix | Stop leaking a ClickableSpan per mention on every block rebind

### DIFF
--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/widgets/text/MentionSpanExt.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/widgets/text/MentionSpanExt.kt
@@ -8,6 +8,7 @@ import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
 import com.anytypeio.anytype.core_ui.R
+import com.anytypeio.anytype.core_ui.common.Span
 import com.anytypeio.anytype.core_ui.common.isRangeValid
 import com.anytypeio.anytype.core_ui.extensions.disable
 import com.anytypeio.anytype.core_ui.widgets.text.setClickableSpan
@@ -247,7 +248,9 @@ fun Editable.proceedWithSettingMentionSpan(
 }
 
 fun Editable.setClickableSpan(click: ((String) -> Unit)?, mark: Markup.Mark.Mention) {
-    val clickableSpan = object : ClickableSpan() {
+    // Must implement Span, so that setMarkup()'s removeSpans<Span>() can clear it on rebind.
+    // Otherwise one ClickableSpan leaks per mention on every rebind of a recycled block.
+    val clickableSpan = object : ClickableSpan(), Span {
         override fun onClick(widget: View) {
             (widget as? TextInputWidget)?.disable()
             click?.invoke(mark.param)

--- a/core-ui/src/test/java/com/anytypeio/anytype/core_ui/SetMarkupSpanAccumulationTest.kt
+++ b/core-ui/src/test/java/com/anytypeio/anytype/core_ui/SetMarkupSpanAccumulationTest.kt
@@ -1,0 +1,78 @@
+package com.anytypeio.anytype.core_ui
+
+import android.content.Context
+import android.graphics.Color
+import android.os.Build
+import android.text.SpannableStringBuilder
+import android.text.style.ClickableSpan
+import androidx.test.core.app.ApplicationProvider
+import com.anytypeio.anytype.core_ui.common.setMarkup
+import com.anytypeio.anytype.presentation.editor.editor.Markup
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+/**
+ * Regression test for span accumulation in [setMarkup] (production ANR in
+ * SpannableStringBuilder.countSpans during text selection).
+ *
+ * When a recycled text block is re-bound, setMarkup() removes only Span-typed
+ * spans before copying the freshly built ones. Any span applied by the markup
+ * pipeline that does not implement Span leaks and piles up with every rebind,
+ * making the span set grow without bound.
+ */
+@Config(sdk = [Build.VERSION_CODES.P])
+@RunWith(RobolectricTestRunner::class)
+class SetMarkupSpanAccumulationTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `should not accumulate spans on repeated setMarkup calls`() {
+        val markup = object : Markup {
+            override val body: String = "Hello @user, check this out"
+            override var marks: List<Markup.Mark> = listOf(
+                Markup.Mark.Bold(from = 0, to = 5),
+                Markup.Mark.Mention.Base(from = 6, to = 11, param = "obj-id", isArchived = false)
+            )
+        }
+
+        val editable = SpannableStringBuilder(markup.body)
+
+        fun bind() = editable.setMarkup(
+            markup = markup,
+            context = context,
+            click = {},
+            mentionCheckedIcon = null,
+            mentionUncheckedIcon = null,
+            mentionInitialsSize = 12f,
+            textColor = Color.BLACK,
+            underlineHeight = 1f
+        )
+
+        bind()
+
+        val spanCountAfterFirstBind = editable.getSpans(0, editable.length, Any::class.java).size
+        val clickableCountAfterFirstBind =
+            editable.getSpans(0, editable.length, ClickableSpan::class.java).size
+
+        repeat(49) { bind() }
+
+        val spanCountAfterFiftyBinds = editable.getSpans(0, editable.length, Any::class.java).size
+        val clickableCountAfterFiftyBinds =
+            editable.getSpans(0, editable.length, ClickableSpan::class.java).size
+
+        assertEquals(
+            expected = clickableCountAfterFirstBind,
+            actual = clickableCountAfterFiftyBinds,
+            message = "ClickableSpan count must not grow with rebinds"
+        )
+        assertEquals(
+            expected = spanCountAfterFirstBind,
+            actual = spanCountAfterFiftyBinds,
+            message = "Total span count must not grow with rebinds"
+        )
+    }
+}


### PR DESCRIPTION
Closes DROID-4562.

## Problem

The app's top ANR cluster in Play Console (verified 2026-08-01): 14 distinct users across two clusters over 28 days, attributed to `MarkupKt.setMarkup`. **Still present on the current shipping release** — 25 of 40 reports on versionCode 4809 (0.48.9), 15 on 4703. Devices are modern (samsung a54x, google stallion, Nothing Galaga; API 33/36), so this is the span set, not the hardware.

All ten sampled reports sit in **text selection UI** — `Editor$TextActionModeCallback.onGetContentRect` x4, `SelectionHandleView.getHorizontal` x3, and so on — with ~14 recursive `SpannableStringBuilder.countSpans` frames on the main thread.

## Root cause

`Editable.setMarkup` (`core-ui/.../common/Markup.kt:76-87`) clears spans with `removeSpans<Span>()` but copies back **every** span type:

```kotlin
removeSpans<Span>()                                            // clears only Span implementors
val spans = built.getSpans(0, built.length, Any::class.java)   // copies EVERY span type
```

Every span the markup pipeline creates implements the `Span` marker — except the anonymous `ClickableSpan` in `MentionSpanExt.kt:250`, applied for every non-archived mention. So on a recycled RecyclerView block, **each rebind leaks one `ClickableSpan` per mention**, monotonically. `countSpans` recurses over the interval tree and the selection UI walks that set repeatedly per frame.

Mentions are exactly what a busy chat is full of, which matches the community report that triggered the investigation ("enter the channel, try to add or edit, freezes").

Verified this is the only anonymous `ClickableSpan` in `core-ui/src/main`.

## Fix

```kotlin
val clickableSpan = object : ClickableSpan(), Span { ... }
```

`Span` is a pure marker interface with no abstract members, so this is behaviourally inert — it just brings the span into the scope of `removeSpans<Span>()`.

## Measured evidence

Robolectric test, one mention + one bold, repeated `setMarkup` on the same `Editable`:

| binds | ClickableSpan count |
|---|---|
| 1 | 1 |
| 50 | **50** |

Growth is linear in rebinds x mentions.

## Verification

- New `SetMarkupSpanAccumulationTest` simulates 50 rebinds, asserting ClickableSpan count and total span count stay constant.
- Confirmed it **fails without the fix** (`1 test completed, 1 failed`) and passes with it — a real regression test, not a tautology.
- Full `:core-ui:testDebugUnitTest`: **467 tests, 0 failures**.

## Caveats for review

- The ANR itself (multi-second `countSpans` under `FloatingActionMode`) cannot be reproduced in a JVM test. The test pins down the span growth that causes it, so "this fixes the ANR" is an inference from the mechanism rather than a measured on-device before/after.
- Old builds will keep reporting until a release ships this.
- Strong candidate for the original community report, but not provable for that user specifically: he is on Android 10 (API 29), and Play has essentially no API-29 data (one error report app-wide in 28 days).
