### PR TITLE
DROID-4334 Sets | Fix | Gallery card border weight and card size sync

### DIFF
--- a/core-ui/src/main/res/values/styles.xml
+++ b/core-ui/src/main/res/values/styles.xml
@@ -793,7 +793,10 @@
         <item name="cardElevation">0dp</item>
         <item name="rippleColor">@android:color/transparent</item>
         <item name="strokeColor">@color/shape_primary</item>
-        <item name="strokeWidth">0.5dp</item>
+        <!-- 1dp, not 0.5dp: the card has no fill, so this stroke is the only thing separating
+             neighbouring cards, and a sub-pixel line is antialiased down to roughly half alpha
+             — which is why the border read as almost invisible on light backgrounds. -->
+        <item name="strokeWidth">1dp</item>
         <item name="cardBackgroundColor">@android:color/transparent</item>
     </style>
 

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sets/ObjectSetViewModel.kt
@@ -4617,18 +4617,30 @@ if (effectiveType.recommendedLayout == ObjectType.Layout.SET || effectiveType.re
             is ViewerLayoutWidgetUi.Action.CardSize -> {
                 viewerLayoutWidgetState.value =
                     viewerLayoutWidgetState.value.copy(showCardSize = false)
+                val cardSizeViewerId = viewerLayoutWidgetState.value.viewer
                 when (action.cardSize) {
                     ViewerLayoutWidgetUi.State.CardSize.Small -> {
-                        viewModelScope.launch {
-                            proceedWithUpdateViewer(
-                                viewerId = viewerLayoutWidgetState.value.viewer
-                            ) { it.copy(cardSize = DVViewerCardSize.SMALL) }
+                        // Desktop has three card sizes, mobile only two: SMALL and MEDIUM both
+                        // render as two columns here. Since cardSize lives on the viewer and is
+                        // synced across devices, writing SMALL over a MEDIUM viewer would shrink
+                        // the desktop layout while changing nothing on mobile — so leave it alone.
+                        val current = stateReducer.state.value.dataViewState()
+                            ?.viewerById(cardSizeViewerId)
+                            ?.cardSize
+                        if (current == DVViewerCardSize.MEDIUM) {
+                            Timber.d("Viewer card size is MEDIUM, already rendered as small on mobile — skipping update")
+                        } else {
+                            viewModelScope.launch {
+                                proceedWithUpdateViewer(
+                                    viewerId = cardSizeViewerId
+                                ) { it.copy(cardSize = DVViewerCardSize.SMALL) }
+                            }
                         }
                     }
                     ViewerLayoutWidgetUi.State.CardSize.Large -> {
                         viewModelScope.launch {
                             proceedWithUpdateViewer(
-                                viewerId = viewerLayoutWidgetState.value.viewer
+                                viewerId = cardSizeViewerId
                             ) { it.copy(cardSize = DVViewerCardSize.LARGE) }
                         }
                     }

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/main/ObjectSetGalleryCardSizeTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/sets/main/ObjectSetGalleryCardSizeTest.kt
@@ -1,0 +1,155 @@
+package com.anytypeio.anytype.presentation.sets.main
+
+import com.anytypeio.anytype.core_models.Block
+import com.anytypeio.anytype.core_models.DVViewer
+import com.anytypeio.anytype.core_models.DVViewerCardSize
+import com.anytypeio.anytype.core_models.ObjectType
+import com.anytypeio.anytype.core_models.ObjectViewDetails
+import com.anytypeio.anytype.core_models.Relations
+import com.anytypeio.anytype.core_models.StubDataView
+import com.anytypeio.anytype.core_models.StubTitle
+import com.anytypeio.anytype.presentation.sets.ObjectSetViewModel
+import com.anytypeio.anytype.presentation.sets.ViewerLayoutWidgetUi
+import com.anytypeio.anytype.presentation.sets.viewer.ViewerEvent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verifyBlocking
+
+/**
+ * ViewModel-level coverage for the gallery card-size picker.
+ *
+ * Desktop offers three card sizes (small / medium / large), mobile only two: SMALL and MEDIUM
+ * both render as two columns here, LARGE as one. Since `cardSize` lives on the viewer and is
+ * synced across devices, a mobile write must not downgrade a size that mobile cannot even
+ * represent — see [ObjectSetViewModel.onViewerLayoutWidgetAction].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ObjectSetGalleryCardSizeTest : ObjectSetViewModelTestSetup() {
+
+    private val galleryViewerId = "gallery-view"
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        proceedWithDefaultBeforeTestStubbing()
+    }
+
+    /** Seeds the layout widget open on the gallery viewer without a middleware round-trip. */
+    private fun ObjectSetViewModel.openLayoutWidgetOnGallery() {
+        viewerLayoutWidgetState.value = viewerLayoutWidgetState.value.copy(
+            showWidget = true,
+            viewer = galleryViewerId,
+            layoutType = Block.Content.DataView.Viewer.Type.GALLERY
+        )
+    }
+
+    /**
+     * Opens the set as a Collection whose only viewer is a gallery with the given card size, so
+     * the reducer holds a real GALLERY viewer that the write path can resolve.
+     */
+    private fun stubGalleryCollection(cardSize: DVViewerCardSize) {
+        val galleryViewer = DVViewer(
+            id = galleryViewerId,
+            name = "Gallery",
+            type = Block.Content.DataView.Viewer.Type.GALLERY,
+            sorts = emptyList(),
+            filters = emptyList(),
+            viewerRelations = emptyList(),
+            cardSize = cardSize
+        )
+        stubOpenObject(
+            doc = listOf(StubTitle(), StubDataView(views = listOf(galleryViewer), isCollection = true)),
+            details = ObjectViewDetails(
+                mapOf(root to mapOf(Relations.LAYOUT to ObjectType.Layout.COLLECTION.code.toDouble()))
+            )
+        )
+    }
+
+    private fun TestScope.givenGalleryOpenedWith(cardSize: DVViewerCardSize): ObjectSetViewModel {
+        stubGalleryCollection(cardSize)
+        val vm = givenViewModel()
+        vm.onStart(view = galleryViewerId)
+        advanceUntilIdle()
+        vm.openLayoutWidgetOnGallery()
+        return vm
+    }
+
+    @Test
+    fun `selecting Small on a MEDIUM viewer does not write, since mobile renders both the same`() =
+        runTest {
+            val vm = givenGalleryOpenedWith(DVViewerCardSize.MEDIUM)
+
+            vm.onViewerLayoutWidgetAction(
+                ViewerLayoutWidgetUi.Action.CardSize(ViewerLayoutWidgetUi.State.CardSize.Small)
+            )
+            advanceUntilIdle()
+
+            // Writing SMALL here would silently shrink the desktop layout while changing nothing
+            // on mobile, so no viewer update must be sent at all.
+            verifyBlocking(viewerDelegate, never()) {
+                onEvent(argThat { this is ViewerEvent.UpdateView && viewer.id == galleryViewerId })
+            }
+        }
+
+    @Test
+    fun `selecting Small on a LARGE viewer writes SMALL`() = runTest {
+        val vm = givenGalleryOpenedWith(DVViewerCardSize.LARGE)
+
+        vm.onViewerLayoutWidgetAction(
+            ViewerLayoutWidgetUi.Action.CardSize(ViewerLayoutWidgetUi.State.CardSize.Small)
+        )
+        advanceUntilIdle()
+
+        verifyBlocking(viewerDelegate) {
+            onEvent(
+                argThat {
+                    this is ViewerEvent.UpdateView &&
+                            viewer.id == galleryViewerId &&
+                            viewer.cardSize == DVViewerCardSize.SMALL
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `selecting Large on a MEDIUM viewer writes LARGE`() = runTest {
+        val vm = givenGalleryOpenedWith(DVViewerCardSize.MEDIUM)
+
+        vm.onViewerLayoutWidgetAction(
+            ViewerLayoutWidgetUi.Action.CardSize(ViewerLayoutWidgetUi.State.CardSize.Large)
+        )
+        advanceUntilIdle()
+
+        // Large is a real change on mobile (one column), so it is persisted as usual.
+        verifyBlocking(viewerDelegate) {
+            onEvent(
+                argThat {
+                    this is ViewerEvent.UpdateView &&
+                            viewer.id == galleryViewerId &&
+                            viewer.cardSize == DVViewerCardSize.LARGE
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `card size selection closes the card size picker`() = runTest {
+        val vm = givenGalleryOpenedWith(DVViewerCardSize.MEDIUM)
+        vm.onViewerLayoutWidgetAction(ViewerLayoutWidgetUi.Action.CardSizeMenu)
+
+        vm.onViewerLayoutWidgetAction(
+            ViewerLayoutWidgetUi.Action.CardSize(ViewerLayoutWidgetUi.State.CardSize.Small)
+        )
+        advanceUntilIdle()
+
+        // The picker collapses even when the selection is intentionally not persisted.
+        kotlin.test.assertFalse(vm.viewerLayoutWidgetState.value.showCardSize)
+    }
+}


### PR DESCRIPTION
Two fixes for the gallery layout in sets and collections, from [user feedback on the forum](https://community.anytype.io/) about card visibility on mobile.

## 1. Card borders were nearly invisible

`SetGalleryViewCardStyle` used `strokeWidth` of `0.5dp`. That is sub-pixel on most densities, so the renderer antialiases it down to roughly half alpha — the border rendered closer to `#F1F1F1` than to the `#E3E3E3` we specify. The card has a transparent fill, so that stroke is the only thing separating neighbouring cards.

Now `1dp`, which renders `shape_primary` at full strength.

The reporter suggested darkening the colour to `#dddddd`. Not doing that: `shape_primary` is shared across the app and has a paired dark-theme value, so changing the token for one screen would affect everything else. Width was the actual cause.

## 2. Mobile silently downgraded a MEDIUM card size

`cardSize` is a property of the viewer and syncs across devices. Desktop has three sizes, mobile two — `SMALL` and `MEDIUM` both render as two columns here, so a `MEDIUM` viewer displays as "Small" in the mobile layout widget.

Selecting that already-displayed option wrote `SMALL` back to the viewer: nothing changed on mobile, but the desktop layout shrank. `onViewerLayoutWidgetAction` now reads the current size first and skips the write when it is `MEDIUM`.

Also hoisted `viewerLayoutWidgetState.value.viewer` into a local — the id was previously re-read from mutable state after `showCardSize = false` had already been written to it.

## Out of scope

The reporter also asked for card sizes to be fully independent per device. That needs a device-local view setting, which does not exist in the data model, and would have to be agreed across desktop and iOS. Choosing **large** on mobile still applies to desktop.

Border radius (16dp) is unchanged — it comes from the design system's Gallery Card component and is shared with iOS. Raised with design separately.

## Testing

New `ObjectSetGalleryCardSizeTest` covers four cases: MEDIUM + Small does not write, LARGE + Small writes SMALL, MEDIUM + Large writes LARGE, and the picker closes even when the write is skipped. Verified the first test fails against the pre-fix code (`NeverWantedButInvoked`).

- `:presentation:testDebugUnitTest --tests "com.anytypeio.anytype.presentation.sets.*"` — 216 tests, 0 failures
- `:core-ui:assembleDebug` — passes

The border change is XML-only and not covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)