### PR TITLE
DROID-4563 UI | Fix | Stop clipping object types and space names at large system font sizes

### DIFF
--- a/core-ui/src/main/res/layout/relation_value_list.xml
+++ b/core-ui/src/main/res/layout/relation_value_list.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
-    android:layout_height="18dp"
+    android:layout_height="wrap_content"
+    android:minHeight="18dp"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="horizontal"

--- a/core-ui/src/test/java/com/anytypeio/anytype/core_ui/widgets/RelationValueListWidgetFontScaleTest.kt
+++ b/core-ui/src/test/java/com/anytypeio/anytype/core_ui/widgets/RelationValueListWidgetFontScaleTest.kt
@@ -1,0 +1,111 @@
+package com.anytypeio.anytype.core_ui.widgets
+
+import android.content.Context
+import android.content.res.Configuration
+import android.os.Build
+import android.util.TypedValue
+import android.view.View
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import com.anytypeio.anytype.core_ui.R
+import com.anytypeio.anytype.presentation.relations.ObjectRelationView
+import kotlin.test.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Featured relations (object type, tags, ...) used to live in a row whose height was
+ * hardcoded to 18dp, while the text inside is sized in sp. At the system font scales
+ * above 1.0 the text no longer fitted and was drawn clipped (DROID-4563).
+ *
+ * [GraphicsMode.Mode.NATIVE] is required: with the legacy shadow graphics Robolectric
+ * reports font metrics that do not depend on the text size, so the clipping is invisible.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class RelationValueListWidgetFontScaleTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun before() {
+        context.setTheme(R.style.Theme_MaterialComponents)
+    }
+
+    private class Measurement(val rowHeight: Int, val textHeight: Int, val textNeeds: Int)
+
+    private fun measureAtFontScale(scale: Float): Measurement {
+        val configuration = Configuration(context.resources.configuration).apply {
+            fontScale = scale
+        }
+        val widget = RelationValueListWidget(context.createConfigurationContext(configuration))
+        widget.setRelation(
+            relation = ObjectRelationView.ObjectType.Base(
+                id = "relation-id",
+                key = "type",
+                name = "Page",
+                featured = true,
+                system = false,
+                readOnly = false,
+                type = "type-id"
+            )
+        )
+        widget.measure(
+            View.MeasureSpec.makeMeasureSpec(1000, View.MeasureSpec.AT_MOST),
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+        )
+        val text = widget.findViewById<TextView>(R.id.text1)
+        return Measurement(
+            rowHeight = widget.measuredHeight,
+            textHeight = text.measuredHeight,
+            textNeeds = requireNotNull(text.layout) { "Text must be laid out" }.height
+        )
+    }
+
+    @Test
+    fun `object type is not clipped at any system font scale`() {
+        listOf(1f, 1.15f, 1.3f, 1.5f, 2f).forEach { scale ->
+            val measurement = measureAtFontScale(scale)
+            assertTrue(
+                actual = measurement.textHeight >= measurement.textNeeds,
+                message = "At font scale $scale the text view is ${measurement.textHeight}px " +
+                    "tall but needs ${measurement.textNeeds}px, so the text is clipped"
+            )
+            assertTrue(
+                actual = measurement.rowHeight >= measurement.textNeeds,
+                message = "At font scale $scale the relation row is ${measurement.rowHeight}px " +
+                    "tall but its text needs ${measurement.textNeeds}px"
+            )
+        }
+    }
+
+    @Test
+    fun `relation row grows with the system font scale`() {
+        val default = measureAtFontScale(1f).rowHeight
+        val largest = measureAtFontScale(2f).rowHeight
+        assertTrue(
+            actual = largest > default,
+            message = "Row must grow with the font scale but was ${default}px at 1.0 " +
+                "and ${largest}px at 2.0"
+        )
+    }
+
+    @Test
+    fun `relation row keeps its designed height at the default font scale`() {
+        val expected = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            18f,
+            context.resources.displayMetrics
+        ).toInt()
+        val actual = measureAtFontScale(1f).rowHeight
+        assertTrue(
+            actual = actual == expected,
+            message = "Row must still be ${expected}px at the default font scale but was ${actual}px"
+        )
+    }
+}

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/ui/VaultChatCard.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/ui/VaultChatCard.kt
@@ -107,7 +107,9 @@ fun vaultCardBackgroundModifier(
     fixedHeight: Boolean
 ): Modifier {
     val sizeModifier = if (fixedHeight) {
-        modifier.fillMaxWidth().height(96.dp)
+        // Min height instead of a fixed one: at large system font scales the card content
+        // is taller than 96dp and would otherwise be clipped (DROID-4563).
+        modifier.fillMaxWidth().heightIn(min = 96.dp)
     } else {
         modifier.fillMaxWidth().heightIn(min = 56.dp)
     }

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/ui/VaultDataSpaceChatCard.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/ui/VaultDataSpaceChatCard.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Text
@@ -192,7 +193,7 @@ private fun ContentDataSpaceChat(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(24.dp),
+                .heightIn(min = 24.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             TitleRow(

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/ui/VaultOneToOneSpaceCard.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/ui/VaultOneToOneSpaceCard.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
@@ -194,7 +195,7 @@ private fun ContentOneToOne(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(24.dp),
+                .heightIn(min = 24.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             TitleRow(


### PR DESCRIPTION
## Problem

At large system font sizes text is cut off in two places, reported with a screenshot in [DROID-4563](https://linear.app/anytype/issue/DROID-4563/biggest-font-size-breaks-ui): the object type / featured-properties row under an object title, and space names in the vault.

Both are the same mistake — a container whose height is hardcoded in `dp` around text that is sized in `sp`:

- `relation_value_list.xml` pinned the row to `18dp`, while `TextView.ContentStyle.Relations.2` declares `13sp` text with an `18sp` line height. The two match exactly at font scale 1.0, so the design sat precisely at its breaking point and clipped at every scale above it.
- In the vault, `vaultCardBackgroundModifier` pinned the card to `96dp` and the space-name row to `24dp`. Compose `Text` clips rather than overflows once `hasVisualOverflow` is set, so the name is truncated mid-glyph.

Measured in the featured-properties row before the fix (px at density 1.0):

| fontScale | row height | text needs | clipped |
|---|---|---|---|
| 1.0 | 18 | 16 | — |
| 1.3 | 18 | 20 | 2px |
| 2.0 | 18 | 31 | 13px (42%) |

## Solution

Fixed heights become minimums: `wrap_content` + `android:minHeight="18dp"` in the layout, `heightIn(min = …)` instead of `height(…)` in the vault cards.

`minHeight` matters — the text measures 16px at scale 1.0, so a bare `wrap_content` would have quietly tightened every featured-properties row by 2dp. This way the appearance at the default font scale is unchanged and only the overflow case moves.

## Testing

- New `RelationValueListWidgetFontScaleTest` (core-ui, Robolectric) asserts the row is never shorter than the text it must draw, at scales 1.0 / 1.15 / 1.3 / 1.5 / 2.0; that it grows with the font scale; and that it still measures exactly 18dp at the default scale. Confirmed to fail on the old layout and pass on the new one. It needs `@GraphicsMode(GraphicsMode.Mode.NATIVE)` — with the legacy shadow graphics Robolectric reports font metrics that ignore the text size, so the clipping is invisible.
- `:core-ui:testDebugUnitTest` and `:feature-vault:testDebugUnitTest` pass in full.
- The vault change has no automated test: this repo has no Compose UI-test infrastructure in any module, and standing it up for a three-line modifier change looked disproportionate. Verified by reasoning about the measure pass instead.

## Not included

Adjacent instances of the same antipattern, left alone as out of scope for this ticket: `ds_button_icon.xml` (28dp pill around `Captions.1.Medium`, clips near 1.8×) and the editor / set top-toolbar title pills (44dp, headroom to roughly 2.5×). A scan of every layout in the repo found no other fixed-height container under 44dp wrapping text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)