### PR TITLE
Streamline share flow when only one space

### DIFF
--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sharing/SharingViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sharing/SharingViewModel.kt
@@ -152,6 +152,9 @@ class SharingViewModel(
                     allSpaces.clear()
                     allSpaces.addAll(spaces)
                     updateSpaceSelectionState()
+                    if (spaces.count() == 1) {
+                        onSpaceSelected(spaces.first())
+                    }
                 }
         }
     }


### PR DESCRIPTION


- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

As a user of Anytype with only one space, I don't want to have to select my one space every time I share content to the app via the android share sheet. (It doesn't help that the icon for the one space is in the upper-left corner.)

This change intends to streamline this flow by automatically selecting my one space, *iff* there is only and exactly one space to choose from.


<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

Nil

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 😎 will do if this approach is acceptable
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
