### PR TITLE
DROID-4570 Properties | Fix | Tag picker drops hidden selections when a search query is active

### DIFF
--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
@@ -107,7 +107,12 @@ class TagOrStatusValueViewModel(
      * (DROID-4570).
      *
      * The field is updated from the [values].subscribe emission and from every optimistic
-     * write, so it stays correct while the query changes.
+     * write. It therefore survives a query change, which the rendered items do not.
+     *
+     * The field stays consistent with [viewState], because the [combine] block writes both
+     * from the same `ids`. That is deliberate: a divergence would show one selection in the
+     * list and persist a different one. A record that goes stale — a host with no live writer
+     * for the backing store — makes the field and the list stale together, never in conflict.
      */
     private var selectedIds: List<Id> = emptyList()
 
@@ -468,10 +473,16 @@ class TagOrStatusValueViewModel(
             ).process(
                 failure = { e ->
                     Timber.e(e, "Error while updating tag/status value")
-                    // Revert optimistic update and release the lock so real events are honored again.
-                    optionEventLockTimestamp = null
-                    selectedIds = previousSelectedIds
-                    viewState.value = previousState
+                    // Revert only while this write is still the newest one. Two taps can be in
+                    // flight together, because setObjectDetails suspends onto the io dispatcher.
+                    // A late failure must not restore a snapshot older than a newer write that
+                    // already succeeded, and must not release the lock under that newer write.
+                    // The identity check holds because this call assigned newIds to selectedIds.
+                    if (selectedIds === newIds) {
+                        optionEventLockTimestamp = null
+                        selectedIds = previousSelectedIds
+                        viewState.value = previousState
+                    }
                     sendToast("Error while updating value")
                 },
                 success = {

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
@@ -98,6 +98,19 @@ class TagOrStatusValueViewModel(
     // re-reading the (possibly orphaned / never re-emitting) value store. See proceedWithOptimisticUpdate.
     private var currentRelation: ObjectWrapper.Relation? = null
 
+    /**
+     * The authoritative, ordered list of selected option ids.
+     *
+     * It must NOT be derived from [viewState], because [filterOptions] removes every option
+     * that the search query hides. A selection that the query hides is therefore absent from
+     * the rendered items. A write built from the rendered items deletes that selection
+     * (DROID-4570).
+     *
+     * The field is updated from the [values].subscribe emission and from every optimistic
+     * write, so it stays correct while the query changes.
+     */
+    private var selectedIds: List<Id> = emptyList()
+
     init {
         viewModelScope.launch {
             val relation = storeOfRelations.getByKey(key = viewModelParams.relationKey) ?: return@launch
@@ -119,6 +132,7 @@ class TagOrStatusValueViewModel(
                 val options = storeOfRelationOptions.getByRelationKey(viewModelParams.relationKey)
                     .sortedBy { it.orderId }
                 val ids = getRecordValues(record)
+                selectedIds = ids
                 if (!isInitialExpandDone) {
                     isInitialExpandDone = true
                     if (ids.isEmpty() && isEditableRelation) {
@@ -368,22 +382,9 @@ class TagOrStatusValueViewModel(
         }
     }
 
-    /**
-     * Reconstructs the current ordered list of selected option ids from the *UI* state
-     * ([viewState]) rather than from [values], whose backing store may never re-emit for
-     * some hosts (see [proceedWithOptimisticUpdate]). For tags the selection order is carried
-     * by [RelationsListItem.Item.Tag.number] (1-based index among selected); status has at
-     * most one selected item.
-     */
-    private fun currentSelectedIds(content: TagStatusViewState.Content): List<Id> =
-        content.items
-            .filter { it.isSelected }
-            .sortedBy { (it as? RelationsListItem.Item.Tag)?.number ?: 0 }
-            .map { it.optionId }
-
     private fun addTag(tag: Id) {
-        val content = viewState.value as? TagStatusViewState.Content ?: return
-        val newIds = currentSelectedIds(content) + tag
+        if (selectedIds.contains(tag)) return
+        val newIds = selectedIds + tag
         proceedWithOptimisticUpdate(
             newIds = newIds,
             persistedValue = newIds,
@@ -393,8 +394,7 @@ class TagOrStatusValueViewModel(
     }
 
     private fun removeTag(tag: Id) {
-        val content = viewState.value as? TagStatusViewState.Content ?: return
-        val newIds = currentSelectedIds(content) - tag
+        val newIds = selectedIds - tag
         proceedWithOptimisticUpdate(
             newIds = newIds,
             persistedValue = newIds,
@@ -427,12 +427,13 @@ class TagOrStatusValueViewModel(
      * Single entry point for value edits. The sheet's list is normally rebuilt only when
      * [values].subscribe re-emits, but some hosts have no live writer for the backing store,
      * so a click would never be reflected. To fix that we update [viewState] optimistically:
-     * 1. lock event processing so a stale [values] re-emission can't clobber the UI,
-     * 2. rebuild [viewState] from [newIds] via [initViewState] (reuses filterOptions +
+     * 1. adopt [newIds] as the new [selectedIds],
+     * 2. lock event processing so a stale [values] re-emission can't clobber the UI,
+     * 3. rebuild [viewState] from [newIds] via [initViewState] (reuses filterOptions +
      *    option mapping / number recompute + create-item logic),
-     * 3. persist via [setObjectDetails],
-     * 4. on failure revert to the pre-click snapshot and toast,
-     * 5. on success dispatch the payload, send analytics, optionally dismiss.
+     * 4. persist via [setObjectDetails],
+     * 5. on failure revert [selectedIds] and [viewState] to the pre-click snapshot, then toast,
+     * 6. on success dispatch the payload, send analytics, optionally dismiss.
      */
     private fun proceedWithOptimisticUpdate(
         newIds: List<Id>,
@@ -442,6 +443,9 @@ class TagOrStatusValueViewModel(
     ) {
         val relation = currentRelation ?: return
         val previousState = viewState.value
+        val previousSelectedIds = selectedIds
+        // Assign before the launch, so a second click reads the result of the first one.
+        selectedIds = newIds
         viewModelScope.launch {
             // Lock BEFORE the optimistic write so any concurrent combine emission is skipped.
             activateOptionEventLock()
@@ -466,6 +470,7 @@ class TagOrStatusValueViewModel(
                     Timber.e(e, "Error while updating tag/status value")
                     // Revert optimistic update and release the lock so real events are honored again.
                     optionEventLockTimestamp = null
+                    selectedIds = previousSelectedIds
                     viewState.value = previousState
                     sendToast("Error while updating value")
                 },

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt
@@ -76,6 +76,11 @@ class TagOrStatusValueViewModelTest {
     private val tagB = "opt-b"
     private val tagC = "opt-c"
 
+    // Named so that the query "7" matches tag7 only.
+    private val tag2 = "tag2"
+    private val tag3 = "tag3"
+    private val tag7 = "tag7"
+
     @Before
     fun setup() {
         MockitoAnnotations.openMocks(this)
@@ -297,6 +302,52 @@ class TagOrStatusValueViewModelTest {
 
         // Reverted to the pre-click state.
         assertEquals(snapshot, vm.viewState.value)
+    }
+
+    @Test
+    fun `selecting a tag under an active query keeps the selections hidden by the query`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(
+            listOf(option(tag2, "0"), option(tag3, "1"), option(tag7, "2"))
+        )
+        stubPersistSuccess()
+
+        val vm = buildViewModel(initialIds = listOf(tag2, tag3))
+        advanceUntilIdle()
+
+        vm.onQueryChanged("7")
+        advanceUntilIdle()
+
+        // The query hides the two selected tags.
+        assertEquals(listOf(tag7), vm.items().map { it.optionId })
+
+        vm.onAction(TagStatusAction.Click(vm.items().byId(tag7)))
+        advanceUntilIdle()
+
+        verifyBlocking(setObjectDetails) { invoke(params(listOf(tag2, tag3, tag7))) }
+    }
+
+    @Test
+    fun `deselecting a tag under an active query keeps the selections hidden by the query`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(
+            listOf(option(tag2, "0"), option(tag3, "1"), option(tag7, "2"))
+        )
+        stubPersistSuccess()
+
+        val vm = buildViewModel(initialIds = listOf(tag2, tag3, tag7))
+        advanceUntilIdle()
+
+        vm.onQueryChanged("7")
+        advanceUntilIdle()
+
+        assertEquals(listOf(tag7), vm.items().map { it.optionId })
+        assertTrue(vm.items().byId(tag7).isSelected)
+
+        vm.onAction(TagStatusAction.Click(vm.items().byId(tag7)))
+        advanceUntilIdle()
+
+        verifyBlocking(setObjectDetails) { invoke(params(listOf(tag2, tag3))) }
     }
 
     @Test

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt
@@ -26,6 +26,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -35,6 +36,7 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
@@ -348,6 +350,38 @@ class TagOrStatusValueViewModelTest {
         advanceUntilIdle()
 
         verifyBlocking(setObjectDetails) { invoke(params(listOf(tag2, tag3))) }
+    }
+
+    @Test
+    fun `a late failure does not revert a newer write that already succeeded`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(
+            listOf(option(tagA, "0"), option(tagB, "1"), option(tagC, "2"))
+        )
+
+        // The first write fails, but only after the second write succeeds.
+        setObjectDetails.stub {
+            onBlocking { invoke(params(listOf(tagA, tagB))) } doSuspendableAnswer {
+                delay(1000)
+                Either.Left(RuntimeException("boom"))
+            }
+            onBlocking { invoke(params(listOf(tagA, tagB, tagC))) } doReturn
+                    Either.Right(Payload(context = objectId, events = emptyList()))
+        }
+
+        val vm = buildViewModel(initialIds = listOf(tagA))
+        advanceUntilIdle()
+
+        // Two taps in flight together.
+        vm.onAction(TagStatusAction.Click(vm.items().byId(tagB)))
+        vm.onAction(TagStatusAction.Click(vm.items().byId(tagC)))
+        advanceUntilIdle()
+
+        // The late failure must not resurrect the snapshot that holds tagA alone.
+        val updated = vm.items()
+        assertTrue(updated.byId(tagA).isSelected)
+        assertTrue(updated.byId(tagB).isSelected)
+        assertTrue(updated.byId(tagC).isSelected)
     }
 
     @Test


### PR DESCRIPTION
Linear: [DROID-4570](https://linear.app/anytype/issue/DROID-4570/properties-fix-tag-picker-drops-hidden-selections-when-a-search-query)

## Problem

The multi-select tag picker deletes the selected tags that the search query hides. The user never unchecks them. This is silent data loss.

Steps:
1. Open an object that holds the tags `tag2` and `tag3`.
2. Open the Tag property picker. Both tags show a selection badge.
3. Type `7` into the search field. The list shows only `tag7`.
4. Tap `tag7`.
5. Close the picker.

Expected: the object holds `tag2`, `tag3` and `tag7`.
Actual: the object holds only `tag7`.

Reported by forum user `trialsin` on version 0.48.9. [Forum post](https://community.anytype.io/t/anytype-android-0-48-9/31085/9)

## Root cause

`currentSelectedIds` read the selection back out of `viewState.items`. `filterOptions` already removed every option whose name does not match the query. A selected tag that the query hides was therefore absent from the rendered items. `addTag` and `removeTag` built the new id list from that reduced set. `proceedWithOptimisticUpdate` then persisted that list as the complete relation value.

`removeTag` carried the same fault. Under an active query it also deleted every hidden selection.

Regression source: `38c8bdbb4` ("DROID-4543 tag and status values fix", #3301). First shipped in 0.48.6.

## Fix

`TagOrStatusValueViewModel.kt`

- A new field `selectedIds` holds the authoritative ordered selection.
- The `values.subscribe` branch of the `combine` block writes `selectedIds`. The active option-event lock still skips that branch, so a stale emission cannot clobber the field.
- `proceedWithOptimisticUpdate` adopts `newIds` into `selectedIds` before it starts the coroutine. A second fast click therefore reads the result of the first click.
- The failure path reverts `selectedIds` together with `viewState`.
- `addTag` and `removeTag` read `selectedIds`. `addTag` also rejects a duplicate id.
- `currentSelectedIds` is deleted.

The optimistic render behavior does not change.

## Tests

`TagOrStatusValueViewModelTest.kt` gets two regression tests: one for select, one for deselect. Each test sets the query `7`, holds `tag2` and `tag3` outside the query, then asserts the persisted value.

Both tests fail on `main` with `ArgumentsAreDifferent`. Both pass with this change.

Full module run: `:presentation:testDebugUnitTest` — 1327 tests, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)