### PR TITLE
DROID-4588 Quick Capture | New | Delete a fully empty draft when the user leaves it

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/di/feature/quickcapture/QuickCaptureDI.kt
+++ b/app/src/main/java/com/anytypeio/anytype/di/feature/quickcapture/QuickCaptureDI.kt
@@ -20,6 +20,9 @@ import com.anytypeio.anytype.domain.workspace.SpaceManager
 import com.anytypeio.anytype.presentation.analytics.AnalyticSpaceHelperDelegate
 import com.anytypeio.anytype.ui.quickcapture.QuickCaptureFragment
 import dagger.Component
+import javax.inject.Named
+import kotlinx.coroutines.CoroutineScope
+import com.anytypeio.anytype.di.main.ConfigModule
 
 @Component(
     dependencies = [QuickCaptureDependencies::class]
@@ -51,5 +54,7 @@ interface QuickCaptureDependencies : ComponentDependencies {
     fun typeSuggestionEngine(): TypeSuggestionEngine
     fun participantSubscriptionContainer(): ParticipantSubscriptionContainer
     fun authRepository(): AuthRepository
+    @Named(ConfigModule.DEFAULT_APP_COROUTINE_SCOPE)
+    fun applicationCoroutineScope(): CoroutineScope
     fun logger(): Logger
 }

--- a/app/src/main/java/com/anytypeio/anytype/ui/quickcapture/QuickCaptureFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/quickcapture/QuickCaptureFragment.kt
@@ -167,6 +167,10 @@ class QuickCaptureFragment : BaseBottomSheetFragment<FragmentQuickCaptureBinding
     private fun hasBinding(): Boolean = view != null
 
     override fun onDestroyView() {
+        // Before super: the child editor is still attached here, and onCleared (where the
+        // empty-draft cleanup decides) runs after this. Config changes reach this too, but
+        // recording a boolean is harmless — onCleared does not fire for those.
+        vm.onEditorDetached(hasEdits = editor()?.hasEdits() == true)
         binding.root.viewTreeObserver.removeOnGlobalLayoutListener(imeLayoutListener)
         sheet?.let { view -> BottomSheetBehavior.from(view).removeBottomSheetCallback(dragCallback) }
         super.onDestroyView()

--- a/domain/src/main/java/com/anytypeio/anytype/domain/quickcapture/DeleteQuickCaptureDraftIfEmpty.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/quickcapture/DeleteQuickCaptureDraftIfEmpty.kt
@@ -1,0 +1,96 @@
+package com.anytypeio.anytype.domain.quickcapture
+
+import com.anytypeio.anytype.core_models.Block
+import com.anytypeio.anytype.core_models.Id
+import com.anytypeio.anytype.core_models.Relations
+import com.anytypeio.anytype.core_models.primitives.SpaceId
+import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
+import com.anytypeio.anytype.domain.base.ResultInteractor
+import com.anytypeio.anytype.domain.block.repo.BlockRepository
+import com.anytypeio.anytype.domain.config.UserSettingsRepository
+import com.anytypeio.anytype.domain.debugging.Logger
+import javax.inject.Inject
+
+/**
+ * Deletes a quick-capture draft the user walked away from, but only when it holds nothing.
+ *
+ * Drafts are created with [com.anytypeio.anytype.core_models.InternalFlags.ShouldEmptyDelete],
+ * which is heart's own "bin this on close if it is still empty" mechanism — but that flag is
+ * one-way and any details write clears it, and quick capture writes details at creation
+ * (`isHidden`, `isDraft`). So abandoned empties never actually went away, and each one left a
+ * pointer and a picker dot behind it. This does that cleanup explicitly.
+ *
+ * Emptiness is decided from the STORE, not from the editor, for two reasons: the editor is
+ * usually gone by the time the sheet closes, and the store is what the next device will see.
+ *
+ * The delete is `Object.ListDelete` — permanent, no bin. That is only defensible because the
+ * object holds nothing, so every uncertainty resolves to "keep it":
+ *  - the object cannot be read, or the read fails      -> keep
+ *  - it is no longer a draft (published, archived)     -> keep
+ *  - it carries a title, any text, or any attachment   -> keep
+ *  - an unrecognised block type is present             -> keep
+ */
+class DeleteQuickCaptureDraftIfEmpty @Inject constructor(
+    private val repo: BlockRepository,
+    private val settings: UserSettingsRepository,
+    private val logger: Logger,
+    dispatchers: AppCoroutineDispatchers
+) : ResultInteractor<DeleteQuickCaptureDraftIfEmpty.Params, Boolean>(dispatchers.io) {
+
+    /** @return true when the draft was empty and has been deleted. */
+    override suspend fun doWork(params: Params): Boolean {
+        val view = runCatching { repo.getObject(id = params.draft, space = params.space) }
+            .onFailure { logger.logException(it, "Quick capture: could not read draft to clean up") }
+            .getOrNull() ?: return false
+
+        val details = view.details[view.root].orEmpty()
+
+        // Still ours to delete? A published or archived object is not an abandoned draft.
+        // isDraft may be absent on drafts made before the relation existed, in which case
+        // isHidden is the marker; an explicit false always means published.
+        val isDraft = details[Relations.IS_DRAFT] as? Boolean
+        val isHidden = details[Relations.IS_HIDDEN] as? Boolean
+        if (isDraft == false || isHidden != true) return false
+        if (details[Relations.IS_ARCHIVED] == true || details[Relations.IS_DELETED] == true) {
+            return false
+        }
+
+        if (!(details[Relations.NAME] as? String).isNullOrBlank()) return false
+
+        val root = view.blocks.firstOrNull { it.id == view.root }
+        val header = view.blocks.firstOrNull { block ->
+            val content = block.content
+            content is Block.Content.Layout && content.type == Block.Content.Layout.Type.HEADER
+        }
+        val body = root?.children.orEmpty().filter { it != header?.id }
+        if (view.blocks.any { it.id in body && it.holdsContent() }) return false
+
+        runCatching { repo.deleteObjects(listOf(params.draft)) }
+            .onFailure {
+                logger.logException(it, "Quick capture: could not delete empty draft")
+                return false
+            }
+        runCatching { settings.clearQuickCaptureDraft(params.space) }
+            .onFailure { logger.logException(it, "Quick capture: could not clear pointer") }
+        return true
+    }
+
+    /**
+     * Inverted on purpose: only known-structural blocks are treated as empty, so a block type
+     * this code does not recognise counts as content and spares the object.
+     */
+    private fun Block.holdsContent(): Boolean = when (val content = content) {
+        is Block.Content.Smart,
+        is Block.Content.Layout,
+        is Block.Content.FeaturedRelations,
+        is Block.Content.RelationBlock,
+        is Block.Content.Icon -> false
+        is Block.Content.Text -> content.text.isNotBlank()
+        else -> true
+    }
+
+    data class Params(
+        val space: SpaceId,
+        val draft: Id
+    )
+}

--- a/domain/src/main/java/com/anytypeio/anytype/domain/quickcapture/DeleteQuickCaptureDraftIfEmpty.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/quickcapture/DeleteQuickCaptureDraftIfEmpty.kt
@@ -57,13 +57,23 @@ class DeleteQuickCaptureDraftIfEmpty @Inject constructor(
 
         if (!(details[Relations.NAME] as? String).isNullOrBlank()) return false
 
-        val root = view.blocks.firstOrNull { it.id == view.root }
-        val header = view.blocks.firstOrNull { block ->
-            val content = block.content
-            content is Block.Content.Layout && content.type == Block.Content.Layout.Type.HEADER
-        }
-        val body = root?.children.orEmpty().filter { it != header?.id }
-        if (view.blocks.any { it.id in body && it.holdsContent() }) return false
+        // A view with no root block is a malformed answer, not an empty object.
+        val root = view.blocks.firstOrNull { it.id == view.root } ?: return false
+
+        // Walk EVERY block, not the root's direct children. Content nests — inside a toggle,
+        // a list item, a table cell — and a one-level scan reads all of it as empty. The
+        // description also lives under the header, so excluding that subtree wholesale hid it
+        // too. Skipping by identity/style instead of by parentage means nothing is out of
+        // scope: this is the same shape as EditorViewModel.hasQuickCaptureContent().
+        val structural = setOfNotNull(
+            root.id,
+            view.blocks.firstOrNull { block ->
+                val content = block.content
+                content is Block.Content.Layout &&
+                    content.type == Block.Content.Layout.Type.HEADER
+            }?.id
+        )
+        if (view.blocks.any { it.id !in structural && it.holdsContent() }) return false
 
         runCatching { repo.deleteObjects(listOf(params.draft)) }
             .onFailure {
@@ -85,7 +95,10 @@ class DeleteQuickCaptureDraftIfEmpty @Inject constructor(
         is Block.Content.FeaturedRelations,
         is Block.Content.RelationBlock,
         is Block.Content.Icon -> false
-        is Block.Content.Text -> content.text.isNotBlank()
+        // The title is judged from details[name] above; every other text block counts,
+        // including the description, which sits under the header.
+        is Block.Content.Text ->
+            content.style != Block.Content.Text.Style.TITLE && content.text.isNotBlank()
         else -> true
     }
 

--- a/domain/src/test/java/com/anytypeio/anytype/domain/quickcapture/DeleteQuickCaptureDraftIfEmptyTest.kt
+++ b/domain/src/test/java/com/anytypeio/anytype/domain/quickcapture/DeleteQuickCaptureDraftIfEmptyTest.kt
@@ -1,0 +1,214 @@
+package com.anytypeio.anytype.domain.quickcapture
+
+import com.anytypeio.anytype.core_models.Block
+import com.anytypeio.anytype.core_models.CoroutineTestRule
+import com.anytypeio.anytype.core_models.ObjectView
+import com.anytypeio.anytype.core_models.Relations
+import com.anytypeio.anytype.core_models.primitives.SpaceId
+import com.anytypeio.anytype.domain.base.Resultat
+import com.anytypeio.anytype.domain.block.repo.BlockRepository
+import com.anytypeio.anytype.domain.config.UserSettingsRepository
+import com.anytypeio.anytype.domain.debugging.Logger
+import com.anytypeio.anytype.domain.util.dispatchers
+import com.anytypeio.anytype.test_utils.MockDataFactory
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnit
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.never
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.verifyBlocking
+
+/**
+ * This use case issues a permanent delete, so the tests are weighted toward everything that
+ * must NOT be deleted. The image case is the one that motivated the block-level check: an
+ * image-only draft has no name and no snippet, so a text-based emptiness test would have
+ * called it empty and destroyed the image.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DeleteQuickCaptureDraftIfEmptyTest {
+
+    @get:Rule
+    val mockitoRule = MockitoJUnit.rule()
+
+    @ExperimentalCoroutinesApi
+    @get:Rule
+    var rule = CoroutineTestRule()
+
+    @Mock
+    lateinit var repo: BlockRepository
+
+    @Mock
+    lateinit var settings: UserSettingsRepository
+
+    @Mock
+    lateinit var logger: Logger
+
+    private lateinit var usecase: DeleteQuickCaptureDraftIfEmpty
+
+    private val space = SpaceId(MockDataFactory.randomUuid())
+    private val draft = MockDataFactory.randomUuid()
+    private val headerId = MockDataFactory.randomUuid()
+    private val bodyId = MockDataFactory.randomUuid()
+
+    @Before
+    fun setup() {
+        usecase = DeleteQuickCaptureDraftIfEmpty(
+            repo = repo,
+            settings = settings,
+            logger = logger,
+            dispatchers = dispatchers
+        )
+    }
+
+    private fun view(
+        body: Block.Content? = null,
+        name: String? = null,
+        isDraft: Any? = true,
+        isHidden: Any? = true
+    ) = ObjectView(
+        root = draft,
+        blocks = buildList {
+            add(
+                Block(
+                    id = draft,
+                    children = buildList {
+                        add(headerId)
+                        if (body != null) add(bodyId)
+                    },
+                    content = Block.Content.Smart,
+                    fields = Block.Fields.empty()
+                )
+            )
+            add(
+                Block(
+                    id = headerId,
+                    children = emptyList(),
+                    content = Block.Content.Layout(Block.Content.Layout.Type.HEADER),
+                    fields = Block.Fields.empty()
+                )
+            )
+            if (body != null) {
+                add(
+                    Block(
+                        id = bodyId,
+                        children = emptyList(),
+                        content = body,
+                        fields = Block.Fields.empty()
+                    )
+                )
+            }
+        },
+        details = mapOf(
+            draft to buildMap {
+                if (name != null) put(Relations.NAME, name)
+                if (isDraft != null) put(Relations.IS_DRAFT, isDraft)
+                if (isHidden != null) put(Relations.IS_HIDDEN, isHidden)
+            }
+        ),
+        objectRestrictions = emptyList(),
+        dataViewRestrictions = emptyList()
+    )
+
+    private fun stub(v: ObjectView) {
+        repo.stub { onBlocking { getObject(draft, space) } doReturn v }
+    }
+
+    private fun run() = runBlocking {
+        usecase.run(DeleteQuickCaptureDraftIfEmpty.Params(space = space, draft = draft))
+    }
+
+    private val emptyParagraph = Block.Content.Text(
+        text = "",
+        style = Block.Content.Text.Style.P,
+        marks = emptyList()
+    )
+
+    @Test
+    fun `deletes a draft with no title and an empty paragraph`() {
+        stub(view(body = emptyParagraph))
+
+        assertTrue(run())
+
+        verifyBlocking(repo) { deleteObjects(listOf(draft)) }
+        verifyBlocking(settings) { clearQuickCaptureDraft(space) }
+    }
+
+    @Test
+    fun `keeps a draft that holds only an image`() {
+        // No name, no snippet — a text-only emptiness test would delete this.
+        stub(
+            view(
+                body = Block.Content.File(
+                    targetObjectId = MockDataFactory.randomUuid(),
+                    name = "photo.jpg",
+                    mime = "image/jpeg",
+                    size = 1024,
+                    type = Block.Content.File.Type.IMAGE,
+                    state = Block.Content.File.State.DONE,
+                    addedAt = 0L
+                )
+            )
+        )
+
+        assertFalse(run())
+
+        verifyBlocking(repo, never()) { deleteObjects(any()) }
+    }
+
+    @Test
+    fun `keeps a draft with a title`() {
+        stub(view(body = emptyParagraph, name = "Buy milk"))
+
+        assertFalse(run())
+
+        verifyBlocking(repo, never()) { deleteObjects(any()) }
+    }
+
+    @Test
+    fun `keeps a draft with body text`() {
+        stub(
+            view(
+                body = Block.Content.Text(
+                    text = "call the dentist",
+                    style = Block.Content.Text.Style.P,
+                    marks = emptyList()
+                )
+            )
+        )
+
+        assertFalse(run())
+
+        verifyBlocking(repo, never()) { deleteObjects(any()) }
+    }
+
+    @Test
+    fun `keeps an object that has been published`() {
+        // isDraft explicitly false: no longer a draft, whatever else it looks like.
+        stub(view(body = emptyParagraph, isDraft = false, isHidden = false))
+
+        assertFalse(run())
+
+        verifyBlocking(repo, never()) { deleteObjects(any()) }
+    }
+
+    @Test
+    fun `keeps the draft when the object cannot be read`() {
+        // A failed read must never be mistaken for "there is nothing here".
+        repo.stub {
+            onBlocking { getObject(draft, space) } doThrow IllegalStateException("offline")
+        }
+
+        assertFalse(run())
+
+        verifyBlocking(repo, never()) { deleteObjects(any()) }
+    }
+}

--- a/domain/src/test/java/com/anytypeio/anytype/domain/quickcapture/DeleteQuickCaptureDraftIfEmptyTest.kt
+++ b/domain/src/test/java/com/anytypeio/anytype/domain/quickcapture/DeleteQuickCaptureDraftIfEmptyTest.kt
@@ -164,6 +164,98 @@ class DeleteQuickCaptureDraftIfEmptyTest {
         verifyBlocking(repo, never()) { deleteObjects(any()) }
     }
 
+    /**
+     * The note lives inside a toggle, not at the top level. A scan of the root's direct
+     * children sees only the toggle — which is itself blank — and calls the draft empty.
+     * Typing "> " turns a paragraph into a toggle, so this is an ordinary thing to do.
+     */
+    @Test
+    fun `keeps a draft whose only text is nested inside another block`() {
+        val nestedId = MockDataFactory.randomUuid()
+        val toggle = Block(
+            id = bodyId,
+            children = listOf(nestedId),
+            content = Block.Content.Text(
+                text = "",
+                style = Block.Content.Text.Style.TOGGLE,
+                marks = emptyList()
+            ),
+            fields = Block.Fields.empty()
+        )
+        val nested = Block(
+            id = nestedId,
+            children = emptyList(),
+            content = Block.Content.Text(
+                text = "the actual note",
+                style = Block.Content.Text.Style.P,
+                marks = emptyList()
+            ),
+            fields = Block.Fields.empty()
+        )
+        val v = view(body = emptyParagraph)
+        stub(v.copy(blocks = v.blocks.filter { it.id != bodyId } + listOf(toggle, nested)))
+
+        assertFalse(run())
+
+        verifyBlocking(repo, never()) { deleteObjects(any()) }
+    }
+
+    /**
+     * The description block is a child of the header, not of the root. Excluding the header
+     * subtree to skip the title hid the description with it — and the quick-capture menu
+     * deliberately keeps "Show description".
+     */
+    @Test
+    fun `keeps a draft whose only text is in the description`() {
+        val descriptionId = MockDataFactory.randomUuid()
+        val description = Block(
+            id = descriptionId,
+            children = emptyList(),
+            content = Block.Content.Text(
+                text = "written into the description",
+                style = Block.Content.Text.Style.DESCRIPTION,
+                marks = emptyList()
+            ),
+            fields = Block.Fields.empty()
+        )
+        val v = view(body = emptyParagraph)
+        val header = v.blocks.first { it.id == headerId }
+        stub(
+            v.copy(
+                blocks = v.blocks.filter { it.id != headerId } +
+                    listOf(header.copy(children = listOf(descriptionId)), description)
+            )
+        )
+
+        assertFalse(run())
+
+        verifyBlocking(repo, never()) { deleteObjects(any()) }
+    }
+
+    /** A view without its root block is a malformed answer, not an empty object. */
+    @Test
+    fun `keeps the draft when the view has no root block`() {
+        val v = view(body = emptyParagraph)
+        stub(v.copy(blocks = v.blocks.filter { it.id != draft }))
+
+        assertFalse(run())
+
+        verifyBlocking(repo, never()) { deleteObjects(any()) }
+    }
+
+    /** A failed delete must not clear the pointer, or the object is stranded unreachable. */
+    @Test
+    fun `keeps the pointer when the delete fails`() {
+        stub(view(body = emptyParagraph))
+        repo.stub { onBlocking { deleteObjects(any()) } doThrow IllegalStateException("offline") }
+
+        assertFalse(run())
+
+        // Concrete, not any(): SpaceId is a value class and a Mockito matcher for one
+        // returns null, which NPEs on unboxing and poisons the following tests.
+        verifyBlocking(settings, never()) { clearQuickCaptureDraft(space) }
+    }
+
     @Test
     fun `keeps a draft with a title`() {
         stub(view(body = emptyParagraph, name = "Buy milk"))

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/editor/EditorViewModel.kt
@@ -8093,12 +8093,29 @@ class EditorViewModel(
         val document = blocks
         val title = document.title()?.content<Content.Text>()?.text
         if (!title.isNullOrBlank()) return true
-        return document.any { block ->
-            val content = block.content
-            content is Content.Text &&
-                content.style != Content.Text.Style.TITLE &&
-                content.text.isNotBlank()
-        }
+        return document.any { block -> block.isQuickCaptureContent() }
+    }
+
+    /**
+     * Whether this block is something the user put here, as opposed to structure every
+     * object is born with.
+     *
+     * Deliberately inverted: the listed types are the ones known to be structural, and
+     * everything else counts as content. This answer gates a permanent delete, so an
+     * unrecognised block type must read as "there is something here" rather than as empty.
+     * A text-only test would call an image-only draft empty and destroy the image with it.
+     */
+    private fun Block.isQuickCaptureContent(): Boolean = when (val content = content) {
+        // Structure present on every object before the user does anything.
+        is Content.Smart,
+        is Content.Layout,
+        is Content.FeaturedRelations,
+        is Content.RelationBlock,
+        is Content.Icon -> false
+        // The title is judged separately; an empty paragraph is not content.
+        is Content.Text -> content.style != Content.Text.Style.TITLE && content.text.isNotBlank()
+        // Files, images, bookmarks, links, tables, embeds, dividers — all user-placed.
+        else -> true
     }
 
     /**

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/quickcapture/QuickCaptureViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/quickcapture/QuickCaptureViewModel.kt
@@ -1,5 +1,6 @@
 package com.anytypeio.anytype.presentation.quickcapture
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -27,6 +28,7 @@ import com.anytypeio.anytype.domain.`object`.SetObjectDetails
 import com.anytypeio.anytype.domain.objects.DeleteObjects
 import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
 import com.anytypeio.anytype.domain.page.CreateObject
+import com.anytypeio.anytype.domain.quickcapture.DeleteQuickCaptureDraftIfEmpty
 import com.anytypeio.anytype.domain.quickcapture.FetchQuickCaptureDraft
 import com.anytypeio.anytype.domain.quickcapture.MoveQuickCaptureDraft
 import com.anytypeio.anytype.domain.quickcapture.SearchQuickCaptureDrafts
@@ -38,6 +40,8 @@ import com.anytypeio.anytype.presentation.sync.SyncStatusWidgetState
 import com.anytypeio.anytype.presentation.sync.toSyncStatusWidgetState
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
+import javax.inject.Named
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -88,7 +92,9 @@ class QuickCaptureViewModel(
     private val spaceSyncAndP2PStatusProvider: SpaceSyncAndP2PStatusProvider,
     private val typeSuggestionEngine: TypeSuggestionEngine,
     private val fetchQuickCaptureDraft: FetchQuickCaptureDraft,
-    private val searchQuickCaptureDrafts: SearchQuickCaptureDrafts
+    private val searchQuickCaptureDrafts: SearchQuickCaptureDrafts,
+    private val deleteQuickCaptureDraftIfEmpty: DeleteQuickCaptureDraftIfEmpty,
+    private val appScope: CoroutineScope
 ) : BaseViewModel(), AnalyticSpaceHelperDelegate by analyticSpaceHelperDelegate {
 
     sealed class ScreenState {
@@ -781,11 +787,13 @@ class QuickCaptureViewModel(
                     // the type/relation stores have already switched space beneath it.
                     mode == SwitchMode.KEEP_CURRENT -> {
                         screenState.value = ScreenState.Loading
+                        deleteSourceIfEmpty(current)
                         ensureDraft(SpaceId(target))
                     }
                     isSourceDraftEmpty() -> {
                         // Nothing typed — just open/create the target space's own draft.
                         screenState.value = ScreenState.Loading
+                        deleteSourceIfEmpty(current)
                         ensureDraft(SpaceId(target))
                     }
                     else -> {
@@ -795,6 +803,28 @@ class QuickCaptureViewModel(
                     }
                 }
             }
+        )
+    }
+
+    /**
+     * The space we are leaving keeps its draft only if that draft holds something. An empty
+     * one is not "parked", it is litter: it would keep a pointer and a picker dot alive for a
+     * space with nothing in it.
+     *
+     * Safe to run unconditionally — the use case re-reads the object and deletes only when it
+     * is genuinely empty and still a draft, so a draft with content is never touched here.
+     */
+    private suspend fun deleteSourceIfEmpty(source: ScreenState.Ready) {
+        deleteQuickCaptureDraftIfEmpty.async(
+            DeleteQuickCaptureDraftIfEmpty.Params(space = source.space, draft = source.draft)
+        ).fold(
+            onSuccess = { deleted ->
+                if (deleted) {
+                    Timber.d("Quick capture: deleted empty draft in ${source.space.id}")
+                    refreshDraftSpaces()
+                }
+            },
+            onFailure = { Timber.w(it, "Quick capture: leaving empty draft in place") }
         )
     }
 
@@ -1052,7 +1082,32 @@ class QuickCaptureViewModel(
      */
     override fun onCleared() {
         super.onCleared()
+        cleanUpAbandonedDraft()
         spaceManager.clear()
+    }
+
+    /**
+     * The sheet is really going away (onCleared does not fire for a configuration change), so
+     * a draft still holding nothing is abandoned rather than parked, and is deleted.
+     *
+     * Runs on the application scope: viewModelScope is already cancelled here, so anything
+     * launched on it would never execute. The use case decides emptiness from the store, not
+     * from the editor — which no longer exists by this point.
+     */
+    @VisibleForTesting
+    internal fun cleanUpAbandonedDraft() {
+        if (isSending.get()) return // published, not abandoned
+        val current = screenState.value as? ScreenState.Ready ?: return
+        appScope.launch {
+            deleteQuickCaptureDraftIfEmpty.async(
+                DeleteQuickCaptureDraftIfEmpty.Params(space = current.space, draft = current.draft)
+            ).fold(
+                onSuccess = { deleted ->
+                    if (deleted) Timber.d("Quick capture: deleted empty draft on close")
+                },
+                onFailure = { Timber.w(it, "Quick capture: empty-draft cleanup failed") }
+            )
+        }
     }
 
     class Factory @Inject constructor(
@@ -1072,7 +1127,9 @@ class QuickCaptureViewModel(
         private val spaceSyncAndP2PStatusProvider: SpaceSyncAndP2PStatusProvider,
         private val typeSuggestionEngine: TypeSuggestionEngine,
         private val fetchQuickCaptureDraft: FetchQuickCaptureDraft,
-        private val searchQuickCaptureDrafts: SearchQuickCaptureDrafts
+        private val searchQuickCaptureDrafts: SearchQuickCaptureDrafts,
+        private val deleteQuickCaptureDraftIfEmpty: DeleteQuickCaptureDraftIfEmpty,
+        @Named(APP_COROUTINE_SCOPE) private val appScope: CoroutineScope
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -1093,7 +1150,9 @@ class QuickCaptureViewModel(
                 spaceSyncAndP2PStatusProvider = spaceSyncAndP2PStatusProvider,
                 typeSuggestionEngine = typeSuggestionEngine,
                 fetchQuickCaptureDraft = fetchQuickCaptureDraft,
-                searchQuickCaptureDrafts = searchQuickCaptureDrafts
+                searchQuickCaptureDrafts = searchQuickCaptureDrafts,
+                deleteQuickCaptureDraftIfEmpty = deleteQuickCaptureDraftIfEmpty,
+                appScope = appScope
             ) as T
         }
     }
@@ -1102,6 +1161,14 @@ class QuickCaptureViewModel(
         const val QUICK_CAPTURE_DRAFT_SUBSCRIPTION = "quick-capture-draft-subscription"
         private const val SOMETHING_WENT_WRONG = "Something went wrong. Please, try again."
         private const val SPACES_AWAIT_TIMEOUT_MS = 3_000L
+        /**
+         * Must match ConfigModule.DEFAULT_APP_COROUTINE_SCOPE. Duplicated rather than
+         * imported because that constant lives in :app, which :presentation cannot depend
+         * on. Dagger matches qualifiers by string, so a divergence fails the build with
+         * MissingBinding rather than misbehaving at runtime.
+         */
+        const val APP_COROUTINE_SCOPE = "Default application coroutine scope"
+
         private val DRAFT_VALIDATION_KEYS = listOf(
             Relations.ID,
             Relations.IS_DELETED,

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/quickcapture/QuickCaptureViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/quickcapture/QuickCaptureViewModel.kt
@@ -786,12 +786,17 @@ class QuickCaptureViewModel(
                     // The current draft stays put; the target opens its own. Still detach:
                     // the type/relation stores have already switched space beneath it.
                     mode == SwitchMode.KEEP_CURRENT -> {
+                        // No cleanup here: the user was asked and said keep. This branch is
+                        // only reachable with a source the editor reported as non-empty, so
+                        // deleting on a second opinion could only ever contradict them.
                         screenState.value = ScreenState.Loading
-                        deleteSourceIfEmpty(current)
                         ensureDraft(SpaceId(target))
                     }
                     isSourceDraftEmpty() -> {
                         // Nothing typed — just open/create the target space's own draft.
+                        // The source's cleanup is fired and forgotten: it is a different
+                        // object, and awaiting a read + delete + cross-space refresh would
+                        // hold the sheet on Loading for no benefit to the user.
                         screenState.value = ScreenState.Loading
                         deleteSourceIfEmpty(current)
                         ensureDraft(SpaceId(target))
@@ -814,7 +819,12 @@ class QuickCaptureViewModel(
      * Safe to run unconditionally — the use case re-reads the object and deletes only when it
      * is genuinely empty and still a draft, so a draft with content is never touched here.
      */
-    private suspend fun deleteSourceIfEmpty(source: ScreenState.Ready) {
+    private fun deleteSourceIfEmpty(source: ScreenState.Ready) {
+        if (isSending.get()) return
+        appScope.launch { runCleanup(source) }
+    }
+
+    private suspend fun runCleanup(source: ScreenState.Ready) {
         deleteQuickCaptureDraftIfEmpty.async(
             DeleteQuickCaptureDraftIfEmpty.Params(space = source.space, draft = source.draft)
         ).fold(
@@ -1094,9 +1104,26 @@ class QuickCaptureViewModel(
      * launched on it would never execute. The use case decides emptiness from the store, not
      * from the editor — which no longer exists by this point.
      */
+    /**
+     * Recorded while the editor is still alive (onDestroyView runs before onCleared), because
+     * by cleanup time it is gone and its pending writes are gone with it.
+     */
+    private var editorReportedEdits = false
+
+    fun onEditorDetached(hasEdits: Boolean) {
+        editorReportedEdits = hasEdits
+    }
+
     @VisibleForTesting
     internal fun cleanUpAbandonedDraft() {
         if (isSending.get()) return // published, not abandoned
+        // The user typed something. Whether it reached the store yet is not knowable here:
+        // the editor's write pipeline lives on its own scope and is cancelled during this
+        // same teardown, so a keystroke can still be in flight while this reads the store and
+        // sees nothing. The switch path solves it by flushing first; the close path cannot
+        // suspend, so it declines to delete instead. An empty draft that survives is litter;
+        // a deleted one that was not empty is gone for good.
+        if (editorReportedEdits) return
         val current = screenState.value as? ScreenState.Ready ?: return
         appScope.launch {
             deleteQuickCaptureDraftIfEmpty.async(

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/quickcapture/QuickCaptureViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/quickcapture/QuickCaptureViewModelTest.kt
@@ -22,6 +22,7 @@ import com.anytypeio.anytype.domain.`object`.SetObjectDetails
 import com.anytypeio.anytype.domain.objects.DeleteObjects
 import com.anytypeio.anytype.domain.objects.StoreOfObjectTypes
 import com.anytypeio.anytype.domain.page.CreateObject
+import com.anytypeio.anytype.domain.quickcapture.DeleteQuickCaptureDraftIfEmpty
 import com.anytypeio.anytype.domain.quickcapture.FetchQuickCaptureDraft
 import com.anytypeio.anytype.domain.quickcapture.MoveQuickCaptureDraft
 import com.anytypeio.anytype.domain.quickcapture.SearchQuickCaptureDrafts
@@ -31,6 +32,7 @@ import com.anytypeio.anytype.presentation.util.DefaultCoroutineTestRule
 import com.anytypeio.anytype.test_utils.MockDataFactory
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -66,6 +68,7 @@ class QuickCaptureViewModelTest {
     @Mock lateinit var createObject: CreateObject
     @Mock lateinit var fetchQuickCaptureDraft: FetchQuickCaptureDraft
     @Mock lateinit var searchQuickCaptureDrafts: SearchQuickCaptureDrafts
+    @Mock lateinit var deleteQuickCaptureDraftIfEmpty: DeleteQuickCaptureDraftIfEmpty
 
     @Mock lateinit var setObjectDetails: SetObjectDetails
     @Mock lateinit var deleteObjects: DeleteObjects
@@ -91,6 +94,8 @@ class QuickCaptureViewModelTest {
         createObject = createObject,
         fetchQuickCaptureDraft = fetchQuickCaptureDraft,
         searchQuickCaptureDrafts = searchQuickCaptureDrafts,
+        deleteQuickCaptureDraftIfEmpty = deleteQuickCaptureDraftIfEmpty,
+        appScope = CoroutineScope(coroutineTestRule.dispatcher),
         setObjectDetails = setObjectDetails,
         deleteObjects = deleteObjects,
         moveQuickCaptureDraft = moveQuickCaptureDraft,
@@ -120,6 +125,9 @@ class QuickCaptureViewModelTest {
         }
         spaceManager.stub {
             onBlocking { set(targetSpace, false) } doReturn Result.success(mock<Config>())
+        }
+        deleteQuickCaptureDraftIfEmpty.stub {
+            onBlocking { async(any()) } doReturn Resultat.success(false)
         }
         searchQuickCaptureDrafts.stub {
             onBlocking { async(any()) } doReturn Resultat.success(
@@ -244,6 +252,9 @@ class QuickCaptureViewModelTest {
         }
         // The pointer is only a hint now: it is honoured because the store still lists that
         // draft. Discovery is the source of truth for what exists.
+        deleteQuickCaptureDraftIfEmpty.stub {
+            onBlocking { async(any()) } doReturn Resultat.success(false)
+        }
         searchQuickCaptureDrafts.stub {
             onBlocking { async(any()) } doReturn Resultat.success(
                 SearchQuickCaptureDrafts.Result(drafts = listOf(pending), isComplete = true)
@@ -366,6 +377,9 @@ class QuickCaptureViewModelTest {
             onBlocking { getQuickCaptureLastSpace() } doReturn null
             onBlocking { getQuickCaptureDraft(SpaceId(targetSpace)) } doReturn null
         }
+        deleteQuickCaptureDraftIfEmpty.stub {
+            onBlocking { async(any()) } doReturn Resultat.success(false)
+        }
         searchQuickCaptureDrafts.stub {
             onBlocking { async(any()) } doReturn Resultat.success(
                 SearchQuickCaptureDrafts.Result(drafts = listOf(remote), isComplete = true)
@@ -393,6 +407,9 @@ class QuickCaptureViewModelTest {
             onBlocking { getQuickCaptureLastSpace() } doReturn null
             onBlocking { getQuickCaptureDraft(SpaceId(targetSpace)) } doReturn null
         }
+        deleteQuickCaptureDraftIfEmpty.stub {
+            onBlocking { async(any()) } doReturn Resultat.success(false)
+        }
         searchQuickCaptureDrafts.stub {
             onBlocking { async(any()) } doReturn Resultat.success(
                 SearchQuickCaptureDrafts.Result(drafts = emptyList(), isComplete = false)
@@ -405,6 +422,57 @@ class QuickCaptureViewModelTest {
 
         // Pencils must not be cleared on an inconclusive answer.
         assertTrue(vm.spaces.value.none { it.hasDraft })
+    }
+
+    /**
+     * Closing the sheet on a draft nobody filled in should clean it up. The decision is the
+     * use case's — this only pins that the sheet actually asks on the way out, on a scope
+     * that outlives it (viewModelScope is already cancelled inside onCleared).
+     */
+    @Test
+    fun `asks to clean up the draft when the sheet closes`() = runTest {
+        val vm = vm()
+        vm.onStart()
+        coroutineTestRule.advanceUntilIdle()
+
+        vm.cleanUpAbandonedDraft()
+        coroutineTestRule.advanceUntilIdle()
+
+        val params = argumentCaptor<DeleteQuickCaptureDraftIfEmpty.Params>()
+        verifyBlocking(deleteQuickCaptureDraftIfEmpty) { async(params.capture()) }
+        assertEquals(draftId, params.lastValue.draft)
+        assertEquals(targetSpace, params.lastValue.space.id)
+    }
+
+    /** A draft on its way to being published is not abandoned, whatever it currently holds. */
+    @Test
+    fun `does not clean up a draft that is being sent`() = runTest {
+        // Send is only reachable on a non-empty draft, so give the subscription content.
+        storelessSubscriptionContainer.stub {
+            on { subscribe(any<StoreSearchByIdsParams>()) } doReturn flowOf(
+                listOf(
+                    ObjectWrapper.Basic(
+                        mapOf(Relations.ID to draftId, Relations.NAME to "Buy milk")
+                    )
+                )
+            )
+        }
+        setObjectDetails.stub {
+            onBlocking { async(any()) } doReturn Resultat.success(mock())
+        }
+        analyticSpaceHelperDelegate.stub {
+            on { provideParams(any()) } doReturn AnalyticSpaceHelperDelegate.Params.EMPTY
+        }
+        val vm = vm()
+        vm.onStart()
+        coroutineTestRule.advanceUntilIdle()
+        vm.onSendClicked()
+        coroutineTestRule.advanceUntilIdle()
+
+        vm.cleanUpAbandonedDraft()
+        coroutineTestRule.advanceUntilIdle()
+
+        verifyBlocking(deleteQuickCaptureDraftIfEmpty, never()) { async(any()) }
     }
 
     private val conflictSpace = MockDataFactory.randomUuid()

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/quickcapture/QuickCaptureViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/quickcapture/QuickCaptureViewModelTest.kt
@@ -1,5 +1,8 @@
 package com.anytypeio.anytype.presentation.quickcapture
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
 import app.cash.turbine.test
 import com.anytypeio.anytype.analytics.base.Analytics
 import com.anytypeio.anytype.core_models.Config
@@ -425,17 +428,26 @@ class QuickCaptureViewModelTest {
     }
 
     /**
-     * Closing the sheet on a draft nobody filled in should clean it up. The decision is the
-     * use case's — this only pins that the sheet actually asks on the way out, on a scope
-     * that outlives it (viewModelScope is already cancelled inside onCleared).
+     * Drives the REAL teardown — ViewModelStore.clear() cancels viewModelScope and then calls
+     * onCleared — rather than invoking the cleanup directly. That is the whole point of the
+     * design: work launched on viewModelScope from onCleared would never run, so the cleanup
+     * is dispatched to a scope that outlives the sheet. Calling the method by hand proves
+     * neither that onCleared triggers it nor that the scope choice matters.
      */
     @Test
-    fun `asks to clean up the draft when the sheet closes`() = runTest {
-        val vm = vm()
+    fun `cleans up the draft when the view model is actually cleared`() = runTest {
+        val store = ViewModelStore()
+        val vm = ViewModelProvider(
+            store,
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T = vm() as T
+            }
+        )[QuickCaptureViewModel::class.java]
         vm.onStart()
         coroutineTestRule.advanceUntilIdle()
 
-        vm.cleanUpAbandonedDraft()
+        store.clear()
         coroutineTestRule.advanceUntilIdle()
 
         val params = argumentCaptor<DeleteQuickCaptureDraftIfEmpty.Params>()
@@ -466,9 +478,28 @@ class QuickCaptureViewModelTest {
         val vm = vm()
         vm.onStart()
         coroutineTestRule.advanceUntilIdle()
+        // Guard the false pass: cleanup also bails when state is not Ready.
+        assertTrue(vm.screenState.value is QuickCaptureViewModel.ScreenState.Ready)
         vm.onSendClicked()
         coroutineTestRule.advanceUntilIdle()
 
+        vm.cleanUpAbandonedDraft()
+        coroutineTestRule.advanceUntilIdle()
+
+        verifyBlocking(deleteQuickCaptureDraftIfEmpty, never()) { async(any()) }
+    }
+
+    /**
+     * A keystroke can still be in flight while the editor's write scope is torn down, so the
+     * store may not yet show it. Anything the user typed means hands off.
+     */
+    @Test
+    fun `does not clean up when the editor reported edits`() = runTest {
+        val vm = vm()
+        vm.onStart()
+        coroutineTestRule.advanceUntilIdle()
+
+        vm.onEditorDetached(hasEdits = true)
         vm.cleanUpAbandonedDraft()
         coroutineTestRule.advanceUntilIdle()
 


### PR DESCRIPTION
## What

Follow-up to DROID-4587. A quick-capture draft the user never put anything into is deleted when they leave it, instead of lingering as a hidden object that keeps a pointer and a picker dot alive for an empty space.

Two moments count as leaving: **switching the target space**, and **closing the sheet**.

## Why it wasn't already happening

Drafts are created with `InternalFlags.ShouldEmptyDelete` — heart's own "bin this on close if it is still empty". It never fires: the flag is one-way and any details write clears it, and quick capture writes details at creation (`isHidden`, `isDraft`). So every abandoned empty draft survived.

## Emptiness is block-level, and fails safe

The existing check reads `name` + `snippet`. An **image-only draft has neither**, so a text-based test would have called it empty and destroyed the image.

`DeleteQuickCaptureDraftIfEmpty` reads the object and is written inverted: only known-structural blocks (smart, layout, featured relations, relation, icon) count as empty, and **any unrecognised block type counts as content**. It gates a permanent `Object.ListDelete`, so every uncertainty resolves to keeping the object:

- read fails, or object missing → keep
- no longer a draft (published/archived) → keep
- any title, any text, any attachment → keep
- block type the code doesn't recognise → keep

Emptiness is decided from the **store**, not the editor — the editor is usually gone by the time the sheet closes, and the store is what the next device sees.

## Lifecycle details

- The close path runs on the **application coroutine scope**. `viewModelScope` is already cancelled inside `onCleared`, so anything launched there would never execute.
- It hooks `onCleared`, **not** `onDismiss`/`onDestroyView` — those also fire when the view is torn down for a configuration change, and rotating the phone must not delete a draft.
- A send in flight is not an abandonment; the existing send latch suppresses cleanup.

## Tests

`DeleteQuickCaptureDraftIfEmptyTest` — six cases, weighted toward what must *not* be deleted (image-only, titled, body text, published, unreadable). Plus two on the ViewModel: the sheet asks for cleanup on close, and does not while sending.

1803 unit tests pass.
