### PR TITLE
DROID-4571 Properties | Fix | Selected tag options no longer move to the top of the picker

### DIFF
--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/relations/TagOrStatusCompose.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/relations/TagOrStatusCompose.kt
@@ -46,6 +46,7 @@ import com.anytypeio.anytype.core_ui.common.DefaultPreviews
 import com.anytypeio.anytype.core_ui.extensions.swapList
 import com.anytypeio.anytype.core_ui.foundation.Divider
 import com.anytypeio.anytype.core_ui.foundation.Dragger
+import com.anytypeio.anytype.core_ui.foundation.Section
 import com.anytypeio.anytype.core_ui.foundation.noRippleClickable
 import com.anytypeio.anytype.core_ui.foundation.noRippleThrottledClickable
 import com.anytypeio.anytype.core_ui.views.BodyCalloutMedium
@@ -192,7 +193,7 @@ fun RelationsViewContent(
 
     if (state.isRelationEditable) {
         // Use reorderable list for both Tags and Status
-        val items = remember { mutableStateListOf<RelationsListItem.Item>() }
+        val items = remember { mutableStateListOf<RelationsListItem>() }
         items.swapList(state.items)
 
         // Track the original dragged item's ID (not index) to handle multiple callback invocations
@@ -202,9 +203,9 @@ fun RelationsViewContent(
             val originalItemId = draggedItemId.value
             if (originalItemId != null) {
                 // Find original index from state.items (unchanged during drag)
-                val originalIndex = state.items.indexOfFirst { it.optionId == originalItemId }
+                val originalIndex = state.items.indexOfFirst { it.uiKey() == originalItemId }
                 // Find new index in reordered items list
-                val newIndex = items.indexOfFirst { it.optionId == originalItemId }
+                val newIndex = items.indexOfFirst { it.uiKey() == originalItemId }
 
                 if (originalIndex != -1 && newIndex != -1 && originalIndex != newIndex) {
                     action(TagStatusAction.OnMove(from = originalIndex, to = newIndex))
@@ -226,10 +227,18 @@ fun RelationsViewContent(
             }
 
             // Find current indices by key
-            val f = items.indexOfFirst { it.optionId == fromId }
-            val t = items.indexOfFirst { it.optionId == toId }
+            val f = items.indexOfFirst { it.uiKey() == fromId }
+            val t = items.indexOfFirst { it.uiKey() == toId }
+            val fromItem = items.getOrNull(f) as? RelationsListItem.Item
+            val toItem = items.getOrNull(t) as? RelationsListItem.Item
 
-            if (f != -1 && t != -1 && f != t) {
+            // A drag never crosses a section header: the target must be an item
+            // of the same section (same selection state).
+            if (fromItem == null || toItem == null || fromItem.isSelected != toItem.isSelected) {
+                return@rememberReorderableLazyListState
+            }
+
+            if (f != t) {
                 val newList = items.toMutableList().apply {
                     add(t, removeAt(f))
                 }
@@ -249,49 +258,60 @@ fun RelationsViewContent(
             // Reorderable items
             items(
                 count = items.size,
-                key = { index -> items[index].optionId }
+                key = { index -> items[index].uiKey() }
             ) { index ->
-                val item = items[index]
-                ReorderableItem(reorderableLazyListState, key = item.optionId) { isDragging ->
-                    val currentItem = LocalView.current
-                    if (isDragging) {
-                        currentItem.isHapticFeedbackEnabled = true
-                        currentItem.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
-                    }
-                    val dragHandleModifier = Modifier.longPressDraggableHandle(
-                        onDragStarted = {
-                            ViewCompat.performHapticFeedback(
-                                view,
-                                HapticFeedbackConstantsCompat.GESTURE_START
-                            )
-                        },
-                        onDragStopped = {
-                            ViewCompat.performHapticFeedback(
-                                view,
-                                HapticFeedbackConstantsCompat.GESTURE_END
-                            )
-                            onDragStoppedHandler()
-                        }
+                when (val item = items[index]) {
+                    RelationsListItem.Section.Selected -> Section(
+                        title = stringResource(id = R.string.tag_status_section_selected)
                     )
-                    when (item) {
-                        is RelationsListItem.Item.Tag -> TagItem(
-                            state = item,
-                            action = action,
-                            isEditable = state.isRelationEditable,
-                            showDivider = true,
-                            isDragging = isDragging,
-                            dragHandleModifier = dragHandleModifier
+                    RelationsListItem.Section.AllValues -> Section(
+                        title = stringResource(id = R.string.tag_status_section_all_values)
+                    )
+                    is RelationsListItem.Item -> ReorderableItem(
+                        reorderableLazyListState,
+                        key = item.uiKey()
+                    ) { isDragging ->
+                        val currentItem = LocalView.current
+                        if (isDragging) {
+                            currentItem.isHapticFeedbackEnabled = true
+                            currentItem.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                        }
+                        val dragHandleModifier = Modifier.longPressDraggableHandle(
+                            onDragStarted = {
+                                ViewCompat.performHapticFeedback(
+                                    view,
+                                    HapticFeedbackConstantsCompat.GESTURE_START
+                                )
+                            },
+                            onDragStopped = {
+                                ViewCompat.performHapticFeedback(
+                                    view,
+                                    HapticFeedbackConstantsCompat.GESTURE_END
+                                )
+                                onDragStoppedHandler()
+                            }
                         )
+                        when (item) {
+                            is RelationsListItem.Item.Tag -> TagItem(
+                                state = item,
+                                action = action,
+                                isEditable = state.isRelationEditable,
+                                showDivider = true,
+                                isDragging = isDragging,
+                                dragHandleModifier = dragHandleModifier
+                            )
 
-                        is RelationsListItem.Item.Status -> StatusItem(
-                            state = item,
-                            action = action,
-                            isEditable = state.isRelationEditable,
-                            showDivider = true,
-                            isDragging = isDragging,
-                            dragHandleModifier = dragHandleModifier
-                        )
+                            is RelationsListItem.Item.Status -> StatusItem(
+                                state = item,
+                                action = action,
+                                isEditable = state.isRelationEditable,
+                                showDivider = true,
+                                isDragging = isDragging,
+                                dragHandleModifier = dragHandleModifier
+                            )
+                        }
                     }
+                    is RelationsListItem.CreateItem -> Unit
                 }
             }
 
@@ -329,6 +349,8 @@ fun RelationsViewContent(
                             isEditable = state.isRelationEditable,
                             showDivider = !isLastItem
                         )
+
+                        else -> Unit
                     }
                 }
             )
@@ -416,6 +438,13 @@ private fun getTitle(state: TagStatusViewState): String {
     }
 }
 
+private fun RelationsListItem.uiKey(): String = when (this) {
+    RelationsListItem.Section.Selected -> "section_selected"
+    RelationsListItem.Section.AllValues -> "section_all_values"
+    is RelationsListItem.Item -> optionId
+    is RelationsListItem.CreateItem -> "create_item"
+}
+
 @DefaultPreviews
 @Composable
 private fun TagOrStatusValueScreenEmptyEditablePreview() {
@@ -452,7 +481,8 @@ private fun TagOrStatusValueScreenEmptyReadOnlyPreview() {
 @DefaultPreviews
 @Composable
 private fun TagOrStatusValueScreenPreview() {
-    val items = listOf(
+    val items: List<RelationsListItem> = listOf(
+        RelationsListItem.Section.Selected,
         RelationsListItem.Item.Tag(
             optionId = "1",
             name = "Urgent",
@@ -460,6 +490,7 @@ private fun TagOrStatusValueScreenPreview() {
             color = ThemeColor.RED,
             number = 10
         ),
+        RelationsListItem.Section.AllValues,
         RelationsListItem.Item.Tag(
             optionId = "2",
             name = "In Progress",

--- a/docs/superpowers/plans/2026-08-12-droid-4571-tag-picker-sections.md
+++ b/docs/superpowers/plans/2026-08-12-droid-4571-tag-picker-sections.md
@@ -1,0 +1,837 @@
+# DROID-4571 Tag Picker Sections Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The tag/status value picker shows a "Selected" section on top and an "All values" section below, each with drag-to-reorder.
+
+**Architecture:** The ViewModel builds one flat list with two header items interleaved. A drag inside "Selected" writes the permuted id list through the existing optimistic `UpdateDetail` path. A drag inside "All values" merges the displayed order back into the full option order and calls `SetRelationOptionOrder`. The Compose layer renders the headers as non-draggable rows and rejects a move across a section boundary.
+
+**Tech Stack:** Kotlin, Jetpack Compose, `sh.calvin.reorderable`, Mockito-Kotlin, Turbine, JUnit4.
+
+**Spec:** `docs/superpowers/specs/2026-08-12-droid-4571-tag-picker-sections-design.md`
+
+## Global Constraints
+
+- Java 17 is required for every Gradle invocation.
+- New user-visible strings go to `localization/src/main/res/values/strings.xml` only.
+- Commit messages start with `DROID-4571` and use ASD-STE100 Simplified Technical English (active voice, no contractions, one action per sentence).
+- Every commit ends with the trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- The read-only picker layout must not change: a flat list of the selected values, no headers.
+- The display sort of selected values must never write through `SetRelationOptionOrder` (that RPC changes the global option order for all objects).
+- Match existing code style: plain `object` subclasses in sealed classes (not `data object`), Timber logging, no new comments that merely restate code.
+
+## File Map
+
+| File | Role |
+| --- | --- |
+| `presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt` | ViewModel + all state models (bottom of file). Both tasks modify it. |
+| `core-ui/src/main/java/com/anytypeio/anytype/core_ui/relations/TagOrStatusCompose.kt` | The picker screen. Task 1 modifies it. |
+| `localization/src/main/res/values/strings.xml` | Task 1 adds two strings. |
+| `presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt` | All new tests. |
+
+Test command used throughout:
+
+```bash
+./gradlew :presentation:testDebugUnitTest --tests "com.anytypeio.anytype.presentation.relations.value.tagstatus.TagOrStatusValueViewModelTest"
+```
+
+Compile check for the UI module:
+
+```bash
+./gradlew :core-ui:compileDebugKotlin
+```
+
+---
+
+### Task 1: Section composition — model, ViewModel, Compose rendering
+
+**Files:**
+- Modify: `presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt`
+- Modify: `core-ui/src/main/java/com/anytypeio/anytype/core_ui/relations/TagOrStatusCompose.kt`
+- Modify: `localization/src/main/res/values/strings.xml`
+- Test: `presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt`
+
+**Interfaces:**
+- Consumes: existing `RelationsListItem`, `TagStatusViewState.Content`, `initViewState`, `filterOptions`.
+- Produces (Task 2 relies on these exact shapes):
+  - `RelationsListItem.Section` sealed class with `object Selected : Section()` and `object AllValues : Section()`.
+  - `TagStatusViewState.Content.items: List<RelationsListItem>` (widened from `List<RelationsListItem.Item>`).
+  - Editable list layout: `[Section.Selected, selected items in value order, Section.AllValues, unselected items in orderId order]`, a header omitted when its group is empty.
+  - Test helpers `allItems()` (full list) and `items()` (items only, headers filtered).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `TagOrStatusValueViewModelTest.kt`, replace the `items()` helper (line 162-163) with:
+
+```kotlin
+    private fun TagOrStatusValueViewModel.allItems(): List<RelationsListItem> =
+        (viewState.value as TagStatusViewState.Content).items
+
+    private fun TagOrStatusValueViewModel.items(): List<RelationsListItem.Item> =
+        allItems().filterIsInstance<RelationsListItem.Item>()
+
+    private fun List<RelationsListItem>.byId(id: Id) =
+        filterIsInstance<RelationsListItem.Item>().first { it.optionId == id }
+
+    /** Maps each row to its optionId, or to the Section object itself, for order assertions. */
+    private fun TagOrStatusValueViewModel.rows(): List<Any> =
+        allItems().map { if (it is RelationsListItem.Item) it.optionId else it }
+```
+
+Note: the old `byId` extension on `List<RelationsListItem.Item>` still compiles; replace it with the version above (receiver `List<RelationsListItem>`) so both helper outputs work with it. Keep every existing test unchanged otherwise — `items()` filters the headers out, so the old assertions stay valid.
+
+Change `buildViewModel` (line 137) to accept a lock flag:
+
+```kotlin
+    private fun buildViewModel(
+        initialIds: List<Id>,
+        isLocked: Boolean = false
+    ): TagOrStatusValueViewModel {
+```
+
+and pass `isLocked = isLocked` in `ViewModelParams` (line 147).
+
+Add the new tests at the end of the class:
+
+```kotlin
+    @Test
+    fun `editable tag list shows the selected section then the all values section`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1"), option(tagC, "2")))
+
+        val vm = buildViewModel(initialIds = listOf(tagC, tagB))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf<Any>(
+                RelationsListItem.Section.Selected,
+                tagC,
+                tagB,
+                RelationsListItem.Section.AllValues,
+                tagA
+            ),
+            vm.rows()
+        )
+        assertEquals(1, (vm.allItems().byId(tagC) as RelationsListItem.Item.Tag).number)
+        assertEquals(2, (vm.allItems().byId(tagB) as RelationsListItem.Item.Tag).number)
+    }
+
+    @Test
+    fun `no selection shows only the all values header`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+
+        val vm = buildViewModel(initialIds = emptyList())
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf<Any>(RelationsListItem.Section.AllValues, tagA, tagB),
+            vm.rows()
+        )
+    }
+
+    @Test
+    fun `full selection shows only the selected header`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+
+        val vm = buildViewModel(initialIds = listOf(tagA, tagB))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf<Any>(RelationsListItem.Section.Selected, tagA, tagB),
+            vm.rows()
+        )
+    }
+
+    @Test
+    fun `status list gets the same sections`() = runTest {
+        storeOfRelations.merge(listOf(statusRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+
+        val vm = buildViewModel(initialIds = listOf(tagB))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf<Any>(
+                RelationsListItem.Section.Selected,
+                tagB,
+                RelationsListItem.Section.AllValues,
+                tagA
+            ),
+            vm.rows()
+        )
+    }
+
+    @Test
+    fun `read-only list has no section headers`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+
+        val vm = buildViewModel(initialIds = listOf(tagB), isLocked = true)
+        advanceUntilIdle()
+
+        assertEquals(listOf<Any>(tagB), vm.rows())
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run the test command from the File Map section.
+Expected: the five new tests FAIL to compile or FAIL on assertion (`Section` does not exist yet). If compilation of the test file fails entirely, that counts as the expected failure.
+
+- [ ] **Step 3: Implement the model change and the list composition**
+
+In `TagOrStatusValueViewModel.kt`:
+
+3a. Add `Section` to `RelationsListItem` (line 635) and keep everything else:
+
+```kotlin
+sealed class RelationsListItem {
+
+    sealed class Section : RelationsListItem() {
+        object Selected : Section()
+        object AllValues : Section()
+    }
+
+    sealed class Item : RelationsListItem() {
+        // ... unchanged ...
+```
+
+3b. Widen `TagStatusViewState.Content.items` (line 614):
+
+```kotlin
+    data class Content(
+        val title: String,
+        val items: List<RelationsListItem>,
+        val createItem: RelationsListItem.CreateItem.Tag? = null,
+        val isRelationEditable: Boolean,
+        val showItemMenu: RelationsListItem.Item? = null
+    ) : TagStatusViewState()
+```
+
+3c. Rewrite `initViewState` (line 327-380). Replace the `result` accumulation with:
+
+```kotlin
+    private fun initViewState(
+        relation: ObjectWrapper.Relation,
+        ids: List<Id>,
+        options: List<ObjectWrapper.Option>,
+        query: String
+    ) {
+        val isTagRelation = relation.format == Relation.Format.TAG
+
+        val mapped: List<RelationsListItem.Item> = when (relation.format) {
+            Relation.Format.STATUS -> mapStatusOptions(ids = ids, options = options)
+            Relation.Format.TAG -> mapTagOptions(ids = ids, options = options)
+            else -> {
+                Timber.w("Relation format should be Tag or Status but was: ${relation.format}")
+                emptyList()
+            }
+        }
+
+        val items = buildSectionedList(mapped = mapped, ids = ids)
+
+        // CreateItem is only shown for TAG relations when there's a search query
+        val createItem = if (isTagRelation && query.isNotBlank() && isEditableRelation) {
+            RelationsListItem.CreateItem.Tag(query)
+        } else {
+            null
+        }
+
+        viewState.value = if (items.isEmpty() && createItem == null) {
+            TagStatusViewState.Empty(
+                isRelationEditable = isEditableRelation,
+                title = relation.name.orEmpty(),
+            )
+        } else {
+            TagStatusViewState.Content(
+                isRelationEditable = isEditableRelation,
+                title = relation.name.orEmpty(),
+                items = items,
+                createItem = createItem
+            )
+        }.also {
+            Timber.d("TagStatusViewModel initViewState, viewState: $it")
+        }
+    }
+
+    /**
+     * Editable relations get two sections: the selected options in value order,
+     * then the unselected options in the global option order. The read-only list
+     * stays flat. A header is omitted when its group is empty. The display sort
+     * is deliberately separate from the persisted option order (DROID-3916).
+     */
+    private fun buildSectionedList(
+        mapped: List<RelationsListItem.Item>,
+        ids: List<Id>
+    ): List<RelationsListItem> {
+        if (!isEditableRelation) return mapped
+        val selected = mapped.filter { it.isSelected }.sortedBy { ids.indexOf(it.optionId) }
+        val unselected = mapped.filter { !it.isSelected }
+        return buildList {
+            if (selected.isNotEmpty()) {
+                add(RelationsListItem.Section.Selected)
+                addAll(selected)
+            }
+            if (unselected.isNotEmpty()) {
+                add(RelationsListItem.Section.AllValues)
+                addAll(unselected)
+            }
+        }
+    }
+```
+
+3d. The `OnMove` handler (line 253-280) no longer compiles because `items` now holds headers without `optionId`. Apply a minimal compile fix only — Task 2 replaces the whole handler:
+
+```kotlin
+                    val reorderedIds = currentState.items
+                        .filterIsInstance<RelationsListItem.Item>()
+                        .toMutableList()
+                        .apply { add(action.to, removeAt(action.from)) }
+                        .map { it.optionId }
+```
+
+Note: this intermediate behavior is wrong for sectioned lists (the indices include headers). That is acceptable inside this task only because Task 2 rewrites the handler before the branch is finished; the tests for `OnMove` arrive in Task 2.
+
+3e. Add the two strings to `localization/src/main/res/values/strings.xml`, next to other relation strings (search for `name="options_empty_title"` and add below that block):
+
+```xml
+    <string name="tag_status_section_selected">Selected</string>
+    <string name="tag_status_section_all_values">All values</string>
+```
+
+- [ ] **Step 4: Adapt the Compose screen**
+
+In `TagOrStatusCompose.kt`:
+
+4a. Add imports:
+
+```kotlin
+import com.anytypeio.anytype.core_ui.foundation.Section
+```
+
+4b. Add a private key helper at file scope (below `getTitle`, line 417):
+
+```kotlin
+private fun RelationsListItem.uiKey(): String = when (this) {
+    RelationsListItem.Section.Selected -> "section_selected"
+    RelationsListItem.Section.AllValues -> "section_all_values"
+    is RelationsListItem.Item -> optionId
+    is RelationsListItem.CreateItem -> "create_item"
+}
+```
+
+4c. In `RelationsViewContent` (editable branch), widen the local list (line 195):
+
+```kotlin
+        val items = remember { mutableStateListOf<RelationsListItem>() }
+        items.swapList(state.items)
+```
+
+4d. Change `onDragStoppedHandler` (line 201-214) to key-based lookups:
+
+```kotlin
+        val onDragStoppedHandler = {
+            val originalItemId = draggedItemId.value
+            if (originalItemId != null) {
+                // Find original index from state.items (unchanged during drag)
+                val originalIndex = state.items.indexOfFirst { it.uiKey() == originalItemId }
+                // Find new index in reordered items list
+                val newIndex = items.indexOfFirst { it.uiKey() == originalItemId }
+
+                if (originalIndex != -1 && newIndex != -1 && originalIndex != newIndex) {
+                    action(TagStatusAction.OnMove(from = originalIndex, to = newIndex))
+                }
+            }
+            draggedItemId.value = null
+        }
+```
+
+4e. In `rememberReorderableLazyListState` (line 216-243), reject a move across a section boundary. Replace the index lookups with:
+
+```kotlin
+            // Capture original dragged item on first move
+            if (draggedItemId.value == null) {
+                draggedItemId.value = fromId
+            }
+
+            // Find current indices by key
+            val f = items.indexOfFirst { it.uiKey() == fromId }
+            val t = items.indexOfFirst { it.uiKey() == toId }
+            val fromItem = items.getOrNull(f) as? RelationsListItem.Item
+            val toItem = items.getOrNull(t) as? RelationsListItem.Item
+
+            // A drag never crosses a section header: the target must be an item
+            // of the same section (same selection state).
+            if (fromItem == null || toItem == null || fromItem.isSelected != toItem.isSelected) {
+                return@rememberReorderableLazyListState
+            }
+
+            if (f != t) {
+                val newList = items.toMutableList().apply {
+                    add(t, removeAt(f))
+                }
+                items.swapList(newList)
+
+                ViewCompat.performHapticFeedback(
+                    view,
+                    HapticFeedbackConstantsCompat.SEGMENT_FREQUENT_TICK
+                )
+            }
+```
+
+4f. In the editable `LazyColumn` (line 245-296), key by `uiKey()` and render headers outside `ReorderableItem`:
+
+```kotlin
+            items(
+                count = items.size,
+                key = { index -> items[index].uiKey() }
+            ) { index ->
+                when (val item = items[index]) {
+                    RelationsListItem.Section.Selected -> Section(
+                        title = stringResource(id = R.string.tag_status_section_selected)
+                    )
+                    RelationsListItem.Section.AllValues -> Section(
+                        title = stringResource(id = R.string.tag_status_section_all_values)
+                    )
+                    is RelationsListItem.Item -> ReorderableItem(
+                        reorderableLazyListState,
+                        key = item.uiKey()
+                    ) { isDragging ->
+                        val currentItem = LocalView.current
+                        if (isDragging) {
+                            currentItem.isHapticFeedbackEnabled = true
+                            currentItem.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                        }
+                        val dragHandleModifier = Modifier.longPressDraggableHandle(
+                            onDragStarted = {
+                                ViewCompat.performHapticFeedback(
+                                    view,
+                                    HapticFeedbackConstantsCompat.GESTURE_START
+                                )
+                            },
+                            onDragStopped = {
+                                ViewCompat.performHapticFeedback(
+                                    view,
+                                    HapticFeedbackConstantsCompat.GESTURE_END
+                                )
+                                onDragStoppedHandler()
+                            }
+                        )
+                        when (item) {
+                            is RelationsListItem.Item.Tag -> TagItem(
+                                state = item,
+                                action = action,
+                                isEditable = state.isRelationEditable,
+                                showDivider = true,
+                                isDragging = isDragging,
+                                dragHandleModifier = dragHandleModifier
+                            )
+
+                            is RelationsListItem.Item.Status -> StatusItem(
+                                state = item,
+                                action = action,
+                                isEditable = state.isRelationEditable,
+                                showDivider = true,
+                                isDragging = isDragging,
+                                dragHandleModifier = dragHandleModifier
+                            )
+                        }
+                    }
+                    is RelationsListItem.CreateItem -> Unit
+                }
+            }
+```
+
+Keep the `state.createItem` block after it unchanged.
+
+4g. In the read-only branch (line 314-334), the `when (item)` now sees `RelationsListItem`. Add a fall-through branch so the block stays exhaustive-safe:
+
+```kotlin
+                    when (item) {
+                        is RelationsListItem.Item.Tag -> TagItem(...unchanged...)
+                        is RelationsListItem.Item.Status -> StatusItem(...unchanged...)
+                        else -> Unit
+                    }
+```
+
+4h. Update `TagOrStatusValueScreenPreview` (line 454) so the preview shows the sections: insert `RelationsListItem.Section.Selected` before the selected tag and `RelationsListItem.Section.AllValues` before the unselected tags in the `items` list. The preview's `items` variable type becomes `List<RelationsListItem>`.
+
+- [ ] **Step 5: Run the tests and the UI compile check**
+
+Run both commands from the File Map section.
+Expected: all tests PASS (the five new ones and the ten existing ones), `:core-ui:compileDebugKotlin` succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt \
+        core-ui/src/main/java/com/anytypeio/anytype/core_ui/relations/TagOrStatusCompose.kt \
+        localization/src/main/res/values/strings.xml \
+        presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt
+git commit -m "DROID-4571 Properties | Fix | Show Selected and All values sections in the tag picker
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Sectioned drag semantics in OnMove
+
+**Files:**
+- Modify: `presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt`
+- Test: `presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt`
+
+**Interfaces:**
+- Consumes from Task 1: `RelationsListItem.Section`, `Content.items: List<RelationsListItem>`, sectioned list layout, `proceedWithOptimisticUpdate(newIds, persistedValue, analyticsEvent, dismissOnSuccess)` (unchanged, line 443), `activateOptionEventLock()` (line 555), `selectedIds` (line 117).
+- Produces: private functions `onMove(from, to)`, `moveSelectedValue(moved)`, `moveOptionOrder(moved)`, `mergeReorderedSubset(full, displayedNewOrder)`. `TagStatusAction.OnMove(from, to)` keeps flat-list indices that include the headers.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the test class fields (near line 84):
+
+```kotlin
+    private val tagD = "opt-d"
+
+    // Named so that the query "7" matches both.
+    private val tag7a = "tag7a"
+    private val tag7b = "tag7b"
+```
+
+Add imports:
+
+```kotlin
+import com.anytypeio.anytype.core_models.primitives.RelationKey
+import com.anytypeio.anytype.domain.base.Resultat
+import com.anytypeio.anytype.domain.relations.SetRelationOptionOrder
+import org.mockito.kotlin.verifyNoInteractions
+```
+
+(`SetRelationOptionOrder` is already imported; skip it if the import exists.)
+
+Add a stub helper next to `stubPersistSuccess` (line 125):
+
+```kotlin
+    private fun stubOptionOrderSuccess() {
+        setRelationOptionOrder.stub {
+            onBlocking { async(any()) } doReturn Resultat.success(Unit)
+        }
+    }
+
+    private fun orderParams(orderedIds: List<Id>) = SetRelationOptionOrder.Params(
+        spaceId = space,
+        relationKey = RelationKey(relationKey),
+        orderedIds = orderedIds
+    )
+```
+
+Add the tests:
+
+```kotlin
+    @Test
+    fun `drag inside the selected section reorders the object value`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1"), option(tagC, "2")))
+        stubPersistSuccess()
+
+        val vm = buildViewModel(initialIds = listOf(tagA, tagB, tagC))
+        advanceUntilIdle()
+
+        // Flat list: [Section.Selected, A, B, C]. Move A after C.
+        vm.onAction(TagStatusAction.OnMove(from = 1, to = 3))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf<Any>(RelationsListItem.Section.Selected, tagB, tagC, tagA),
+            vm.rows()
+        )
+        assertEquals(1, (vm.allItems().byId(tagB) as RelationsListItem.Item.Tag).number)
+        assertEquals(3, (vm.allItems().byId(tagA) as RelationsListItem.Item.Tag).number)
+        verifyBlocking(setObjectDetails) { invoke(params(listOf(tagB, tagC, tagA))) }
+        verifyNoInteractions(setRelationOptionOrder)
+    }
+
+    @Test
+    fun `drag inside the selected section keeps the selections hidden by the query`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(
+            listOf(option(tag2, "0"), option(tag7a, "1"), option(tag7b, "2"))
+        )
+        stubPersistSuccess()
+
+        val vm = buildViewModel(initialIds = listOf(tag2, tag7a, tag7b))
+        advanceUntilIdle()
+
+        vm.onQueryChanged("7")
+        advanceUntilIdle()
+
+        // Flat list under the query: [Section.Selected, tag7a, tag7b]. Swap them.
+        vm.onAction(TagStatusAction.OnMove(from = 1, to = 2))
+        advanceUntilIdle()
+
+        // The hidden selection tag2 keeps its first position.
+        verifyBlocking(setObjectDetails) { invoke(params(listOf(tag2, tag7b, tag7a))) }
+    }
+
+    @Test
+    fun `a failed value write after a selected drag reverts the order and toasts`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+        stubPersistFailure()
+
+        val vm = buildViewModel(initialIds = listOf(tagA, tagB))
+        advanceUntilIdle()
+        val snapshot = vm.viewState.value
+
+        vm.toasts.test {
+            vm.onAction(TagStatusAction.OnMove(from = 1, to = 2))
+            advanceUntilIdle()
+            val messages = cancelAndConsumeRemainingEvents()
+                .filterIsInstance<Event.Item<String>>()
+                .map { it.value }
+            assertTrue(messages.contains("Error while updating value"))
+        }
+
+        assertEquals(snapshot, vm.viewState.value)
+    }
+
+    @Test
+    fun `drag inside all values saves the merged global option order`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(
+            listOf(option(tagA, "0"), option(tagB, "1"), option(tagC, "2"), option(tagD, "3"))
+        )
+        stubOptionOrderSuccess()
+
+        val vm = buildViewModel(initialIds = listOf(tagB))
+        advanceUntilIdle()
+
+        // Flat list: [Section.Selected, B, Section.AllValues, A, C, D]. Move D before A.
+        vm.onAction(TagStatusAction.OnMove(from = 5, to = 3))
+        advanceUntilIdle()
+
+        // Full order was [A, B, C, D]; B is hidden from the section and keeps its slot.
+        verifyBlocking(setRelationOptionOrder) {
+            async(orderParams(listOf(tagD, tagB, tagA, tagC)))
+        }
+        verifyNoInteractions(setObjectDetails)
+    }
+
+    @Test
+    fun `drag inside all values under a query keeps the hidden options in place`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(
+            listOf(option(tag7a, "0"), option(tag2, "1"), option(tag7b, "2"))
+        )
+        stubOptionOrderSuccess()
+
+        val vm = buildViewModel(initialIds = emptyList())
+        advanceUntilIdle()
+
+        vm.onQueryChanged("7")
+        advanceUntilIdle()
+
+        // Flat list under the query: [Section.AllValues, tag7a, tag7b]. Swap them.
+        vm.onAction(TagStatusAction.OnMove(from = 1, to = 2))
+        advanceUntilIdle()
+
+        // Full order was [tag7a, tag2, tag7b]; hidden tag2 keeps its slot.
+        verifyBlocking(setRelationOptionOrder) {
+            async(orderParams(listOf(tag7b, tag2, tag7a)))
+        }
+    }
+
+    @Test
+    fun `drag across sections is ignored`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+
+        val vm = buildViewModel(initialIds = listOf(tagA))
+        advanceUntilIdle()
+
+        // Flat list: [Section.Selected, A, Section.AllValues, B].
+        // from = selected item, to = unselected item.
+        vm.onAction(TagStatusAction.OnMove(from = 1, to = 3))
+        // from = item, to = section header.
+        vm.onAction(TagStatusAction.OnMove(from = 3, to = 2))
+        advanceUntilIdle()
+
+        verifyNoInteractions(setObjectDetails)
+        verifyNoInteractions(setRelationOptionOrder)
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run the test command from the File Map section.
+Expected: the six new tests FAIL (the current handler reorders the header-free list by header-inclusive indices and always calls `setRelationOptionOrder`). Every pre-existing test must still PASS.
+
+- [ ] **Step 3: Rewrite the OnMove handler**
+
+In `TagOrStatusValueViewModel.kt`:
+
+3a. Replace the whole `is TagStatusAction.OnMove -> { ... }` branch (line 253-280) with:
+
+```kotlin
+            is TagStatusAction.OnMove -> {
+                Timber.d("OnMove from ${action.from} to ${action.to}")
+                onMove(from = action.from, to = action.to)
+            }
+```
+
+3b. Add the three private functions (below `onActionClick`, line 325):
+
+```kotlin
+    /**
+     * [from] and [to] are indices into the flat, header-inclusive items list.
+     * The section of the dragged item decides the write path: a selected item
+     * permutes this object's value list, an unselected item permutes the
+     * global option order. A move whose target is a header or an item of the
+     * other section is ignored — the UI rejects those moves as well, this is
+     * the second gate.
+     */
+    private fun onMove(from: Int, to: Int) {
+        val currentState = viewState.value as? TagStatusViewState.Content ?: return
+        val items = currentState.items
+        val dragged = items.getOrNull(from) as? RelationsListItem.Item ?: return
+        val target = items.getOrNull(to) as? RelationsListItem.Item ?: return
+        if (dragged.isSelected != target.isSelected) return
+        val moved = items.toMutableList().apply { add(to, removeAt(from)) }
+        if (dragged.isSelected) {
+            moveSelectedValue(moved)
+        } else {
+            moveOptionOrder(moved)
+        }
+    }
+
+    private fun moveSelectedValue(moved: List<RelationsListItem>) {
+        val displayedOrder = moved
+            .filterIsInstance<RelationsListItem.Item>()
+            .filter { it.isSelected }
+            .map { it.optionId }
+        val newIds = mergeReorderedSubset(
+            full = selectedIds,
+            displayedNewOrder = displayedOrder
+        )
+        proceedWithOptimisticUpdate(
+            newIds = newIds,
+            persistedValue = newIds,
+            analyticsEvent = EventsDictionary.relationChangeValue,
+            dismissOnSuccess = false
+        )
+    }
+
+    private fun moveOptionOrder(moved: List<RelationsListItem>) {
+        viewModelScope.launch {
+            val fullOrder = storeOfRelationOptions
+                .getByRelationKey(viewModelParams.relationKey)
+                .sortedBy { it.orderId }
+                .map { it.id }
+            val displayedOrder = moved
+                .filterIsInstance<RelationsListItem.Item>()
+                .filter { !it.isSelected }
+                .map { it.optionId }
+            val orderedIds = mergeReorderedSubset(
+                full = fullOrder,
+                displayedNewOrder = displayedOrder
+            )
+            // Activate lock before sending to middleware to prevent race conditions
+            activateOptionEventLock()
+            setRelationOptionOrder.async(
+                SetRelationOptionOrder.Params(
+                    spaceId = viewModelParams.space,
+                    relationKey = RelationKey(viewModelParams.relationKey),
+                    orderedIds = orderedIds
+                )
+            ).fold(
+                onSuccess = {
+                    Timber.d("Option order saved successfully")
+                },
+                onFailure = { e ->
+                    Timber.e(e, "Failed to save option order")
+                    sendToast("Failed to save order")
+                }
+            )
+        }
+    }
+
+    /**
+     * Applies the new relative order of a displayed subset to the full list.
+     * An id that the list displays takes the next displayed slot in the new
+     * order. An id that the query or the section hides keeps its position.
+     */
+    private fun mergeReorderedSubset(
+        full: List<Id>,
+        displayedNewOrder: List<Id>
+    ): List<Id> {
+        val displayed = displayedNewOrder.toSet()
+        val iterator = displayedNewOrder.iterator()
+        return full.map { id -> if (displayed.contains(id)) iterator.next() else id }
+    }
+```
+
+Note: `moveSelectedValue` reuses `proceedWithOptimisticUpdate`, so the optimistic rebuild, the event lock, the failure revert, and the analytics event all come for free and stay consistent with tap-selection.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run the test command from the File Map section.
+Expected: all tests PASS (six new, five from Task 1, ten pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt \
+        presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt
+git commit -m "DROID-4571 Properties | Fix | Route a drag to the value order or the option order by section
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Full verification
+
+**Files:**
+- No new source changes are expected. Fix regressions here if verification finds any.
+
+**Interfaces:**
+- Consumes: the finished code of Tasks 1-2.
+- Produces: a green build as the merge gate.
+
+- [ ] **Step 1: Run the presentation unit tests for the whole module**
+
+```bash
+./gradlew :presentation:testDebugUnitTest
+```
+
+Expected: PASS. Watch for failures in neighboring relation tests (for example `ObjectValueViewModelTest`) — they share providers with this ViewModel.
+
+- [ ] **Step 2: Compile the app and the UI modules**
+
+```bash
+./gradlew :core-ui:compileDebugKotlin :app:compileDebugSources
+```
+
+Expected: success. This catches usages of `TagStatusViewState.Content.items` outside the two edited files.
+
+- [ ] **Step 3: Run lint on the touched modules**
+
+```bash
+./gradlew :presentation:lintDebug :core-ui:lintDebug
+```
+
+Expected: no new errors. Pre-existing warnings stay.
+
+- [ ] **Step 4: Commit fixes, if any**
+
+If steps 1-3 required fixes, commit them:
+
+```bash
+git add -A
+git commit -m "DROID-4571 Properties | Fix | Repair issues found by full verification
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+If nothing changed, skip the commit.

--- a/docs/superpowers/specs/2026-08-12-droid-4571-tag-picker-sections-design.md
+++ b/docs/superpowers/specs/2026-08-12-droid-4571-tag-picker-sections-design.md
@@ -1,0 +1,125 @@
+# DROID-4571 — Tag picker: "Selected" and "All values" sections
+
+Date: 2026-08-12
+Ticket: https://linear.app/anytype/issue/DROID-4571/properties-fix-selected-tag-options-no-longer-move-to-the-top-of-the
+Status: approved by the user (approach B, desktop parity)
+
+## Problem
+
+The tag/status value picker shows one flat list in the global option order.
+The selected options do not move to the top. The user must scroll a long
+list to find the active selections.
+
+The selected-first sort existed before. Commit `9bac416af` (DROID-3916,
+manual option sorting) removed it and replaced it with a sort by `orderId`.
+
+The desktop client shows two sections: "Selected" on top, then "All values".
+Each section supports drag-to-reorder. Android must match this layout.
+
+## Current state
+
+- Screen: `core-ui/src/main/java/com/anytypeio/anytype/core_ui/relations/TagOrStatusCompose.kt`.
+  One `LazyColumn` with the `sh.calvin.reorderable` library. Drag is active
+  only when `state.isRelationEditable`.
+- ViewModel: `presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt`.
+  - `initViewState` builds a flat `List<RelationsListItem.Item>`.
+  - `mapTagOptions` sets `isSelected` and the `number` badge. It does not sort.
+  - `TagStatusAction.OnMove` sends the full displayed order to
+    `SetRelationOptionOrder`. This edits the global option order of the
+    relation, for all objects.
+  - `proceedWithOptimisticUpdate` writes the selected id list through
+    `UpdateDetail`, with revert on failure.
+- No mechanism reorders the selected values on one object. The selection is
+  a plain id list, so a permuted id list through `UpdateDetail` is enough.
+  No new middleware is needed.
+- Latent bug: a drag during an active search sends only the filtered ids to
+  `SetRelationOptionOrder` as the full order.
+
+## Decisions
+
+1. Two sections in the editable picker: "Selected" on top, then "All values".
+2. "All values" shows only the unselected options. A selected option appears
+   only in the "Selected" section.
+3. The numbered circle badges on the selected tags stay.
+4. A drag inside "Selected" reorders the values of this object.
+5. A drag inside "All values" reorders the global option order.
+6. A drag cannot cross a section header.
+
+## Design
+
+### 1. State model (`TagOrStatusValueViewModel.kt`)
+
+Add two header items to `RelationsListItem`:
+
+- `RelationsListItem.Section.Selected`
+- `RelationsListItem.Section.AllValues`
+
+`TagStatusViewState.Content.items` stays one flat list, with the headers
+interleaved. This keeps one `LazyColumn` and the existing reorder library.
+
+### 2. List construction (`initViewState`)
+
+For an editable relation, the list is:
+
+1. `Section.Selected` header
+2. The selected options, sorted by `number` (the position in the value list)
+3. `Section.AllValues` header
+4. The unselected options, sorted by `orderId`
+
+Rules:
+
+- The query filters both groups by name.
+- A header is hidden when its group is empty. Consequence: with no
+  selection, only the "All values" header shows. With a full selection,
+  only the "Selected" header shows.
+- The read-only path stays flat: only the selected values, no headers.
+- The `CreateItem` row stays at the bottom.
+
+### 3. Drag semantics
+
+The headers are not draggable. The Compose layer rejects a move that
+crosses a header, so an item stays inside its section.
+
+`OnMove(from, to)` in the ViewModel resolves the section of the dragged
+item from the flat list:
+
+- **Selected section**: build the new selected id order. Write it with the
+  existing optimistic `UpdateDetail` path, with revert on failure. The
+  number badges recompute from the new positions.
+- **All values section**: merge the new relative order of the displayed
+  unselected options back into the full option order. Call
+  `SetRelationOptionOrder` under the existing option-event lock. The merge
+  keeps the positions of the options that are not displayed (selected
+  options, and options hidden by the query). This also fixes the latent
+  filtered-drag bug.
+
+### 4. Status relations
+
+The status picker uses the same screen and gets the same sections. The
+"Selected" section holds at most one status. A drag there is a no-op.
+
+### 5. Strings
+
+Add "Selected" and "All values" to
+`localization/src/main/res/values/strings.xml`.
+
+### 6. Tests (`TagOrStatusValueViewModelTest.kt`)
+
+New cases:
+
+- Section composition: headers and group membership.
+- Selected-first order with correct `number` badges.
+- Value reorder through `UpdateDetail` after a drag in "Selected".
+- Option reorder through `SetRelationOptionOrder` after a drag in
+  "All values", with the merge of hidden options.
+- Sections under an active query.
+- Revert on `UpdateDetail` failure after a value reorder.
+
+The `OnMove` path has no tests today, so these are the first.
+
+## Out of scope
+
+- Cross-section drag (drag to select or deselect).
+- Changes to the read-only picker layout.
+- Changes to other multi-select pickers (`ObjectValueViewModel` already
+  sorts selected-first).

--- a/localization/src/main/res/values/strings.xml
+++ b/localization/src/main/res/values/strings.xml
@@ -1464,6 +1464,8 @@
     <string name="options_empty_not_editable">The property is empty</string>
     <string name="options_delete_title">Are you sure?</string>
     <string name="options_delete_description">The option will be permanently removed from your space</string>
+    <string name="tag_status_section_selected">Selected</string>
+    <string name="tag_status_section_all_values">All values</string>
 
     <string name="object_values_empty_description">Objects not found</string>
     <string name="object_values_empty_description_limited">Objects not found. This property only accepts: %1$s</string>

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
@@ -256,6 +256,7 @@ class TagOrStatusValueViewModel(
                     val currentState = viewState.value
                     if (currentState !is TagStatusViewState.Content) return@launch
                     val reorderedIds = currentState.items
+                        .filterIsInstance<RelationsListItem.Item>()
                         .toMutableList()
                         .apply { add(action.to, removeAt(action.from)) }
                         .map { it.optionId }
@@ -296,6 +297,7 @@ class TagOrStatusValueViewModel(
 
     private fun onActionClick(item: RelationsListItem) {
         when (item) {
+            is RelationsListItem.Section -> Unit
             is RelationsListItem.Item.Status -> {
                 if (item.isSelected) {
                     clearTagsOrStatus()
@@ -330,30 +332,18 @@ class TagOrStatusValueViewModel(
         options: List<ObjectWrapper.Option>,
         query: String
     ) {
-        val result = mutableListOf<RelationsListItem.Item>()
         val isTagRelation = relation.format == Relation.Format.TAG
 
-        when (relation.format) {
-            Relation.Format.STATUS -> {
-                result.addAll(
-                    mapStatusOptions(
-                        ids = ids,
-                        options = options
-                    )
-                )
-            }
-            Relation.Format.TAG -> {
-                result.addAll(
-                    mapTagOptions(
-                        ids = ids,
-                        options = options
-                    )
-                )
-            }
+        val mapped: List<RelationsListItem.Item> = when (relation.format) {
+            Relation.Format.STATUS -> mapStatusOptions(ids = ids, options = options)
+            Relation.Format.TAG -> mapTagOptions(ids = ids, options = options)
             else -> {
                 Timber.w("Relation format should be Tag or Status but was: ${relation.format}")
+                emptyList()
             }
         }
+
+        val items = buildSectionedList(mapped = mapped, ids = ids)
 
         // CreateItem is only shown for TAG relations when there's a search query
         val createItem = if (isTagRelation && query.isNotBlank() && isEditableRelation) {
@@ -362,7 +352,7 @@ class TagOrStatusValueViewModel(
             null
         }
 
-        viewState.value = if (result.isEmpty() && createItem == null) {
+        viewState.value = if (items.isEmpty() && createItem == null) {
             TagStatusViewState.Empty(
                 isRelationEditable = isEditableRelation,
                 title = relation.name.orEmpty(),
@@ -371,11 +361,36 @@ class TagOrStatusValueViewModel(
             TagStatusViewState.Content(
                 isRelationEditable = isEditableRelation,
                 title = relation.name.orEmpty(),
-                items = result,
+                items = items,
                 createItem = createItem
             )
         }.also {
             Timber.d("TagStatusViewModel initViewState, viewState: $it")
+        }
+    }
+
+    /**
+     * Editable relations get two sections: the selected options in value order,
+     * then the unselected options in the global option order. The read-only list
+     * stays flat. A header is omitted when its group is empty. The display sort
+     * is deliberately separate from the persisted option order (DROID-3916).
+     */
+    private fun buildSectionedList(
+        mapped: List<RelationsListItem.Item>,
+        ids: List<Id>
+    ): List<RelationsListItem> {
+        if (!isEditableRelation) return mapped
+        val selected = mapped.filter { it.isSelected }.sortedBy { ids.indexOf(it.optionId) }
+        val unselected = mapped.filter { !it.isSelected }
+        return buildList {
+            if (selected.isNotEmpty()) {
+                add(RelationsListItem.Section.Selected)
+                addAll(selected)
+            }
+            if (unselected.isNotEmpty()) {
+                add(RelationsListItem.Section.AllValues)
+                addAll(unselected)
+            }
         }
     }
 
@@ -611,7 +626,7 @@ sealed class TagStatusViewState {
 
     data class Content(
         val title: String,
-        val items: List<RelationsListItem.Item>,
+        val items: List<RelationsListItem>,
         val createItem: RelationsListItem.CreateItem.Tag? = null,
         val isRelationEditable: Boolean,
         val showItemMenu: RelationsListItem.Item? = null
@@ -633,6 +648,11 @@ sealed class TagStatusAction {
 enum class RelationContext { OBJECT, OBJECT_SET, DATA_VIEW }
 
 sealed class RelationsListItem {
+
+    sealed class Section : RelationsListItem() {
+        object Selected : Section()
+        object AllValues : Section()
+    }
 
     sealed class Item : RelationsListItem() {
 

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
@@ -342,6 +342,8 @@ class TagOrStatusValueViewModel(
 
     private fun moveOptionOrder(moved: List<RelationsListItem>) {
         viewModelScope.launch {
+            // Activate lock before sending to middleware to prevent race conditions
+            activateOptionEventLock()
             val fullOrder = storeOfRelationOptions
                 .getByRelationKey(viewModelParams.relationKey)
                 .sortedBy { it.orderId }
@@ -356,8 +358,6 @@ class TagOrStatusValueViewModel(
                 full = fullOrder,
                 displayedNewOrder = displayedOrder
             )
-            // Activate lock before sending to middleware to prevent race conditions
-            activateOptionEventLock()
             setRelationOptionOrder.async(
                 SetRelationOptionOrder.Params(
                     spaceId = viewModelParams.space,
@@ -387,7 +387,9 @@ class TagOrStatusValueViewModel(
     ): List<Id> {
         val displayed = displayedNewOrder.toSet()
         val iterator = displayedNewOrder.iterator()
-        return full.map { id -> if (displayed.contains(id)) iterator.next() else id }
+        return full.map { id ->
+            if (displayed.contains(id) && iterator.hasNext()) iterator.next() else id
+        }
     }
 
     private fun initViewState(

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
@@ -346,10 +346,12 @@ class TagOrStatusValueViewModel(
                 .getByRelationKey(viewModelParams.relationKey)
                 .sortedBy { it.orderId }
                 .map { it.id }
+            val fullOrderSet = fullOrder.toSet()
             val displayedOrder = moved
                 .filterIsInstance<RelationsListItem.Item>()
                 .filter { !it.isSelected }
                 .map { it.optionId }
+                .filter { it in fullOrderSet }
             val orderedIds = mergeReorderedSubset(
                 full = fullOrder,
                 displayedNewOrder = displayedOrder

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModel.kt
@@ -252,32 +252,7 @@ class TagOrStatusValueViewModel(
             }
             is TagStatusAction.OnMove -> {
                 Timber.d("OnMove from ${action.from} to ${action.to}")
-                viewModelScope.launch {
-                    val currentState = viewState.value
-                    if (currentState !is TagStatusViewState.Content) return@launch
-                    val reorderedIds = currentState.items
-                        .filterIsInstance<RelationsListItem.Item>()
-                        .toMutableList()
-                        .apply { add(action.to, removeAt(action.from)) }
-                        .map { it.optionId }
-                    // Activate lock before sending to middleware to prevent race conditions
-                    activateOptionEventLock()
-                    setRelationOptionOrder.async(
-                        SetRelationOptionOrder.Params(
-                            spaceId = viewModelParams.space,
-                            relationKey = RelationKey(viewModelParams.relationKey),
-                            orderedIds = reorderedIds
-                        )
-                    ).fold(
-                        onSuccess = {
-                            Timber.d("Option order saved successfully")
-                        },
-                        onFailure = { e ->
-                            Timber.e(e, "Failed to save option order")
-                            sendToast("Failed to save order")
-                        }
-                    )
-                }
+                onMove(from = action.from, to = action.to)
             }
         }
     }
@@ -324,6 +299,93 @@ class TagOrStatusValueViewModel(
                 )
             }
         }
+    }
+
+    /**
+     * [from] and [to] are indices into the flat, header-inclusive items list.
+     * The section of the dragged item decides the write path: a selected item
+     * permutes this object's value list, an unselected item permutes the
+     * global option order. A move whose target is a header or an item of the
+     * other section is ignored — the UI rejects those moves as well, this is
+     * the second gate.
+     */
+    private fun onMove(from: Int, to: Int) {
+        val currentState = viewState.value as? TagStatusViewState.Content ?: return
+        val items = currentState.items
+        val dragged = items.getOrNull(from) as? RelationsListItem.Item ?: return
+        val target = items.getOrNull(to) as? RelationsListItem.Item ?: return
+        if (dragged.isSelected != target.isSelected) return
+        val moved = items.toMutableList().apply { add(to, removeAt(from)) }
+        if (dragged.isSelected) {
+            moveSelectedValue(moved)
+        } else {
+            moveOptionOrder(moved)
+        }
+    }
+
+    private fun moveSelectedValue(moved: List<RelationsListItem>) {
+        val displayedOrder = moved
+            .filterIsInstance<RelationsListItem.Item>()
+            .filter { it.isSelected }
+            .map { it.optionId }
+        val newIds = mergeReorderedSubset(
+            full = selectedIds,
+            displayedNewOrder = displayedOrder
+        )
+        proceedWithOptimisticUpdate(
+            newIds = newIds,
+            persistedValue = newIds,
+            analyticsEvent = EventsDictionary.relationChangeValue,
+            dismissOnSuccess = false
+        )
+    }
+
+    private fun moveOptionOrder(moved: List<RelationsListItem>) {
+        viewModelScope.launch {
+            val fullOrder = storeOfRelationOptions
+                .getByRelationKey(viewModelParams.relationKey)
+                .sortedBy { it.orderId }
+                .map { it.id }
+            val displayedOrder = moved
+                .filterIsInstance<RelationsListItem.Item>()
+                .filter { !it.isSelected }
+                .map { it.optionId }
+            val orderedIds = mergeReorderedSubset(
+                full = fullOrder,
+                displayedNewOrder = displayedOrder
+            )
+            // Activate lock before sending to middleware to prevent race conditions
+            activateOptionEventLock()
+            setRelationOptionOrder.async(
+                SetRelationOptionOrder.Params(
+                    spaceId = viewModelParams.space,
+                    relationKey = RelationKey(viewModelParams.relationKey),
+                    orderedIds = orderedIds
+                )
+            ).fold(
+                onSuccess = {
+                    Timber.d("Option order saved successfully")
+                },
+                onFailure = { e ->
+                    Timber.e(e, "Failed to save option order")
+                    sendToast("Failed to save order")
+                }
+            )
+        }
+    }
+
+    /**
+     * Applies the new relative order of a displayed subset to the full list.
+     * An id that the list displays takes the next displayed slot in the new
+     * order. An id that the query or the section hides keeps its position.
+     */
+    private fun mergeReorderedSubset(
+        full: List<Id>,
+        displayedNewOrder: List<Id>
+    ): List<Id> {
+        val displayed = displayedNewOrder.toSet()
+        val iterator = displayedNewOrder.iterator()
+        return full.map { id -> if (displayed.contains(id)) iterator.next() else id }
     }
 
     private fun initViewState(

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt
@@ -134,7 +134,10 @@ class TagOrStatusValueViewModelTest {
         }
     }
 
-    private fun buildViewModel(initialIds: List<Id>): TagOrStatusValueViewModel {
+    private fun buildViewModel(
+        initialIds: List<Id>,
+        isLocked: Boolean = false
+    ): TagOrStatusValueViewModel {
         values = FakeObjectValueProvider(
             values = mapOf(objectId to mapOf(relationKey to initialIds))
         )
@@ -144,7 +147,7 @@ class TagOrStatusValueViewModelTest {
                 space = space,
                 objectId = objectId,
                 relationKey = relationKey,
-                isLocked = false,
+                isLocked = isLocked,
                 relationContext = RelationContext.DATA_VIEW
             ),
             values = values,
@@ -159,10 +162,18 @@ class TagOrStatusValueViewModelTest {
         )
     }
 
-    private fun TagOrStatusValueViewModel.items(): List<RelationsListItem.Item> =
+    private fun TagOrStatusValueViewModel.allItems(): List<RelationsListItem> =
         (viewState.value as TagStatusViewState.Content).items
 
-    private fun List<RelationsListItem.Item>.byId(id: Id) = first { it.optionId == id }
+    private fun TagOrStatusValueViewModel.items(): List<RelationsListItem.Item> =
+        allItems().filterIsInstance<RelationsListItem.Item>()
+
+    private fun List<RelationsListItem>.byId(id: Id) =
+        filterIsInstance<RelationsListItem.Item>().first { it.optionId == id }
+
+    /** Maps each row to its optionId, or to the Section object itself, for order assertions. */
+    private fun TagOrStatusValueViewModel.rows(): List<Any> =
+        allItems().map { if (it is RelationsListItem.Item) it.optionId else it }
 
     private fun params(value: Any?) = UpdateDetail.Params(target = objectId, key = relationKey, value = value)
 
@@ -404,5 +415,85 @@ class TagOrStatusValueViewModelTest {
         advanceUntilIdle()
 
         assertTrue(vm.items().byId(tagB).isSelected)
+    }
+
+    @Test
+    fun `editable tag list shows the selected section then the all values section`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1"), option(tagC, "2")))
+
+        val vm = buildViewModel(initialIds = listOf(tagC, tagB))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf<Any>(
+                RelationsListItem.Section.Selected,
+                tagC,
+                tagB,
+                RelationsListItem.Section.AllValues,
+                tagA
+            ),
+            vm.rows()
+        )
+        assertEquals(1, (vm.allItems().byId(tagC) as RelationsListItem.Item.Tag).number)
+        assertEquals(2, (vm.allItems().byId(tagB) as RelationsListItem.Item.Tag).number)
+    }
+
+    @Test
+    fun `no selection shows only the all values header`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+
+        val vm = buildViewModel(initialIds = emptyList())
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf<Any>(RelationsListItem.Section.AllValues, tagA, tagB),
+            vm.rows()
+        )
+    }
+
+    @Test
+    fun `full selection shows only the selected header`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+
+        val vm = buildViewModel(initialIds = listOf(tagA, tagB))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf<Any>(RelationsListItem.Section.Selected, tagA, tagB),
+            vm.rows()
+        )
+    }
+
+    @Test
+    fun `status list gets the same sections`() = runTest {
+        storeOfRelations.merge(listOf(statusRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+
+        val vm = buildViewModel(initialIds = listOf(tagB))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf<Any>(
+                RelationsListItem.Section.Selected,
+                tagB,
+                RelationsListItem.Section.AllValues,
+                tagA
+            ),
+            vm.rows()
+        )
+    }
+
+    @Test
+    fun `read-only list has no section headers`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+
+        val vm = buildViewModel(initialIds = listOf(tagB), isLocked = true)
+        advanceUntilIdle()
+
+        assertEquals(listOf<Any>(tagB), vm.rows())
     }
 }

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt
@@ -9,8 +9,10 @@ import com.anytypeio.anytype.core_models.Payload
 import com.anytypeio.anytype.core_models.RelationFormat
 import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.core_models.ThemeColor
+import com.anytypeio.anytype.core_models.primitives.RelationKey
 import com.anytypeio.anytype.core_models.primitives.SpaceId
 import com.anytypeio.anytype.domain.base.Either
+import com.anytypeio.anytype.domain.base.Resultat
 import com.anytypeio.anytype.domain.`object`.UpdateDetail
 import com.anytypeio.anytype.domain.objects.DefaultStoreOfRelationOptions
 import com.anytypeio.anytype.domain.objects.DefaultStoreOfRelations
@@ -39,6 +41,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -82,6 +85,12 @@ class TagOrStatusValueViewModelTest {
     private val tag2 = "tag2"
     private val tag3 = "tag3"
     private val tag7 = "tag7"
+
+    private val tagD = "opt-d"
+
+    // Named so that the query "7" matches both.
+    private val tag7a = "tag7a"
+    private val tag7b = "tag7b"
 
     @Before
     fun setup() {
@@ -133,6 +142,18 @@ class TagOrStatusValueViewModelTest {
             onBlocking { invoke(any()) } doReturn Either.Left(RuntimeException("boom"))
         }
     }
+
+    private fun stubOptionOrderSuccess() {
+        setRelationOptionOrder.stub {
+            onBlocking { async(any()) } doReturn Resultat.success(Unit)
+        }
+    }
+
+    private fun orderParams(orderedIds: List<Id>) = SetRelationOptionOrder.Params(
+        spaceId = space,
+        relationKey = RelationKey(relationKey),
+        orderedIds = orderedIds
+    )
 
     private fun buildViewModel(
         initialIds: List<Id>,
@@ -495,5 +516,137 @@ class TagOrStatusValueViewModelTest {
         advanceUntilIdle()
 
         assertEquals(listOf<Any>(tagB), vm.rows())
+    }
+
+    @Test
+    fun `drag inside the selected section reorders the object value`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1"), option(tagC, "2")))
+        stubPersistSuccess()
+
+        val vm = buildViewModel(initialIds = listOf(tagA, tagB, tagC))
+        advanceUntilIdle()
+
+        // Flat list: [Section.Selected, A, B, C]. Move A after C.
+        vm.onAction(TagStatusAction.OnMove(from = 1, to = 3))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf<Any>(RelationsListItem.Section.Selected, tagB, tagC, tagA),
+            vm.rows()
+        )
+        assertEquals(1, (vm.allItems().byId(tagB) as RelationsListItem.Item.Tag).number)
+        assertEquals(3, (vm.allItems().byId(tagA) as RelationsListItem.Item.Tag).number)
+        verifyBlocking(setObjectDetails) { invoke(params(listOf(tagB, tagC, tagA))) }
+        verifyNoInteractions(setRelationOptionOrder)
+    }
+
+    @Test
+    fun `drag inside the selected section keeps the selections hidden by the query`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(
+            listOf(option(tag2, "0"), option(tag7a, "1"), option(tag7b, "2"))
+        )
+        stubPersistSuccess()
+
+        val vm = buildViewModel(initialIds = listOf(tag2, tag7a, tag7b))
+        advanceUntilIdle()
+
+        vm.onQueryChanged("7")
+        advanceUntilIdle()
+
+        // Flat list under the query: [Section.Selected, tag7a, tag7b]. Swap them.
+        vm.onAction(TagStatusAction.OnMove(from = 1, to = 2))
+        advanceUntilIdle()
+
+        // The hidden selection tag2 keeps its first position.
+        verifyBlocking(setObjectDetails) { invoke(params(listOf(tag2, tag7b, tag7a))) }
+    }
+
+    @Test
+    fun `a failed value write after a selected drag reverts the order and toasts`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+        stubPersistFailure()
+
+        val vm = buildViewModel(initialIds = listOf(tagA, tagB))
+        advanceUntilIdle()
+        val snapshot = vm.viewState.value
+
+        vm.toasts.test {
+            vm.onAction(TagStatusAction.OnMove(from = 1, to = 2))
+            advanceUntilIdle()
+            val messages = cancelAndConsumeRemainingEvents()
+                .filterIsInstance<Event.Item<String>>()
+                .map { it.value }
+            assertTrue(messages.contains("Error while updating value"))
+        }
+
+        assertEquals(snapshot, vm.viewState.value)
+    }
+
+    @Test
+    fun `drag inside all values saves the merged global option order`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(
+            listOf(option(tagA, "0"), option(tagB, "1"), option(tagC, "2"), option(tagD, "3"))
+        )
+        stubOptionOrderSuccess()
+
+        val vm = buildViewModel(initialIds = listOf(tagB))
+        advanceUntilIdle()
+
+        // Flat list: [Section.Selected, B, Section.AllValues, A, C, D]. Move D before A.
+        vm.onAction(TagStatusAction.OnMove(from = 5, to = 3))
+        advanceUntilIdle()
+
+        // Full order was [A, B, C, D]; B is hidden from the section and keeps its slot.
+        verifyBlocking(setRelationOptionOrder) {
+            async(orderParams(listOf(tagD, tagB, tagA, tagC)))
+        }
+        verifyNoInteractions(setObjectDetails)
+    }
+
+    @Test
+    fun `drag inside all values under a query keeps the hidden options in place`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(
+            listOf(option(tag7a, "0"), option(tag2, "1"), option(tag7b, "2"))
+        )
+        stubOptionOrderSuccess()
+
+        val vm = buildViewModel(initialIds = emptyList())
+        advanceUntilIdle()
+
+        vm.onQueryChanged("7")
+        advanceUntilIdle()
+
+        // Flat list under the query: [Section.AllValues, tag7a, tag7b]. Swap them.
+        vm.onAction(TagStatusAction.OnMove(from = 1, to = 2))
+        advanceUntilIdle()
+
+        // Full order was [tag7a, tag2, tag7b]; hidden tag2 keeps its slot.
+        verifyBlocking(setRelationOptionOrder) {
+            async(orderParams(listOf(tag7b, tag2, tag7a)))
+        }
+    }
+
+    @Test
+    fun `drag across sections is ignored`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))
+
+        val vm = buildViewModel(initialIds = listOf(tagA))
+        advanceUntilIdle()
+
+        // Flat list: [Section.Selected, A, Section.AllValues, B].
+        // from = selected item, to = unselected item.
+        vm.onAction(TagStatusAction.OnMove(from = 1, to = 3))
+        // from = item, to = section header.
+        vm.onAction(TagStatusAction.OnMove(from = 3, to = 2))
+        advanceUntilIdle()
+
+        verifyNoInteractions(setObjectDetails)
+        verifyNoInteractions(setRelationOptionOrder)
     }
 }

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/relations/value/tagstatus/TagOrStatusValueViewModelTest.kt
@@ -632,6 +632,34 @@ class TagOrStatusValueViewModelTest {
     }
 
     @Test
+    fun `an option deleted from the store after the drag is dropped from the persisted order`() = runTest {
+        storeOfRelations.merge(listOf(tagRelation()))
+        storeOfRelationOptions.merge(
+            listOf(option(tagA, "0"), option(tagB, "1"), option(tagC, "2"), option(tagD, "3"))
+        )
+        stubOptionOrderSuccess()
+
+        val vm = buildViewModel(initialIds = listOf(tagB))
+        advanceUntilIdle()
+
+        // Flat list: [Section.Selected, B, Section.AllValues, A, C, D]. Move C before A.
+        // onAction captures the displayed order [C, A, D] synchronously; the store fetch
+        // inside moveOptionOrder only runs once advanceUntilIdle resumes the coroutine.
+        vm.onAction(TagStatusAction.OnMove(from = 4, to = 3))
+
+        // Simulate a concurrent deletion (another device or a fast second drag) that lands
+        // before the suspend fetch resolves. This id was part of the captured displayed order.
+        storeOfRelationOptions.remove(tagC)
+        advanceUntilIdle()
+
+        // Full order at fetch time is [A, B, D]; the dropped tagC is neither written into the
+        // order nor does it displace tagD's slot. tagA and tagD swap as the drag intended.
+        verifyBlocking(setRelationOptionOrder) {
+            async(orderParams(listOf(tagA, tagB, tagD)))
+        }
+    }
+
+    @Test
     fun `drag across sections is ignored`() = runTest {
         storeOfRelations.merge(listOf(tagRelation()))
         storeOfRelationOptions.merge(listOf(option(tagA, "0"), option(tagB, "1")))


### PR DESCRIPTION
## Problem

Since 0.44.8, the tag/status value picker shows one flat list in the global option order. The selected options stay in place, so the user must scroll a long list to find them. Linear: [DROID-4571](https://linear.app/anytype/issue/DROID-4571/properties-fix-selected-tag-options-no-longer-move-to-the-top-of-the).

## Solution

The picker now matches the desktop client, with two sections:

- **Selected** on top: the selected options in value order, with the numbered badges.
- **All values** below: the unselected options in the global option order.

Drag-to-reorder works in each section:

- A drag inside **Selected** permutes the value list of this object. The write goes through the existing optimistic `UpdateDetail` path, with revert on failure.
- A drag inside **All values** merges the displayed order back into the full option order. The write goes through `SetRelationOptionOrder`, as before.
- A drag cannot cross a section header. The Compose layer rejects the move, and the ViewModel rejects it again.

The shared merge helper keeps hidden ids in place. This also fixes a latent bug: a drag under an active search query sent only the filtered ids as the full option order.

The read-only picker keeps the flat list without headers. The status picker gets the same sections.

## Testing

- `TagOrStatusValueViewModelTest`: 22 tests pass (12 new). The new tests cover section composition, both drag paths, query filtering, the deleted-option race, and the failure revert.
- `:presentation:testDebugUnitTest`: 1340 tests pass.
- `:core-ui:compileDebugKotlin`, `:app:compileDebugSources`, and lint on the touched modules pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)