### PR TITLE
DROID-4566 Editor | Fix | Open the mention menu when the IME commits @ inside a multi-char run

### DIFF
--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/tools/MentionHelper.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/tools/MentionHelper.kt
@@ -8,22 +8,31 @@ import timber.log.Timber
 
 object MentionHelper {
 
-    fun isMentionSuggestTriggered(
+    /**
+     * Position of the mention char that should open the suggester,
+     * or [NO_MENTION_POSITION] when this text change is not a mention trigger.
+     *
+     * Only the last char of the freshly inserted run is inspected: soft keyboards
+     * re-commit the whole composing word on every keystroke, so the mention char
+     * regularly arrives at the tail of a multi-char replacement instead of on its own.
+     * Matching a single-char insert only ([count] == 1) made the suggester miss those.
+     *
+     * The suggester opens at the start of a line or after whitespace only, so that
+     * "word@" — an e-mail address, a handle — stays plain text.
+     */
+    fun getMentionSuggestPosition(
         s: CharSequence,
         start: Int,
         count: Int,
         mentionChar: Char = MENTION_CHAR
-    ): Boolean {
-        if (count == 1 && start < s.length && s[start] == mentionChar) {
-            if (start == 0) {
-                return true
-            }
-            val before = start - 1
-            if (before in 0..s.length && s[before] == ' ') {
-                return true
-            }
+    ): Int {
+        if (count <= 0) return NO_MENTION_POSITION
+        val position = start + count - 1
+        if (position !in s.indices || s[position] != mentionChar) {
+            return NO_MENTION_POSITION
         }
-        return false
+        val before = position - 1
+        return if (before < 0 || s[before].isWhitespace()) position else NO_MENTION_POSITION
     }
 
     fun isMentionDeleted(text: CharSequence, start: Int, mentionPosition: Int, before: Int, count: Int): Boolean {

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/tools/TextWatchers.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/tools/TextWatchers.kt
@@ -2,8 +2,8 @@ package com.anytypeio.anytype.core_ui.tools
 
 import android.text.Editable
 import com.anytypeio.anytype.core_ui.BuildConfig
+import com.anytypeio.anytype.core_ui.tools.MentionHelper.getMentionSuggestPosition
 import com.anytypeio.anytype.core_ui.tools.MentionHelper.isMentionDeleted
-import com.anytypeio.anytype.core_ui.tools.MentionHelper.isMentionSuggestTriggered
 import com.anytypeio.anytype.presentation.editor.editor.mention.MentionEvent
 import timber.log.Timber
 
@@ -94,10 +94,18 @@ class MentionTextWatcher(
      * Send all text added after mention start position [mentionCharPosition]
      */
     private fun interceptMentionTriggered(text: CharSequence, start: Int, before: Int, count: Int) {
-        if (isMentionSuggestTriggered(text, start, count)) {
-            mentionCharPosition = start
-            mention = ""
+        val triggered = getMentionSuggestPosition(text, start, count)
+        if (triggered != NO_MENTION_POSITION) {
+            mentionCharPosition = triggered
+            // The inserted run can carry more than the mention char itself, so seed the
+            // query with everything the IME committed from the mention char onwards.
+            mention = text.substring(
+                startIndex = triggered,
+                endIndex = (start + count).coerceAtMost(text.length)
+            )
             proceedWithMentionEvent(MentionTextWatcherState.Start(mentionCharPosition))
+            proceedWithMentionEvent(MentionTextWatcherState.Text(mention))
+            return
         }
 
         if (isMentionCharVisible()) {

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/tools/TextWatchers.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/tools/TextWatchers.kt
@@ -97,12 +97,9 @@ class MentionTextWatcher(
         val triggered = getMentionSuggestPosition(text, start, count)
         if (triggered != NO_MENTION_POSITION) {
             mentionCharPosition = triggered
-            // The inserted run can carry more than the mention char itself, so seed the
-            // query with everything the IME committed from the mention char onwards.
-            mention = text.substring(
-                startIndex = triggered,
-                endIndex = (start + count).coerceAtMost(text.length)
-            )
+            // The trigger only matches when the inserted run ends with the mention char,
+            // so the query starts out as the mention char alone.
+            mention = MENTION_CHAR.toString()
             proceedWithMentionEvent(MentionTextWatcherState.Start(mentionCharPosition))
             proceedWithMentionEvent(MentionTextWatcherState.Text(mention))
             return

--- a/core-ui/src/test/java/com/anytypeio/anytype/core_ui/tools/MentionHelperTest.kt
+++ b/core-ui/src/test/java/com/anytypeio/anytype/core_ui/tools/MentionHelperTest.kt
@@ -334,7 +334,7 @@ class MentionHelperTest {
     }
 
     @Test
-    fun `should isMentionSuggestTriggered be false 1`() {
+    fun `should not trigger mention suggest when the inserted char is not the mention char`() {
 
         val  s = "text $"
         val start = 5
@@ -346,7 +346,7 @@ class MentionHelperTest {
     }
 
     @Test
-    fun `should isMentionSuggestTriggered be false 2`() {
+    fun `should not trigger mention suggest when the run ends with a doubled mention char`() {
 
         val  s = "text $@@"
         val start = 5
@@ -358,7 +358,7 @@ class MentionHelperTest {
     }
 
     @Test
-    fun `should isMentionSuggestTriggered be false 3`() {
+    fun `should not trigger mention suggest when a single mention char follows a word`() {
 
         val  s = "text@"
         val start = 4
@@ -370,7 +370,7 @@ class MentionHelperTest {
     }
 
     @Test
-    fun `should isMentionSuggestTriggered be false 4`() {
+    fun `should not trigger mention suggest when the run ends with a query char`() {
 
         val  s = "text @t"
         val start = 5
@@ -382,7 +382,7 @@ class MentionHelperTest {
     }
 
     @Test
-    fun `should isMentionSuggestTriggered be true 1`() {
+    fun `should trigger mention suggest when a single mention char follows a space`() {
 
         val  s = "text @"
         val start = 5

--- a/core-ui/src/test/java/com/anytypeio/anytype/core_ui/tools/MentionHelperTest.kt
+++ b/core-ui/src/test/java/com/anytypeio/anytype/core_ui/tools/MentionHelperTest.kt
@@ -297,7 +297,7 @@ class MentionHelperTest {
 
         textConditions.forEach { condition ->
 
-            val result = MentionHelper.isMentionSuggestTriggered(
+            val result = isTriggered(
                 s = condition.s,
                 start = condition.start,
                 count = condition.count
@@ -318,7 +318,7 @@ class MentionHelperTest {
 
         textConditions.forEach { condition ->
 
-            val result = MentionHelper.isMentionSuggestTriggered(
+            val result = isTriggered(
                 s = condition.s,
                 start = condition.start,
                 count = condition.count
@@ -340,7 +340,7 @@ class MentionHelperTest {
         val start = 5
         val count = 1
 
-        val result = MentionHelper.isMentionSuggestTriggered(s = s, start = start, count = count)
+        val result = isTriggered(s = s, start = start, count = count)
 
         assertFalse(result)
     }
@@ -352,7 +352,7 @@ class MentionHelperTest {
         val start = 5
         val count = 3
 
-        val result = MentionHelper.isMentionSuggestTriggered(s = s, start = start, count = count)
+        val result = isTriggered(s = s, start = start, count = count)
 
         assertFalse(result)
     }
@@ -364,7 +364,7 @@ class MentionHelperTest {
         val start = 4
         val count = 1
 
-        val result = MentionHelper.isMentionSuggestTriggered(s = s, start = start, count = count)
+        val result = isTriggered(s = s, start = start, count = count)
 
         assertFalse(result)
     }
@@ -376,7 +376,7 @@ class MentionHelperTest {
         val start = 5
         val count = 2
 
-        val result = MentionHelper.isMentionSuggestTriggered(s = s, start = start, count = count)
+        val result = isTriggered(s = s, start = start, count = count)
 
         assertFalse(result)
     }
@@ -388,10 +388,67 @@ class MentionHelperTest {
         val start = 5
         val count = 1
 
-        val result = MentionHelper.isMentionSuggestTriggered(s = s, start = start, count = count)
+        val result = isTriggered(s = s, start = start, count = count)
 
         assertTrue(result)
     }
+
+    @Test
+    fun `should trigger when ime commits a multi char run ending with mention char`() {
+
+        // Gboard replaces the whole composing region on every keystroke, so the "@"
+        // arrives as the last char of a multi-char replacement, not as a lone insert.
+        val s = "text @"
+        val start = 0
+        val count = 6
+
+        val result = isTriggered(s = s, start = start, count = count)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `should trigger when mention char opens a new line inside the block`() {
+
+        val s = "text\n@"
+        val start = 5
+        val count = 1
+
+        val result = isTriggered(s = s, start = start, count = count)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `should trigger when mention char follows a non breaking space`() {
+
+        val s = "text @"
+        val start = 5
+        val count = 1
+
+        val result = isTriggered(s = s, start = start, count = count)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `should not trigger when a multi char run ends with mention char glued to a word`() {
+
+        val s = "mail@"
+        val start = 0
+        val count = 5
+
+        val result = isTriggered(s = s, start = start, count = count)
+
+        assertFalse(result)
+    }
+
+    private fun isTriggered(s: CharSequence, start: Int, count: Int): Boolean =
+        MentionHelper.getMentionSuggestPosition(
+            s = s,
+            start = start,
+            count = count
+        ) != MentionTextWatcher.NO_MENTION_POSITION
 
     data class TextChanged(
         val isEvent: Boolean,

--- a/core-ui/src/test/java/com/anytypeio/anytype/core_ui/tools/MentionTextWatcherTest.kt
+++ b/core-ui/src/test/java/com/anytypeio/anytype/core_ui/tools/MentionTextWatcherTest.kt
@@ -481,6 +481,47 @@ class MentionTextWatcherTest {
         )
     }
 
+    @Test
+    fun `should fire start when ime commits a run ending with mention char`() {
+
+        val events: MutableList<MentionTextWatcher.MentionTextWatcherState> = mutableListOf()
+
+        val watcher = buildMentionWatcher { state -> events.add(state) }
+
+        // The IME re-commits the whole composing word plus the new char in one shot.
+        watcher.onTextChanged("Hello @", 0, 6, 7)
+
+        assertEquals(
+            expected = listOf(
+                MentionTextWatcher.MentionTextWatcherState.Start(start = 6),
+                MentionTextWatcher.MentionTextWatcherState.Text(text = "@")
+            ),
+            actual = events
+        )
+    }
+
+    @Test
+    fun `should keep filtering after the mention char arrived inside a multi char run`() {
+
+        val events: MutableList<MentionTextWatcher.MentionTextWatcherState> = mutableListOf()
+
+        val watcher = buildMentionWatcher { state -> events.add(state) }
+
+        watcher.onTextChanged("Hello @", 0, 6, 7)
+        watcher.onTextChanged("Hello @a", 7, 0, 1)
+        watcher.onTextChanged("Hello @ab", 8, 0, 1)
+
+        assertEquals(
+            expected = listOf(
+                MentionTextWatcher.MentionTextWatcherState.Start(start = 6),
+                MentionTextWatcher.MentionTextWatcherState.Text(text = "@"),
+                MentionTextWatcher.MentionTextWatcherState.Text(text = "@a"),
+                MentionTextWatcher.MentionTextWatcherState.Text(text = "@ab")
+            ),
+            actual = events
+        )
+    }
+
     private fun buildMentionWatcher(
         onMentionEvent: (MentionTextWatcher.MentionTextWatcherState) -> Unit
     ): MentionTextWatcher {


### PR DESCRIPTION
Fixes [DROID-4566](https://linear.app/anytype/issue/DROID-4566/inline-object-link-is-broken) — "the `@` to link objects inline does not seem to be working anymore".

## What the attached video shows

Stepping through the recording frame by frame, in the **same block on the same keyboard**:

| t | Typed | Result |
|---|---|---|
| 00:01 | `/` in an empty block | slash menu opens ✅ |
| 00:11, 00:15 | `@` in an empty block | nothing ❌ |
| 00:16 | `@5/` | slash menu opens — even though `/` follows a digit |
| 00:19 | `@test` | nothing ❌ |

Both watchers are registered side by side in `TextBlockHolder.setupViewHolder` and receive identical `onTextChanged` callbacks, so the difference had to be in the two predicates.

## Root cause

```kotlin
// SlashHelper — last char of the inserted run, any run length
count > 0 && text[start + count - 1] == '/'

// MentionHelper — first char, and only single-char inserts
count == 1 && s[start] == '@' && (start == 0 || s[start - 1] == ' ')
```

`onTextChanged(s, start, before, count)` describes a **range replacement**, not a keystroke. Soft keyboards re-commit the whole composing region on every key — this repo's own `MentionTextWatcherTest` already models it (`onTextChanged("te", 0, 1, 2)`) — so the mention char regularly arrives as the *last char of a multi-char run* and `count == 1` never matched.

A second bug hid behind that guard: the watcher stored `mentionCharPosition = start`, which only equals the `@` index when the run is one char long. That anchor is what `EditorViewModel.mentionFrom` uses to replace the trigger text on insert.

## Changes

`MentionHelper` now resolves the trigger the way slash does and returns the anchor index:

```kotlin
fun getMentionSuggestPosition(s: CharSequence, start: Int, count: Int, mentionChar: Char = MENTION_CHAR): Int {
    if (count <= 0) return NO_MENTION_POSITION
    val position = start + count - 1
    if (position !in s.indices || s[position] != mentionChar) return NO_MENTION_POSITION
    val before = position - 1
    return if (before < 0 || s[before].isWhitespace()) position else NO_MENTION_POSITION
}
```

- **Start of line → show.** `before < 0` covers block offset 0; `isWhitespace()` adds `\n`, so `@` after a line break inside a block now works too (previously only offset 0 did).
- **Space + `@` → show.** `isWhitespace()` also accepts tab and U+00A0 — the reporter is on a French keyboard, the layout most likely to emit a non-breaking space.
- **`word@` → don't show.** Unchanged, and now covered by a test including the multi-char case.

`MentionTextWatcher` anchors on the returned index rather than on `start` — the two only coincide when the run is one char long. `isMentionSuggestTriggered` is dropped — unused in production after this.

## Verification

**Unit** — 5 new tests written first and watched fail, then pass. Full `:core-ui` and `:presentation` suites green; all 25 pre-existing trigger cases in `ConditionsWithBuffer`/`ConditionsWithoutBuffer` still hold.

**Device** — Nothing A063, Gboard, debug APK built from this branch (install time verified, not the version string):

| Scenario | `MentionTextWatcher` log |
|---|---|
| `@` in empty block | `Start(start=0)` + menu renders with objects |
| `Naik@` | *silent* — correctly no trigger |
| `Naik @` | `Start(start=5)` + menu renders |
| `@` then `a` | `Text(@a)`, no spurious `Stop` |

Note: `adb shell input text '@'` bypasses the IME and always yields `count == 1`, so it passes even against the old code — the device checks above tap the on-screen key to exercise the real `InputConnection`.

## Caveats / follow-ups

- **The exact 0.48.9 failure did not reproduce on my hardware** — `@` at start-of-block already worked on my Gboard before the fix, and the trigger code is byte-identical between 0.48.9 and `main`, so this isn't a bisectable regression. This fixes the concrete defect the video points at and is the only mechanism I found that produces exactly that symptom. If the reporter still sees it, the next step is a logcat from their device.
- `onStartMentionWidgetClicked()` has **no callers** — the `@` button appears to have been dropped from the editor toolbar in the redesign, making typing the only way to reach the suggester. Worth a separate ticket if the button was meant to stay.
- The slash watcher opens on `word/` (visible at 00:16 as `@5/`), which contradicts the rule applied to `@`. Left alone as out of scope, but the two should probably agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
