### PR TITLE
DROID-4589 Vault | Fix | Render the channel list without waiting for chat previews

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/ui/vault/VaultFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/vault/VaultFragment.kt
@@ -98,6 +98,7 @@ class VaultFragment : BaseComposeFragment() {
 
             VaultScreen(
                 uiState = vm.uiState.collectAsStateWithLifecycle().value,
+                isEnrichingPreviews = vm.isEnrichingPreviews.collectAsStateWithLifecycle().value,
                 showNotificationBadge = vm.isNotificationDisabled.collectAsStateWithLifecycle().value,
                 showCreateSpaceBadge = vm.showCreateSpaceBadge.collectAsStateWithLifecycle().value,
                 isCompactMode = vm.isCompactMode.collectAsStateWithLifecycle().value,

--- a/data/src/main/java/com/anytypeio/anytype/data/auth/repo/UserSettingsCache.kt
+++ b/data/src/main/java/com/anytypeio/anytype/data/auth/repo/UserSettingsCache.kt
@@ -110,6 +110,9 @@ interface UserSettingsCache {
     suspend fun setSpaceLastInteraction(space: SpaceId, timestamp: Long)
     suspend fun getSpaceLastInteractions(): Map<Id, Long>
 
+    suspend fun getVaultSortKeys(): Map<Id, Long>
+    suspend fun setVaultSortKeys(keys: Map<Id, Long>)
+
     suspend fun setQuickCaptureLastSpace(space: Id)
     suspend fun getQuickCaptureLastSpace(): Id?
 

--- a/data/src/main/java/com/anytypeio/anytype/data/auth/repo/UserSettingsDataRepository.kt
+++ b/data/src/main/java/com/anytypeio/anytype/data/auth/repo/UserSettingsDataRepository.kt
@@ -306,6 +306,14 @@ class UserSettingsDataRepository(private val cache: UserSettingsCache) : UserSet
         return cache.getSpaceLastInteractions()
     }
 
+    override suspend fun getVaultSortKeys(): Map<Id, Long> {
+        return cache.getVaultSortKeys()
+    }
+
+    override suspend fun setVaultSortKeys(keys: Map<Id, Long>) {
+        cache.setVaultSortKeys(keys)
+    }
+
     override suspend fun setQuickCaptureLastSpace(space: Id) {
         cache.setQuickCaptureLastSpace(space)
     }

--- a/domain/src/main/java/com/anytypeio/anytype/domain/config/UserSettingsRepository.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/config/UserSettingsRepository.kt
@@ -117,6 +117,14 @@ interface UserSettingsRepository {
     suspend fun setSpaceLastInteraction(space: SpaceId, timestamp: Long)
     suspend fun getSpaceLastInteractions(): Map<Id, Long>
 
+    /**
+     * Vault sort keys: spaceId -> last chat message timestamp (unix seconds),
+     * cached from the last session so the vault can paint its previous order
+     * before chat previews arrive from the middleware.
+     */
+    suspend fun getVaultSortKeys(): Map<Id, Long>
+    suspend fun setVaultSortKeys(keys: Map<Id, Long>)
+
     /** The space quick capture was last pointed at, so the sheet can reopen there. */
     suspend fun setQuickCaptureLastSpace(space: Id)
     suspend fun getQuickCaptureLastSpace(): Id?

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModel.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModel.kt
@@ -84,6 +84,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -92,7 +93,6 @@ import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
@@ -183,16 +183,42 @@ class VaultViewModel(
     // step, so we know to reopen it when the user presses back on CreateSpace.
     private var didShowSelectMembersForGroupCreation = false
 
-    // NOTE: deliberately NOT filtered to Ready. The vault paints as soon as the
-    // space list is available and enriches with chat previews when they land —
-    // Chat.SubscribeToMessagePreviews can take many seconds on a cold start with
-    // many spaces, and the previous sort order is restored from cache meanwhile.
-    private val previewFlow: StateFlow<ChatPreviewContainer.PreviewState> =
+    /**
+     * The vault's view of chat previews.
+     *
+     * Deliberately NOT gated on [ChatPreviewContainer.PreviewState.Ready]: the vault
+     * paints as soon as the space list is available and enriches when previews land,
+     * because Chat.SubscribeToMessagePreviews can take many seconds on a cold start
+     * with many spaces.
+     *
+     * [items] retains the last loaded previews across a Loading blip. The container
+     * resets to Loading whenever the account restarts — including on a plain
+     * configuration change, via MainViewModel.onRestore() — and this ViewModel
+     * survives that, so treating Loading as "no previews" would blank every chat row
+     * mid-session for the duration of the RPC.
+     */
+    private data class PreviewSnapshot(
+        val items: List<Chat.Preview>,
+        val hasLoadedOnce: Boolean
+    )
+
+    private val previewFlow: StateFlow<PreviewSnapshot> =
         chatPreviewContainer.observePreviewsWithAttachments()
+            .scan(PreviewSnapshot(items = emptyList(), hasLoadedOnce = false)) { previous, state ->
+                when (state) {
+                    is ChatPreviewContainer.PreviewState.Ready -> PreviewSnapshot(
+                        items = state.items,
+                        hasLoadedOnce = true
+                    )
+                    // Keep the previews we already have rather than blanking the rows.
+                    ChatPreviewContainer.PreviewState.Loading -> previous
+                }
+            }
+            .distinctUntilChanged()
             .stateIn(
                 viewModelScope,
                 SharingStarted.Eagerly,
-                ChatPreviewContainer.PreviewState.Loading
+                PreviewSnapshot(items = emptyList(), hasLoadedOnce = false)
             )
 
     private val spaceFlow: StateFlow<List<ObjectWrapper.SpaceView>> =
@@ -237,6 +263,7 @@ class VaultViewModel(
      * yet, so the cold-start vault paints in the order the user last saw instead
      * of falling back to join/creation date and then re-shuffling.
      */
+    @Volatile
     private var cachedSortKeys: Map<Id, Long>? = null
 
     private suspend fun sortKeyFallback(): Map<Id, Long> {
@@ -250,6 +277,17 @@ class VaultViewModel(
 
     private val _uiState = MutableStateFlow<VaultUiState>(VaultUiState.Loading)
     val uiState: StateFlow<VaultUiState> = _uiState.asStateFlow()
+
+    /**
+     * True while chat previews are still in flight. The vault now renders before they
+     * arrive, so without this the screen looks complete — every card present, no
+     * message text, no unread badges — and the user cannot tell "still loading" from
+     * "every channel is empty and read".
+     */
+    val isEnrichingPreviews: StateFlow<Boolean> = previewFlow
+        .map { !it.hasLoadedOnce }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
 
     val isCompactMode: StateFlow<Boolean> = userSettingsRepository
         .observeCompactModeEnabled()
@@ -319,8 +357,15 @@ class VaultViewModel(
             // arrive, or until previews go Ready so a genuinely empty vault still
             // resolves off the spinner.
             .filter { (first, _) ->
-                val (previews, spaces, _) = first
-                spaces.isNotEmpty() || previews is ChatPreviewContainer.PreviewState.Ready
+                val (previews, spaces, perms) = first
+                // Permissions decide whether a space's menu offers "Delete space" or
+                // "Leave space", and both confirmations route to the same Space.Delete
+                // call — so for an owner, painting before permissions are known offers
+                // the leave wording ("removed from your devices") for an action that
+                // destroys the space for every member. permissionsFlow is derived from
+                // the space list and cannot precede it, so waiting on it here costs a
+                // little first-paint latency and removes that hazard.
+                (spaces.isNotEmpty() && perms.isNotEmpty()) || previews.hasLoadedOnce
             }
             // Throttle-latest: the very first vault state passes through without delay;
             // afterwards, bursts of upstream events (chat previews, space views,
@@ -336,11 +381,9 @@ class VaultViewModel(
             .map { (first, second) ->
                 val (previews, spaces, perms) = first
                 val (chatDetails, participants, accountIdentity) = second
-                val previewItems =
-                    (previews as? ChatPreviewContainer.PreviewState.Ready)?.items.orEmpty()
                 val sections = transformToVaultSpaceViews(
                     spaces,
-                    previewItems,
+                    previews.items,
                     perms,
                     chatDetails,
                     participants,
@@ -372,9 +415,9 @@ class VaultViewModel(
         // Cache the per-space last-message dates so the next cold start can paint the
         // vault in this order before Chat.SubscribeToMessagePreviews returns.
         previewFlow
-            .filterIsInstance<ChatPreviewContainer.PreviewState.Ready>()
-            .map { ready ->
-                ready.items
+            .filter { it.hasLoadedOnce }
+            .map { snapshot ->
+                snapshot.items
                     .groupBy { it.space.id }
                     .mapValues { (_, previews) ->
                         previews.maxOf { it.message?.createdAt ?: 0L }
@@ -384,6 +427,10 @@ class VaultViewModel(
             .distinctUntilChanged()
             .debounce(VAULT_SORT_KEY_PERSIST_DEBOUNCE_MS)
             .onEach { keys ->
+                // An empty map is ambiguous: ChatPreviewContainer swallows an RPC
+                // failure and publishes Ready(emptyList()), which is indistinguishable
+                // from an account with no chats. Never let that clear what we have.
+                if (keys.isEmpty()) return@onEach
                 cachedSortKeys = keys
                 runCatching { userSettingsRepository.setVaultSortKeys(keys) }
                     .onFailure { Timber.w(it, "Failed to persist vault sort keys") }
@@ -592,7 +639,9 @@ class VaultViewModel(
 
         // Sort unpinned spaces by effective date (descending), then by creation date (descending)
         val sortedUnpinnedSpaces = unpinnedSpaces.sortedWith(
-            compareByDescending<VaultSpaceView> { calculateEffectiveDate(it, sortKeyFallback) ?: 0L }
+            compareByDescending<VaultSpaceView> {
+                calculateEffectiveDate(it, sortKeyFallback, chatPreviewMap.keys) ?: 0L
+            }
                 .thenByDescending { it.space.getSingleValue<Double>(Relations.CREATED_DATE) ?: 0.0 }
         )
 
@@ -624,9 +673,14 @@ class VaultViewModel(
 
     /**
      * Calculates the effective date for a space by taking the maximum of lastMessageDate and spaceJoinDate.
-     * When the chat preview has not arrived yet, lastMessageDate falls back to the
-     * value cached from the previous session ([sortKeyFallback]) so the cold-start
+     * When a space's chat preview has not arrived yet, lastMessageDate falls back to
+     * the value cached from the previous session ([sortKeyFallback]) so the cold-start
      * order matches what the user last saw.
+     *
+     * The fallback applies only to spaces absent from [spacesWithPreview]. Once a
+     * preview has arrived for a space it is the truth, including when it carries no
+     * message at all (the last message was deleted) — otherwise a stale cached date
+     * would keep that space floating near the top forever.
      *
      * - If both lastMessageDate and spaceJoinDate are available, return the maximum
      * - If only one is available, return that one
@@ -635,10 +689,14 @@ class VaultViewModel(
      */
     private fun calculateEffectiveDate(
         space: VaultSpaceView,
-        sortKeyFallback: Map<Id, Long> = emptyMap()
+        sortKeyFallback: Map<Id, Long> = emptyMap(),
+        spacesWithPreview: Set<Id> = emptySet()
     ): Long? {
+        val targetSpaceId = space.space.targetSpaceId
         val lastMessageDate = space.lastMessageDate
-            ?: space.space.targetSpaceId?.let { sortKeyFallback[it] }
+            ?: targetSpaceId
+                ?.takeIf { it !in spacesWithPreview }
+                ?.let { sortKeyFallback[it] }
         val spaceJoinDate = space.space.spaceJoinDate?.toLong()
         val createdDate = space.space.getSingleValue<Double>(Relations.CREATED_DATE)?.toLong()
 
@@ -672,7 +730,7 @@ class VaultViewModel(
             // so a chat space keeps the same card type (and height) whether or not its
             // preview has arrived yet — otherwise every chat row would swap card type
             // when Chat.SubscribeToMessagePreviews finally returns.
-            space.chatId != null || chatPreview != null -> {
+            !space.chatId.isNullOrEmpty() || chatPreview != null -> {
                 createDataSpaceWithChatView(space, chatPreview, unreadCounts, chatNames, permissions, wallpapers, participantsByIdentity, accountIdentity)
             }
             // Data space without chat preview → VaultSpaceView.DataSpace

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModel.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModel.kt
@@ -91,6 +91,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
@@ -182,9 +183,12 @@ class VaultViewModel(
     // step, so we know to reopen it when the user presses back on CreateSpace.
     private var didShowSelectMembersForGroupCreation = false
 
+    // NOTE: deliberately NOT filtered to Ready. The vault paints as soon as the
+    // space list is available and enriches with chat previews when they land —
+    // Chat.SubscribeToMessagePreviews can take many seconds on a cold start with
+    // many spaces, and the previous sort order is restored from cache meanwhile.
     private val previewFlow: StateFlow<ChatPreviewContainer.PreviewState> =
         chatPreviewContainer.observePreviewsWithAttachments()
-            .filterIsInstance<ChatPreviewContainer.PreviewState.Ready>() // wait until ready
             .stateIn(
                 viewModelScope,
                 SharingStarted.Eagerly,
@@ -226,6 +230,23 @@ class VaultViewModel(
     // Flow for account identity (used to determine outgoing messages)
     // The Config.id is the account identity used as message creator
     private val accountIdentityFlow: StateFlow<Id?> = MutableStateFlow(configStorage.getAccountId())
+
+    /**
+     * spaceId -> last chat message date (unix seconds) as persisted by the last
+     * session. Used as the sort key for spaces whose chat preview has not arrived
+     * yet, so the cold-start vault paints in the order the user last saw instead
+     * of falling back to join/creation date and then re-shuffling.
+     */
+    private var cachedSortKeys: Map<Id, Long>? = null
+
+    private suspend fun sortKeyFallback(): Map<Id, Long> {
+        cachedSortKeys?.let { return it }
+        val loaded = runCatching { userSettingsRepository.getVaultSortKeys() }
+            .onFailure { Timber.w(it, "Failed to read cached vault sort keys") }
+            .getOrDefault(emptyMap())
+        cachedSortKeys = loaded
+        return loaded
+    }
 
     private val _uiState = MutableStateFlow<VaultUiState>(VaultUiState.Loading)
     val uiState: StateFlow<VaultUiState> = _uiState.asStateFlow()
@@ -280,7 +301,7 @@ class VaultViewModel(
         Timber.i("VaultViewModel - init started")
         combine(
             combine(
-                previewFlow.filterIsInstance<ChatPreviewContainer.PreviewState.Ready>(),
+                previewFlow,
                 spaceFlow,
                 permissionsFlow
             ) { previews, spaces, perms -> Triple(previews, spaces, perms) },
@@ -291,6 +312,16 @@ class VaultViewModel(
                 accountIdentityFlow
             ) { _, chatDetails, participants, accountIdentity -> Triple(chatDetails, participants, accountIdentity) }
         ) { first, second -> first to second }
+            // spaceFlow and the space container are both seeded with an empty list, so
+            // the combine fires once with no spaces before the subscription delivers.
+            // Publishing that seed paints an empty vault — measured on device at up to
+            // ~950ms before the real list replaced it. Hold Loading until real spaces
+            // arrive, or until previews go Ready so a genuinely empty vault still
+            // resolves off the spinner.
+            .filter { (first, _) ->
+                val (previews, spaces, _) = first
+                spaces.isNotEmpty() || previews is ChatPreviewContainer.PreviewState.Ready
+            }
             // Throttle-latest: the very first vault state passes through without delay;
             // afterwards, bursts of upstream events (chat previews, space views,
             // permissions) are coalesced into at most one rebuild per
@@ -305,9 +336,11 @@ class VaultViewModel(
             .map { (first, second) ->
                 val (previews, spaces, perms) = first
                 val (chatDetails, participants, accountIdentity) = second
+                val previewItems =
+                    (previews as? ChatPreviewContainer.PreviewState.Ready)?.items.orEmpty()
                 val sections = transformToVaultSpaceViews(
                     spaces,
-                    previews.items,
+                    previewItems,
                     perms,
                     chatDetails,
                     participants,
@@ -334,6 +367,28 @@ class VaultViewModel(
                     _uiState.value = sections
                 }
             }
+            .launchIn(viewModelScope)
+
+        // Cache the per-space last-message dates so the next cold start can paint the
+        // vault in this order before Chat.SubscribeToMessagePreviews returns.
+        previewFlow
+            .filterIsInstance<ChatPreviewContainer.PreviewState.Ready>()
+            .map { ready ->
+                ready.items
+                    .groupBy { it.space.id }
+                    .mapValues { (_, previews) ->
+                        previews.maxOf { it.message?.createdAt ?: 0L }
+                    }
+                    .filterValues { it > 0L }
+            }
+            .distinctUntilChanged()
+            .debounce(VAULT_SORT_KEY_PERSIST_DEBOUNCE_MS)
+            .onEach { keys ->
+                cachedSortKeys = keys
+                runCatching { userSettingsRepository.setVaultSortKeys(keys) }
+                    .onFailure { Timber.w(it, "Failed to persist vault sort keys") }
+            }
+            .flowOn(Dispatchers.Default)
             .launchIn(viewModelScope)
 
         // Track notification permission status for profile icon badge
@@ -430,6 +485,9 @@ class VaultViewModel(
             Timber.w("Failed to fetch space wallpapers")
             emptyMap()
         }
+
+        // Cached last-message dates, used to order spaces whose preview is still in flight.
+        val sortKeyFallback = sortKeyFallback()
 
         // Index chatPreviews by space.id for O(1) lookup, selecting most recent per space
         val chatPreviewMap = chatPreviews.groupBy { it.space.id }
@@ -534,7 +592,7 @@ class VaultViewModel(
 
         // Sort unpinned spaces by effective date (descending), then by creation date (descending)
         val sortedUnpinnedSpaces = unpinnedSpaces.sortedWith(
-            compareByDescending<VaultSpaceView> { calculateEffectiveDate(it) ?: 0L }
+            compareByDescending<VaultSpaceView> { calculateEffectiveDate(it, sortKeyFallback) ?: 0L }
                 .thenByDescending { it.space.getSingleValue<Double>(Relations.CREATED_DATE) ?: 0.0 }
         )
 
@@ -566,13 +624,21 @@ class VaultViewModel(
 
     /**
      * Calculates the effective date for a space by taking the maximum of lastMessageDate and spaceJoinDate.
+     * When the chat preview has not arrived yet, lastMessageDate falls back to the
+     * value cached from the previous session ([sortKeyFallback]) so the cold-start
+     * order matches what the user last saw.
+     *
      * - If both lastMessageDate and spaceJoinDate are available, return the maximum
      * - If only one is available, return that one
      * - If neither is available, fallback to createdDate
      * - If createdDate is also unavailable, return null
      */
-    private fun calculateEffectiveDate(space: VaultSpaceView): Long? {
+    private fun calculateEffectiveDate(
+        space: VaultSpaceView,
+        sortKeyFallback: Map<Id, Long> = emptyMap()
+    ): Long? {
         val lastMessageDate = space.lastMessageDate
+            ?: space.space.targetSpaceId?.let { sortKeyFallback[it] }
         val spaceJoinDate = space.space.spaceJoinDate?.toLong()
         val createdDate = space.space.getSingleValue<Double>(Relations.CREATED_DATE)?.toLong()
 
@@ -601,8 +667,12 @@ class VaultViewModel(
             space.isOneToOneSpace -> {
                 createOneToOneSpaceView(space, chatPreview, unreadCounts, permissions, wallpapers, chatDetailsMap, participantsByIdentity, accountIdentity)
             }
-            // Data space with chat preview → VaultSpaceView.DataSpaceWithChat
-            chatPreview != null -> {
+            // Data space that HAS a chat → VaultSpaceView.DataSpaceWithChat.
+            // Keyed off the space's own chatId rather than the presence of a preview,
+            // so a chat space keeps the same card type (and height) whether or not its
+            // preview has arrived yet — otherwise every chat row would swap card type
+            // when Chat.SubscribeToMessagePreviews finally returns.
+            space.chatId != null || chatPreview != null -> {
                 createDataSpaceWithChatView(space, chatPreview, unreadCounts, chatNames, permissions, wallpapers, participantsByIdentity, accountIdentity)
             }
             // Data space without chat preview → VaultSpaceView.DataSpace
@@ -726,7 +796,7 @@ class VaultViewModel(
      */
     private suspend fun createDataSpaceWithChatView(
         space: ObjectWrapper.SpaceView,
-        chatPreview: Chat.Preview,
+        chatPreview: Chat.Preview?,
         unreadCounts: UnreadCounts?,
         chatNames: List<String>,
         permissions: Map<Id, SpaceMemberPermissions>,
@@ -761,7 +831,9 @@ class VaultViewModel(
             isOwner = isOwner,
             chatNotificationState = calculateChatNotificationState(
                 chatSpace = space,
-                chatId = chatPreview.chat
+                // Preview may not have arrived yet; the space's own chatId identifies
+                // the same chat. Empty string falls through to the space-level mode.
+                chatId = chatPreview?.chat ?: space.chatId.orEmpty()
             ),
             wallpaper = wallpaperResult,
             spaceNotificationState = space.spacePushNotificationMode,
@@ -1867,6 +1939,7 @@ class VaultViewModel(
 
     companion object {
         private const val VAULT_STATE_THROTTLE_MS = 100L
+        private const val VAULT_SORT_KEY_PERSIST_DEBOUNCE_MS = 1_000L
         private const val OS_WIDGET_SYNC_DEBOUNCE_MS = 2000L
         private const val ONE_TO_ONE_HOMEPAGE_POLL_DELAY_MS = 100L
         private const val ONE_TO_ONE_HOMEPAGE_MAX_ATTEMPTS = 30

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/ui/VaultScreen.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/ui/VaultScreen.kt
@@ -49,6 +49,7 @@ import sh.calvin.reorderable.rememberReorderableLazyListState
 fun VaultScreen(
     profile: AccountProfile,
     uiState: VaultUiState,
+    isEnrichingPreviews: Boolean = false,
     showNotificationBadge: Boolean = false,
     showCreateSpaceBadge: Boolean = false,
     isCompactMode: Boolean = false,
@@ -89,7 +90,7 @@ fun VaultScreen(
         topBar = {
             VaultScreenTopToolbar(
                 profile = profile,
-                isLoading = uiState is VaultUiState.Loading,
+                isLoading = uiState is VaultUiState.Loading || isEnrichingPreviews,
                 searchQuery = searchQuery,
                 showNotificationBadge = showNotificationBadge,
                 showCreateSpaceBadge = showCreateSpaceBadge,

--- a/feature-vault/src/test/java/com/anytypeio/anytype/feature_vault/presentation/VaultCachedSortOrderTest.kt
+++ b/feature-vault/src/test/java/com/anytypeio/anytype/feature_vault/presentation/VaultCachedSortOrderTest.kt
@@ -1,0 +1,245 @@
+package com.anytypeio.anytype.feature_vault.presentation
+
+import app.cash.turbine.test
+import app.cash.turbine.turbineScope
+import com.anytypeio.anytype.core_models.StubSpaceView
+import com.anytypeio.anytype.core_models.multiplayer.SpaceMemberPermissions
+import com.anytypeio.anytype.core_models.multiplayer.SpaceUxType
+import com.anytypeio.anytype.core_utils.notifications.NotificationPermissionManager
+import com.anytypeio.anytype.core_utils.notifications.NotificationPermissionManagerImpl
+import com.anytypeio.anytype.domain.base.Resultat
+import com.anytypeio.anytype.domain.chats.ChatPreviewContainer
+import com.anytypeio.anytype.domain.chats.ChatsDetailsSubscriptionContainer
+import com.anytypeio.anytype.domain.config.UserSettingsRepository
+import com.anytypeio.anytype.domain.multiplayer.ParticipantSubscriptionContainer
+import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
+import com.anytypeio.anytype.domain.multiplayer.UserPermissionProvider
+import com.anytypeio.anytype.domain.resources.StringResourceProvider
+import com.anytypeio.anytype.domain.vault.ShouldShowCreateSpaceBadge
+import com.anytypeio.anytype.domain.wallpaper.GetSpaceWallpapers
+import com.anytypeio.anytype.feature_vault.util.DefaultCoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.whenever
+
+/**
+ * The vault used to block its whole first render on
+ * Chat.SubscribeToMessagePreviews, which was measured at 8.6s on a cold start with
+ * 79 spaces. It now paints from the space list alone and orders the main section
+ * with last-message dates cached from the previous session (DROID-4589).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class VaultCachedSortOrderTest {
+
+    @get:Rule
+    val coroutineTestRule = DefaultCoroutineTestRule()
+
+    private lateinit var spaceViewSubscriptionContainer: SpaceViewSubscriptionContainer
+    private lateinit var chatPreviewContainer: ChatPreviewContainer
+    private lateinit var userPermissionProvider: UserPermissionProvider
+    private lateinit var notificationPermissionManager: NotificationPermissionManager
+    private lateinit var stringResourceProvider: StringResourceProvider
+    private lateinit var getSpaceWallpapers: GetSpaceWallpapers
+    private lateinit var shouldShowCreateSpaceBadge: ShouldShowCreateSpaceBadge
+    private lateinit var participantSubscriptionContainer: ParticipantSubscriptionContainer
+    private lateinit var chatsDetailsSubscriptionContainer: ChatsDetailsSubscriptionContainer
+
+    @Before
+    fun setup() {
+        spaceViewSubscriptionContainer = mock()
+        chatPreviewContainer = mock()
+        userPermissionProvider = mock()
+        notificationPermissionManager = mock()
+        stringResourceProvider = mock()
+        getSpaceWallpapers = mock()
+        shouldShowCreateSpaceBadge = mock()
+        participantSubscriptionContainer = mock()
+        chatsDetailsSubscriptionContainer = mock()
+
+        getSpaceWallpapers.stub {
+            onBlocking { async(Unit) }.thenReturn(Resultat.Success(emptyMap()))
+        }
+        shouldShowCreateSpaceBadge.stub {
+            onBlocking { async(any()) }.thenReturn(Resultat.Success(false))
+        }
+        whenever(participantSubscriptionContainer.observe()).thenReturn(flowOf(emptyList()))
+        whenever(chatsDetailsSubscriptionContainer.observe()).thenReturn(flowOf(emptyList()))
+        whenever(notificationPermissionManager.areNotificationsEnabled()).thenReturn(true)
+        whenever(stringResourceProvider.getUntitledCreatorName()).thenReturn("Untitled")
+        whenever(stringResourceProvider.getSpaceAccessTypeName(any())).thenReturn("Private")
+    }
+
+    @Test
+    fun `renders before previews arrive, ordered by cached last-message dates`() = runTest {
+        turbineScope {
+            // "chatty" was created first but has the most recent message; "quiet" was
+            // created later. Creation order and message-recency order disagree, so the
+            // assertion can only pass if the cached sort keys are used.
+            val chatty = StubSpaceView(
+                id = CHATTY,
+                targetSpaceId = CHATTY,
+                spaceOrder = null,
+                spaceUxType = SpaceUxType.CHAT,
+                createdDate = 1_000.0
+            )
+            val quiet = StubSpaceView(
+                id = QUIET,
+                targetSpaceId = QUIET,
+                spaceOrder = null,
+                spaceUxType = SpaceUxType.CHAT,
+                createdDate = 3_000.0
+            )
+
+            setupSpaces(listOf(quiet, chatty))
+            // Previews never become Ready: this is the cold-start window.
+            whenever(chatPreviewContainer.observePreviewsWithAttachments()).thenReturn(
+                flowOf(ChatPreviewContainer.PreviewState.Loading)
+            )
+
+            val viewModel = createViewModel(
+                cachedSortKeys = mapOf(CHATTY to 9_000L, QUIET to 2_000L)
+            )
+
+            viewModel.uiState.test {
+                skipItems(1) // Loading
+                val sections = awaitItem() as VaultUiState.Sections
+                assertEquals(
+                    "Vault must render without waiting for chat previews",
+                    2,
+                    sections.mainSpaces.size
+                )
+                assertEquals(
+                    "Space with the newest cached message must come first",
+                    listOf(CHATTY, QUIET),
+                    sections.mainSpaces.map { it.space.id }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `falls back to creation date when nothing is cached`() = runTest {
+        turbineScope {
+            val older = StubSpaceView(
+                id = "older",
+                targetSpaceId = "older",
+                spaceOrder = null,
+                spaceUxType = SpaceUxType.DATA,
+                createdDate = 1_000.0
+            )
+            val newer = StubSpaceView(
+                id = "newer",
+                targetSpaceId = "newer",
+                spaceOrder = null,
+                spaceUxType = SpaceUxType.DATA,
+                createdDate = 5_000.0
+            )
+
+            setupSpaces(listOf(older, newer))
+            whenever(chatPreviewContainer.observePreviewsWithAttachments()).thenReturn(
+                flowOf(ChatPreviewContainer.PreviewState.Loading)
+            )
+
+            val viewModel = createViewModel(cachedSortKeys = emptyMap())
+
+            viewModel.uiState.test {
+                skipItems(1) // Loading
+                val sections = awaitItem() as VaultUiState.Sections
+                assertEquals(
+                    listOf("newer", "older"),
+                    sections.mainSpaces.map { it.space.id }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `stays on Loading while the space list is still empty`() = runTest {
+        turbineScope {
+            // Both spaceFlow and the space container are seeded with an empty list.
+            // Publishing that seed painted an empty vault for up to ~950ms on device.
+            whenever(spaceViewSubscriptionContainer.observe()).thenReturn(flowOf(emptyList()))
+            whenever(userPermissionProvider.all()).thenReturn(flowOf(emptyMap()))
+            whenever(notificationPermissionManager.permissionState()).thenReturn(
+                MutableStateFlow(NotificationPermissionManagerImpl.PermissionState.Granted)
+            )
+            whenever(chatPreviewContainer.observePreviewsWithAttachments()).thenReturn(
+                flowOf(ChatPreviewContainer.PreviewState.Loading)
+            )
+
+            val viewModel = createViewModel(cachedSortKeys = emptyMap())
+
+            viewModel.uiState.test {
+                assertEquals(VaultUiState.Loading, awaitItem())
+                expectNoEvents()
+            }
+        }
+    }
+
+    @Test
+    fun `an account with no spaces resolves off the spinner once previews are ready`() = runTest {
+        turbineScope {
+            whenever(spaceViewSubscriptionContainer.observe()).thenReturn(flowOf(emptyList()))
+            whenever(userPermissionProvider.all()).thenReturn(flowOf(emptyMap()))
+            whenever(notificationPermissionManager.permissionState()).thenReturn(
+                MutableStateFlow(NotificationPermissionManagerImpl.PermissionState.Granted)
+            )
+            whenever(chatPreviewContainer.observePreviewsWithAttachments()).thenReturn(
+                flowOf(ChatPreviewContainer.PreviewState.Ready(emptyList()))
+            )
+
+            val viewModel = createViewModel(cachedSortKeys = emptyMap())
+
+            viewModel.uiState.test {
+                skipItems(1) // Loading
+                val sections = awaitItem() as VaultUiState.Sections
+                assertEquals(0, sections.mainSpaces.size)
+                assertEquals(0, sections.pinnedSpaces.size)
+            }
+        }
+    }
+
+    private fun setupSpaces(
+        spaces: List<com.anytypeio.anytype.core_models.ObjectWrapper.SpaceView>
+    ) {
+        val permissions = spaces.associate { it.id to SpaceMemberPermissions.OWNER }
+        whenever(spaceViewSubscriptionContainer.observe()).thenReturn(flowOf(spaces))
+        whenever(userPermissionProvider.all()).thenReturn(flowOf(permissions))
+        whenever(notificationPermissionManager.permissionState()).thenReturn(
+            MutableStateFlow(NotificationPermissionManagerImpl.PermissionState.Granted)
+        )
+    }
+
+    private fun createViewModel(cachedSortKeys: Map<String, Long>): VaultViewModel {
+        val settings: UserSettingsRepository = mock {
+            on { observeCompactModeEnabled() }.thenReturn(flowOf(false))
+            on { observeQuickCaptureEnabled() }.thenReturn(flowOf(false))
+            onBlocking { getVaultSortKeys() }.thenReturn(cachedSortKeys)
+        }
+        return VaultViewModelFabric.create(
+            spaceViewSubscriptionContainer = spaceViewSubscriptionContainer,
+            chatPreviewContainer = chatPreviewContainer,
+            userPermissionProvider = userPermissionProvider,
+            notificationPermissionManager = notificationPermissionManager,
+            stringResourceProvider = stringResourceProvider,
+            getSpaceWallpaper = getSpaceWallpapers,
+            chatsDetailsContainer = chatsDetailsSubscriptionContainer,
+            participantSubscriptionContainer = participantSubscriptionContainer,
+            userSettingsRepository = settings
+        )
+    }
+
+    companion object {
+        private const val CHATTY = "chatty-space"
+        private const val QUIET = "quiet-space"
+    }
+}

--- a/feature-vault/src/test/java/com/anytypeio/anytype/feature_vault/presentation/VaultCachedSortOrderTest.kt
+++ b/feature-vault/src/test/java/com/anytypeio/anytype/feature_vault/presentation/VaultCachedSortOrderTest.kt
@@ -3,6 +3,7 @@ package com.anytypeio.anytype.feature_vault.presentation
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
 import com.anytypeio.anytype.core_models.StubSpaceView
+import com.anytypeio.anytype.core_models.stubChatPreview
 import com.anytypeio.anytype.core_models.multiplayer.SpaceMemberPermissions
 import com.anytypeio.anytype.core_models.multiplayer.SpaceUxType
 import com.anytypeio.anytype.core_utils.notifications.NotificationPermissionManager
@@ -18,11 +19,14 @@ import com.anytypeio.anytype.domain.resources.StringResourceProvider
 import com.anytypeio.anytype.domain.vault.ShouldShowCreateSpaceBadge
 import com.anytypeio.anytype.domain.wallpaper.GetSpaceWallpapers
 import com.anytypeio.anytype.feature_vault.util.DefaultCoroutineTestRule
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -167,8 +171,10 @@ class VaultCachedSortOrderTest {
         turbineScope {
             // Both spaceFlow and the space container are seeded with an empty list.
             // Publishing that seed painted an empty vault for up to ~950ms on device.
-            whenever(spaceViewSubscriptionContainer.observe()).thenReturn(flowOf(emptyList()))
-            whenever(userPermissionProvider.all()).thenReturn(flowOf(emptyMap()))
+            val spaces = MutableStateFlow<List<com.anytypeio.anytype.core_models.ObjectWrapper.SpaceView>>(emptyList())
+            val permissions = MutableStateFlow<Map<String, SpaceMemberPermissions>>(emptyMap())
+            whenever(spaceViewSubscriptionContainer.observe()).thenReturn(spaces)
+            whenever(userPermissionProvider.all()).thenReturn(permissions)
             whenever(notificationPermissionManager.permissionState()).thenReturn(
                 MutableStateFlow(NotificationPermissionManagerImpl.PermissionState.Granted)
             )
@@ -179,8 +185,20 @@ class VaultCachedSortOrderTest {
             val viewModel = createViewModel(cachedSortKeys = emptyMap())
 
             viewModel.uiState.test {
-                assertEquals(VaultUiState.Loading, awaitItem())
-                expectNoEvents()
+                skipItems(1) // Loading
+                spaces.value = listOf(
+                    StubSpaceView(
+                        id = CHATTY, targetSpaceId = CHATTY, spaceOrder = null,
+                        spaceUxType = SpaceUxType.CHAT, createdDate = 1_000.0
+                    )
+                )
+                permissions.value = mapOf(CHATTY to SpaceMemberPermissions.OWNER)
+                val sections = awaitItem() as VaultUiState.Sections
+                assertEquals(
+                    "The first painted frame must never be an empty list",
+                    1,
+                    sections.mainSpaces.size
+                )
             }
         }
     }
@@ -206,6 +224,202 @@ class VaultCachedSortOrderTest {
                 assertEquals(0, sections.pinnedSpaces.size)
             }
         }
+    }
+
+    @Test
+    fun `keeps previews when the container drops back to Loading mid-session`() = runTest {
+        turbineScope {
+            // MainViewModel.onRestore() restarts ChatPreviewContainer on a plain
+            // configuration change, which resets it to Loading while this ViewModel
+            // survives. Treating that as "no previews" blanked every chat row.
+            val space = StubSpaceView(
+                id = CHATTY,
+                targetSpaceId = CHATTY,
+                spaceOrder = null,
+                spaceUxType = SpaceUxType.CHAT,
+                createdDate = 1_000.0
+            )
+            val permissions = MutableStateFlow(
+                mapOf(CHATTY to SpaceMemberPermissions.OWNER)
+            )
+            whenever(spaceViewSubscriptionContainer.observe()).thenReturn(flowOf(listOf(space)))
+            whenever(userPermissionProvider.all()).thenReturn(permissions)
+            whenever(notificationPermissionManager.permissionState()).thenReturn(
+                MutableStateFlow(NotificationPermissionManagerImpl.PermissionState.Granted)
+            )
+
+            val previews = MutableStateFlow<ChatPreviewContainer.PreviewState>(
+                ChatPreviewContainer.PreviewState.Ready(
+                    listOf(stubChatPreview(spaceId = CHATTY, chatId = "chat", lastMessageDate = 9_000L))
+                )
+            )
+            whenever(chatPreviewContainer.observePreviewsWithAttachments()).thenReturn(previews)
+
+            val viewModel = createViewModel(cachedSortKeys = emptyMap())
+
+            viewModel.uiState.test {
+                skipItems(1) // Loading
+                val enriched = awaitItem() as VaultUiState.Sections
+                val before = enriched.mainSpaces.first() as VaultSpaceView.DataSpaceWithChat
+                assertEquals("Hello, user1", before.messageText)
+
+                // Drop to Loading, then force a rebuild from another upstream so the
+                // pipeline definitely re-emits and the assertion cannot pass by timing.
+                previews.value = ChatPreviewContainer.PreviewState.Loading
+                permissions.value = mapOf(CHATTY to SpaceMemberPermissions.READER)
+                val after = awaitItem() as VaultUiState.Sections
+                val row = after.mainSpaces.first() as VaultSpaceView.DataSpaceWithChat
+                assertEquals(
+                    "Rows must keep their message text across a Loading blip",
+                    "Hello, user1",
+                    row.messageText
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `an empty preview list does not wipe the cached order`() = runTest {
+        turbineScope {
+            // ChatPreviewContainer swallows an RPC failure and publishes
+            // Ready(emptyList()), indistinguishable from "account has no chats".
+            val chatty = StubSpaceView(
+                id = CHATTY, targetSpaceId = CHATTY, spaceOrder = null,
+                spaceUxType = SpaceUxType.CHAT, createdDate = 1_000.0
+            )
+            val quiet = StubSpaceView(
+                id = QUIET, targetSpaceId = QUIET, spaceOrder = null,
+                spaceUxType = SpaceUxType.CHAT, createdDate = 3_000.0
+            )
+            val permissions = MutableStateFlow(
+                mapOf(CHATTY to SpaceMemberPermissions.OWNER, QUIET to SpaceMemberPermissions.OWNER)
+            )
+            whenever(spaceViewSubscriptionContainer.observe()).thenReturn(flowOf(listOf(quiet, chatty)))
+            whenever(userPermissionProvider.all()).thenReturn(permissions)
+            whenever(notificationPermissionManager.permissionState()).thenReturn(
+                MutableStateFlow(NotificationPermissionManagerImpl.PermissionState.Granted)
+            )
+            whenever(chatPreviewContainer.observePreviewsWithAttachments()).thenReturn(
+                flowOf(ChatPreviewContainer.PreviewState.Ready(emptyList()))
+            )
+
+            val viewModel = createViewModel(
+                cachedSortKeys = mapOf(CHATTY to 9_000L, QUIET to 2_000L)
+            )
+
+            viewModel.uiState.test {
+                skipItems(1) // Loading
+                val first = awaitItem() as VaultUiState.Sections
+                assertEquals(
+                    "A failed previews RPC must not reshuffle the vault",
+                    listOf(CHATTY, QUIET),
+                    first.mainSpaces.map { it.space.id }
+                )
+                // Let the 1s persist debounce fire, then force a rebuild: if the empty
+                // map were allowed through it would have replaced the in-memory
+                // fallback and this second frame would fall back to createdDate.
+                awaitRealTime(millis = 1_400)
+                permissions.value = mapOf(
+                    CHATTY to SpaceMemberPermissions.READER,
+                    QUIET to SpaceMemberPermissions.OWNER
+                )
+                val second = awaitItem() as VaultUiState.Sections
+                assertEquals(
+                    "The cached order must survive an empty preview list",
+                    listOf(CHATTY, QUIET),
+                    second.mainSpaces.map { it.space.id }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a preview with no message stops using the stale cached date`() = runTest {
+        turbineScope {
+            // The last message in CHATTY was deleted, so its preview carries no
+            // message. The cached date must not keep it pinned near the top.
+            val chatty = StubSpaceView(
+                id = CHATTY, targetSpaceId = CHATTY, spaceOrder = null,
+                spaceUxType = SpaceUxType.CHAT, createdDate = 1_000.0
+            )
+            val quiet = StubSpaceView(
+                id = QUIET, targetSpaceId = QUIET, spaceOrder = null,
+                spaceUxType = SpaceUxType.CHAT, createdDate = 3_000.0
+            )
+            setupSpaces(listOf(chatty, quiet))
+
+            val emptied = stubChatPreview(
+                spaceId = CHATTY, chatId = "chat", lastMessageDate = 0L
+            ).copy(message = null)
+            whenever(chatPreviewContainer.observePreviewsWithAttachments()).thenReturn(
+                flowOf(ChatPreviewContainer.PreviewState.Ready(listOf(emptied)))
+            )
+
+            val viewModel = createViewModel(
+                cachedSortKeys = mapOf(CHATTY to 9_000L)
+            )
+
+            viewModel.uiState.test {
+                skipItems(1) // Loading
+                val sections = awaitItem() as VaultUiState.Sections
+                assertEquals(
+                    "CHATTY has a preview now, so it sorts by createdDate (1000) below QUIET (3000)",
+                    listOf(QUIET, CHATTY),
+                    sections.mainSpaces.map { it.space.id }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `does not render before permissions are known`() = runTest {
+        turbineScope {
+            // isOwner drives whether the space menu offers "Delete space" or "Leave
+            // space", and both confirmations route to the same Space.Delete call. If
+            // the vault paints before permissions land, an owner is shown the leave
+            // wording for an action that destroys the space for every member.
+            // permissionsFlow is derived from the space list, so it always trails it.
+            val space = StubSpaceView(
+                id = CHATTY, targetSpaceId = CHATTY, spaceOrder = null,
+                spaceUxType = SpaceUxType.CHAT, createdDate = 1_000.0
+            )
+            val permissions = MutableStateFlow<Map<String, SpaceMemberPermissions>>(emptyMap())
+            whenever(spaceViewSubscriptionContainer.observe()).thenReturn(flowOf(listOf(space)))
+            whenever(userPermissionProvider.all()).thenReturn(permissions)
+            whenever(notificationPermissionManager.permissionState()).thenReturn(
+                MutableStateFlow(NotificationPermissionManagerImpl.PermissionState.Granted)
+            )
+            whenever(chatPreviewContainer.observePreviewsWithAttachments()).thenReturn(
+                flowOf(ChatPreviewContainer.PreviewState.Loading)
+            )
+
+            val viewModel = createViewModel(cachedSortKeys = emptyMap())
+
+            viewModel.uiState.test {
+                skipItems(1) // Loading
+                // Real elapsed time, not virtual: the rebuild pipeline runs on
+                // Dispatchers.Default, so without this the unguarded ViewModel has no
+                // chance to paint its isOwner=false frame and the test would pass
+                // whether or not the gate is present.
+                awaitRealTime()
+                permissions.value = mapOf(CHATTY to SpaceMemberPermissions.OWNER)
+                val sections = awaitItem() as VaultUiState.Sections
+                assertTrue(
+                    "The first painted frame must already know the user owns this space",
+                    sections.mainSpaces.first().isOwner
+                )
+            }
+        }
+    }
+
+    /**
+     * Blocks for real wall-clock time. `runTest` fast-forwards `delay`, but the vault
+     * rebuild and persist pipelines both run on `Dispatchers.Default`, so a negative
+     * assertion ("no frame was painted yet") needs genuine elapsed time to mean
+     * anything.
+     */
+    private suspend fun awaitRealTime(millis: Long = 600) {
+        withContext(Dispatchers.IO) { Thread.sleep(millis) }
     }
 
     private fun setupSpaces(

--- a/feature-vault/src/test/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModelFabric.kt
+++ b/feature-vault/src/test/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModelFabric.kt
@@ -97,6 +97,7 @@ object VaultViewModelFabric {
         userSettingsRepository: UserSettingsRepository = mock {
             on { observeCompactModeEnabled() }.thenReturn(flowOf(false))
             on { observeQuickCaptureEnabled() }.thenReturn(flowOf(false))
+            onBlocking { getVaultSortKeys() }.thenReturn(emptyMap())
         }
     ): VaultViewModel = VaultViewModel(
         spaceViewSubscriptionContainer = spaceViewSubscriptionContainer,

--- a/persistence/src/main/java/com/anytypeio/anytype/persistence/repo/DefaultUserSettingsCache.kt
+++ b/persistence/src/main/java/com/anytypeio/anytype/persistence/repo/DefaultUserSettingsCache.kt
@@ -860,7 +860,9 @@ class DefaultUserSettingsCache(
                     put(key = spaceId, given.copy(vaultLastMessageDate = date))
                 }
             }
-            SpacePreferences(preferences = result)
+            // copy(), not the constructor: preserves top-level unknown fields written
+            // by a newer build, matching how the rest of this file mutates the store.
+            existingPreferences.copy(preferences = result)
         }
     }
 

--- a/persistence/src/main/java/com/anytypeio/anytype/persistence/repo/DefaultUserSettingsCache.kt
+++ b/persistence/src/main/java/com/anytypeio/anytype/persistence/repo/DefaultUserSettingsCache.kt
@@ -838,6 +838,32 @@ class DefaultUserSettingsCache(
             .toMap()
     }
 
+    override suspend fun getVaultSortKeys(): Map<Id, Long> {
+        val spacePreferences = context.spacePrefsStore.data.first()
+        return spacePreferences.preferences
+            .mapNotNull { (spaceId, spacePref) ->
+                val date = spacePref.vaultLastMessageDate
+                if (date != null && date > 0) spaceId to date else null
+            }
+            .toMap()
+    }
+
+    override suspend fun setVaultSortKeys(keys: Map<Id, Long>) {
+        if (keys.isEmpty()) return
+        context.spacePrefsStore.updateData { existingPreferences ->
+            val result = buildMap {
+                putAll(existingPreferences.preferences)
+                keys.forEach { (spaceId, date) ->
+                    val given = existingPreferences
+                        .preferences
+                        .getOrDefault(key = spaceId, defaultValue = SpacePreference())
+                    put(key = spaceId, given.copy(vaultLastMessageDate = date))
+                }
+            }
+            SpacePreferences(preferences = result)
+        }
+    }
+
     override suspend fun getQuickCaptureEnabled(): Boolean {
         return prefs.getBoolean(QUICK_CAPTURE_ENABLED_KEY, true)
     }

--- a/persistence/src/main/proto/preferences.proto
+++ b/persistence/src/main/proto/preferences.proto
@@ -41,6 +41,10 @@ message SpacePreference {
   optional bool inviteMembersDismissed = 13;
   optional string quickCaptureDraftObjectId = 14;
   optional int64 lastInteractionTimestamp = 15;
+  // Last chat message timestamp (unix seconds) as last observed by the vault.
+  // Cached so the vault can restore its previous sort order on cold start,
+  // before Chat.SubscribeToMessagePreviews returns.
+  optional int64 vaultLastMessageDate = 16;
 }
 
 message GlobalSearchHistoryProto {


### PR DESCRIPTION
Closes DROID-4589

## Problem

On a cold start the vault shows a spinner beside "My Channels" and an empty list before any channel appears. Measured on a Nothing A142 (Android 16), account with 79 spaces / ~106 chats: **8588 ms** from `VaultViewModel` init to the first rendered list.

The whole screen was gated on one call. `VaultViewModel` combines seven flows; six are `stateIn(..., Eagerly, <empty seed>)` and emit instantly. The seventh was filtered:

```kotlin
previewFlow.filterIsInstance<ChatPreviewContainer.PreviewState.Ready>()
```

`Ready` only arrives after `ChatPreviewContainer.start()` completes `Chat.SubscribeToMessagePreviews` — **8618 ms** in the capture, the slowest call in the trace and 2.5x `Account.Select` (3348 ms).

Everything needed to draw the list was already available:

| moment | Δ since VaultViewModel init |
|---|---|
| space list ready (79 spaces) | −83 ms |
| `spaceFlow` delivers 79 spaces to the VM | **+6 ms** |
| `Chat.SubscribeToMessagePreviews` returns | +8400 ms |
| transform (79 spaces × 87 previews) | 173 ms |
| first `Sections` published, spinner off | **+8588 ms** |

8.4 s of waiting, 0.17 s of work.

## Why previews were gating it

They are not decoration — they drive the sort. The main section orders by `calculateEffectiveDate`, whose primary key is `chatPreview.message.createdAt`. Rendering without them falls back to `spaceJoinDate`/`createdDate`, an order uncorrelated with message recency, so every row would jump when previews landed.

## Approach

Cache the sort key so the vault can paint its previous order immediately.

- Persist `spaceId -> last message date` as `SpacePreference.vaultLastMessageDate` (unix seconds), written back debounced once previews go `Ready`.
- Drop the `Ready` gate; render as soon as the space list arrives, enrich when previews land.
- `calculateEffectiveDate` falls back to the cached value before `spaceJoinDate`/`createdDate`.
- Hold `Loading` until real spaces arrive — both `spaceFlow` and the space container are seeded with an empty list, and publishing that seed painted an empty vault for up to **942 ms** on device. Previews going `Ready` also releases the hold, so an account with genuinely no spaces still leaves the spinner.
- Pick the card type from the space's own `chatId` rather than from preview presence, so chat rows keep their type and height instead of swapping when previews arrive.

## Result

Same device, same account:

| | before | after |
|---|---|---|
| first list on screen | 8588 ms | **309 / 355 / 489 ms** (3 cold starts) |
| rows on first paint | 79 | 79 |
| rows that move when previews land | — | **0** |

Order verified by logging the rendered sequence before and after previews arrive

## Not fixed here

The RPC is still slow. `core/block/chats/service.go` `SubscribeToMessagePreviews` fans out over every chat in every space and `wg.Wait()`s for all of them, each needing its space's `crdt.db` opened; it runs against the full eager cold load of all 79 spaces (22x `spacestore db open took too long` at 1.0–1.2 s, 65x `load bundled objects` at 250 ms–1 s). That is a GO-side fix — the vault simply no longer waits for it.

## Review notes

- **Unread badges read 0 and message lines are blank** until previews land (2–8 s depending on heart's cold-load state). This is the deliberate trade for an instant list and wants a design call; it shrinks to near-nothing once the GO-side RPC is fixed.
- `getVaultSortKeys()` is read inside `transformToVaultSpaceViews` and memoized after the first call. It hits the same `spacePrefsStore` DataStore that `getSpaceWallpapers` already reads there, so it costs no extra file read.
- First launch after install has no cache, so that one cold start still paints in creation order and re-sorts once.

## Tests

`VaultCachedSortOrderTest` (4 new): cached order before previews arrive; creation-date fallback with no cache; stays on `Loading` while the space list is empty; empty account still resolves. `feature-vault` 34/34, `:domain` `:data` `:persistence` green.
