### PR TITLE
DROID-4590 Vault | Fix | Expire the last-opened-space route 1 hour after backgrounding

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/di/main/DataModule.kt
+++ b/app/src/main/java/com/anytypeio/anytype/di/main/DataModule.kt
@@ -394,10 +394,12 @@ object DataModule {
     @Singleton
     fun provideAppStateService(
         setAppState: SetAppState,
-        @Named(DEFAULT_APP_COROUTINE_SCOPE) scope: CoroutineScope
+        @Named(DEFAULT_APP_COROUTINE_SCOPE) scope: CoroutineScope,
+        userSettingsRepository: UserSettingsRepository
     ): AppStateService = AppStateService(
         setAppState = setAppState,
-        coroutineScope = scope
+        coroutineScope = scope,
+        settings = userSettingsRepository
     )
 
     @JvmStatic

--- a/data/src/main/java/com/anytypeio/anytype/data/auth/repo/UserSettingsCache.kt
+++ b/data/src/main/java/com/anytypeio/anytype/data/auth/repo/UserSettingsCache.kt
@@ -22,6 +22,9 @@ interface UserSettingsCache {
     suspend fun getCurrentSpace(): SpaceId?
     suspend fun clearCurrentSpace()
 
+    suspend fun setLastBackgroundedAt(timeInSeconds: Long)
+    suspend fun getLastBackgroundedAt(): Long?
+
     suspend fun setDefaultObjectType(space: SpaceId, type: TypeId)
     suspend fun getDefaultObjectType(space: SpaceId): TypeId?
     suspend fun setPinnedObjectTypes(space: SpaceId, types: List<TypeId>)

--- a/data/src/main/java/com/anytypeio/anytype/data/auth/repo/UserSettingsDataRepository.kt
+++ b/data/src/main/java/com/anytypeio/anytype/data/auth/repo/UserSettingsDataRepository.kt
@@ -73,6 +73,11 @@ class UserSettingsDataRepository(private val cache: UserSettingsCache) : UserSet
 
     override suspend fun clearCurrentSpace() = cache.clearCurrentSpace()
 
+    override suspend fun setLastBackgroundedAt(timeInSeconds: Long) =
+        cache.setLastBackgroundedAt(timeInSeconds)
+
+    override suspend fun getLastBackgroundedAt(): Long? = cache.getLastBackgroundedAt()
+
     override suspend fun setLastOpenedObject(id: Id, space: SpaceId) {
         cache.setLastOpenedObject(id, space)
     }

--- a/device/src/main/java/com/anytypeio/anytype/device/AppStateService.kt
+++ b/device/src/main/java/com/anytypeio/anytype/device/AppStateService.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.anytypeio.anytype.core_models.AppState
 import com.anytypeio.anytype.domain.base.fold
+import com.anytypeio.anytype.domain.config.UserSettingsRepository
 import com.anytypeio.anytype.domain.device.SetAppState
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -14,7 +15,9 @@ import timber.log.Timber
 @Singleton
 class AppStateService @Inject constructor(
     private val setAppState: SetAppState,
-    private val coroutineScope: CoroutineScope
+    private val coroutineScope: CoroutineScope,
+    private val settings: UserSettingsRepository,
+    private val clock: () -> Long = { System.currentTimeMillis() / 1000 }
 ) : DefaultLifecycleObserver {
 
     override fun onStart(owner: LifecycleOwner) {
@@ -23,6 +26,20 @@ class AppStateService @Inject constructor(
 
     override fun onStop(owner: LifecycleOwner) {
         handleStateTransition(AppState.BACKGROUND)
+        stampBackgroundedAt()
+    }
+
+    /**
+     * Records when the app went to background so [LaunchAccount] can expire the
+     * "restore into the last opened space" route on the next cold start
+     * (DROID-4590). Best effort: a crash or an OS kill skips this, leaving the
+     * previous stamp, which errs toward expiring — the safe direction.
+     */
+    private fun stampBackgroundedAt() {
+        coroutineScope.launch {
+            runCatching { settings.setLastBackgroundedAt(clock()) }
+                .onFailure { Timber.w(it, "Failed to stamp backgrounded-at") }
+        }
     }
 
     private fun handleStateTransition(state: AppState) {

--- a/device/src/test/java/com/anytypeio/anytype/device/AppStateServiceTest.kt
+++ b/device/src/test/java/com/anytypeio/anytype/device/AppStateServiceTest.kt
@@ -1,0 +1,75 @@
+package com.anytypeio.anytype.device
+
+import androidx.lifecycle.LifecycleOwner
+import com.anytypeio.anytype.domain.config.UserSettingsRepository
+import com.anytypeio.anytype.domain.device.SetAppState
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import com.anytypeio.anytype.domain.base.Resultat
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verifyBlocking
+
+/**
+ * The last-backgrounded stamp is what expires the "restore into the last opened
+ * space" route (DROID-4590). It is written here because this is the app's only
+ * ProcessLifecycleOwner observer.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppStateServiceTest {
+
+    private val owner: LifecycleOwner = mock()
+
+    @Test
+    fun `stamps the time the app went to background`() = runTest {
+        val settings: UserSettingsRepository = mock()
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val service = AppStateService(
+            setAppState = stubbedSetAppState(),
+            coroutineScope = scope,
+            settings = settings,
+            clock = { NOW }
+        )
+
+        service.onStop(owner)
+        advanceUntilIdle()
+
+        verifyBlocking(settings) { setLastBackgroundedAt(NOW) }
+    }
+
+    @Test
+    fun `does not stamp when the app comes to foreground`() = runTest {
+        val settings: UserSettingsRepository = mock()
+        val scope = TestScope(StandardTestDispatcher(testScheduler))
+        val service = AppStateService(
+            setAppState = stubbedSetAppState(),
+            coroutineScope = scope,
+            settings = settings,
+            clock = { NOW }
+        )
+
+        service.onStart(owner)
+        advanceUntilIdle()
+
+        verifyBlocking(settings, never()) { setLastBackgroundedAt(NOW) }
+    }
+
+    /**
+     * onStop also fires SetAppState on the same scope. Left unstubbed it returns
+     * null from the mock and the resulting failure tears down the shared scope
+     * before the stamp coroutine runs.
+     */
+    private fun stubbedSetAppState(): SetAppState = mock {
+        onBlocking { async(any()) } doReturn Resultat.Success(Unit)
+    }
+
+    companion object {
+        private const val NOW = 1_700_000_000L
+    }
+}

--- a/domain/src/main/java/com/anytypeio/anytype/domain/auth/interactor/LaunchAccount.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/auth/interactor/LaunchAccount.kt
@@ -26,10 +26,13 @@ class LaunchAccount @Inject constructor(
     private val settings: UserSettingsRepository,
     private val awaitAccountStartManager: AwaitAccountStartManager,
     private val preferredSpaceIdHolder: PreferredSpaceIdHolder,
-    context: CoroutineContext = Dispatchers.IO
+    context: CoroutineContext = Dispatchers.IO,
+    private val clock: () -> Long = { System.currentTimeMillis() / 1000 }
     ) : BaseUseCase<Pair<String, String>, BaseUseCase.None>(context) {
 
     override suspend fun run(params: None) = safe {
+        expireLastOpenedSpaceRouteIfStale()
+
         repository.setInitialParams(initialParamsProvider.toCommand())
 
         val networkMode = repository.getNetworkMode()
@@ -57,5 +60,32 @@ class LaunchAccount @Inject constructor(
             awaitAccountStartManager.setState(AwaitAccountStartManager.State.Started)
             setup.config.analytics to setup.config.network
         }
+    }
+
+    /**
+     * Drops the stored "last opened space" once it is older than
+     * [LAST_SPACE_ROUTE_TTL_SECONDS], so a user coming back later lands on the vault
+     * instead of wherever they happened to close the app.
+     *
+     * Done here, before the space is read, because three things downstream depend on
+     * it: AccountSelect.preferredSpaceId (heart's lazy-load hint), spaceManager, and
+     * the splash route. Expiring only the route would leave heart deferring every
+     * other space for a space we then never open.
+     *
+     * A missing stamp means a fresh install or an upgrade from a build that never
+     * wrote one — treated as not expired, so updating does not bounce people to the
+     * vault once for no reason. A stamp in the future (clock moved backwards) is
+     * likewise treated as not expired.
+     */
+    private suspend fun expireLastOpenedSpaceRouteIfStale() {
+        val backgroundedAt = settings.getLastBackgroundedAt() ?: return
+        val elapsed = clock() - backgroundedAt
+        if (elapsed > LAST_SPACE_ROUTE_TTL_SECONDS) {
+            settings.clearCurrentSpace()
+        }
+    }
+
+    companion object {
+        const val LAST_SPACE_ROUTE_TTL_SECONDS = 60L * 60L
     }
 }

--- a/domain/src/main/java/com/anytypeio/anytype/domain/config/UserSettingsRepository.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/config/UserSettingsRepository.kt
@@ -22,6 +22,16 @@ interface UserSettingsRepository {
     suspend fun getCurrentSpace(): SpaceId?
     suspend fun clearCurrentSpace()
 
+    /**
+     * Wall-clock seconds at which the app last went to background. Used by
+     * LaunchAccount to expire the "restore into the last opened space" route: come
+     * back more than an hour later and you land on the vault instead. Null when
+     * nothing has been stamped yet (fresh install, or an upgrade from a build
+     * without this), which is treated as not expired.
+     */
+    suspend fun setLastBackgroundedAt(timeInSeconds: Long)
+    suspend fun getLastBackgroundedAt(): Long?
+
     suspend fun setWallpaper(space: Id, wallpaper: Wallpaper)
     suspend fun getWallpaper(space: Id): Wallpaper
     suspend fun getWallpapers(): Map<Id, Wallpaper>

--- a/domain/src/test/java/com/anytypeio/anytype/domain/auth/LaunchAccountTest.kt
+++ b/domain/src/test/java/com/anytypeio/anytype/domain/auth/LaunchAccountTest.kt
@@ -24,10 +24,12 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.never
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -51,9 +53,12 @@ class LaunchAccountTest {
      */
     private class FakeSettings(
         delegate: UserSettingsRepository,
-        private val currentSpace: SpaceId?
+        private var currentSpace: SpaceId?,
+        private val lastBackgroundedAt: Long? = null
     ) : UserSettingsRepository by delegate {
         override suspend fun getCurrentSpace(): SpaceId? = currentSpace
+        override suspend fun clearCurrentSpace() { currentSpace = null }
+        override suspend fun getLastBackgroundedAt(): Long? = lastBackgroundedAt
     }
 
     @Before
@@ -62,7 +67,11 @@ class LaunchAccountTest {
         PreferredSpaceIdHolder.Default.clear()
     }
 
-    private fun launchAccountWith(currentSpace: SpaceId?): LaunchAccount {
+    private fun launchAccountWith(
+        currentSpace: SpaceId?,
+        lastBackgroundedAt: Long? = null,
+        now: Long = NOW
+    ): LaunchAccount {
         val setup = StubAccountSetup()
         repo.stub {
             onBlocking { getNetworkMode() } doReturn NetworkModeConfig(networkMode = NetworkMode.DEFAULT)
@@ -76,10 +85,11 @@ class LaunchAccountTest {
             configStorage = configStorage,
             spaceManager = spaceManager,
             initialParamsProvider = initialParamsProvider,
-            settings = FakeSettings(settingsMock, currentSpace),
+            settings = FakeSettings(settingsMock, currentSpace, lastBackgroundedAt),
             awaitAccountStartManager = awaitAccountStartManager,
             preferredSpaceIdHolder = PreferredSpaceIdHolder.Default,
-            context = rule.dispatcher
+            context = rule.dispatcher,
+            clock = { now }
         )
     }
 
@@ -115,5 +125,88 @@ class LaunchAccountTest {
         launchAccount.run(BaseUseCase.None)
 
         assertEquals(null, capturedCommand().preferredSpaceId)
+    }
+
+    //region last-opened-space route expiry (DROID-4590)
+
+    @Test
+    fun `drops the last opened space when backgrounded more than an hour ago`() = runTest {
+        val launchAccount = launchAccountWith(
+            currentSpace = SpaceId("last-space"),
+            lastBackgroundedAt = NOW - 3601
+        )
+
+        launchAccount.run(BaseUseCase.None)
+
+        assertEquals(null, capturedCommand().preferredSpaceId)
+    }
+
+    @Test
+    fun `does not set the space manager when the route has expired`() = runTest {
+        val launchAccount = launchAccountWith(
+            currentSpace = SpaceId("last-space"),
+            lastBackgroundedAt = NOW - 3601
+        )
+
+        launchAccount.run(BaseUseCase.None)
+
+        verifyBlocking(spaceManager, never()) { set(any(), any()) }
+    }
+
+    @Test
+    fun `keeps the last opened space when backgrounded within the hour`() = runTest {
+        val launchAccount = launchAccountWith(
+            currentSpace = SpaceId("last-space"),
+            lastBackgroundedAt = NOW - 600
+        )
+
+        launchAccount.run(BaseUseCase.None)
+
+        assertEquals("last-space", capturedCommand().preferredSpaceId)
+    }
+
+    @Test
+    fun `keeps the last opened space when nothing was ever stamped`() = runTest {
+        // Fresh install, or an upgrade from a build that never wrote the stamp.
+        val launchAccount = launchAccountWith(
+            currentSpace = SpaceId("last-space"),
+            lastBackgroundedAt = null
+        )
+
+        launchAccount.run(BaseUseCase.None)
+
+        assertEquals("last-space", capturedCommand().preferredSpaceId)
+    }
+
+    @Test
+    fun `keeps the last opened space when the clock moved backwards`() = runTest {
+        val launchAccount = launchAccountWith(
+            currentSpace = SpaceId("last-space"),
+            lastBackgroundedAt = NOW + 9_000
+        )
+
+        launchAccount.run(BaseUseCase.None)
+
+        assertEquals("last-space", capturedCommand().preferredSpaceId)
+    }
+
+    @Test
+    fun `holder still wins when the stored route has expired`() = runTest {
+        // A push or deeplink names its own space; expiry must not discard it.
+        val launchAccount = launchAccountWith(
+            currentSpace = SpaceId("last-space"),
+            lastBackgroundedAt = NOW - 86_400
+        )
+        PreferredSpaceIdHolder.Default.set("push-space")
+
+        launchAccount.run(BaseUseCase.None)
+
+        assertEquals("push-space", capturedCommand().preferredSpaceId)
+    }
+
+    //endregion
+
+    companion object {
+        private const val NOW = 1_700_000_000L
     }
 }

--- a/persistence/src/main/java/com/anytypeio/anytype/persistence/repo/DefaultUserSettingsCache.kt
+++ b/persistence/src/main/java/com/anytypeio/anytype/persistence/repo/DefaultUserSettingsCache.kt
@@ -121,6 +121,17 @@ class DefaultUserSettingsCache(
             .apply()
     }
 
+    override suspend fun setLastBackgroundedAt(timeInSeconds: Long) {
+        prefs.edit()
+            .putLong(LAST_BACKGROUNDED_AT_KEY, timeInSeconds)
+            .apply()
+    }
+
+    override suspend fun getLastBackgroundedAt(): Long? {
+        val value = prefs.getLong(LAST_BACKGROUNDED_AT_KEY, NO_TIMESTAMP)
+        return if (value == NO_TIMESTAMP) null else value
+    }
+
     override suspend fun setDefaultObjectType(space: SpaceId, type: TypeId) {
         val curr = prefs
             .getString(DEFAULT_OBJECT_TYPES_KEY, NO_VALUE)
@@ -1112,6 +1123,8 @@ class DefaultUserSettingsCache(
 
     companion object {
         const val CURRENT_SPACE_KEY = "prefs.user_settings.current_space"
+        const val LAST_BACKGROUNDED_AT_KEY = "prefs.user_settings.last_backgrounded_at"
+        private const val NO_TIMESTAMP = -1L
         const val DEFAULT_OBJECT_TYPE_ID_KEY = "prefs.user_settings.default_object_type.id"
         const val DEFAULT_OBJECT_TYPE_NAME_KEY = "prefs.user_settings.default_object_type.name"
 

--- a/persistence/src/test/java/com/anytypeio/anytype/persistence/UserSettingsCacheTest.kt
+++ b/persistence/src/test/java/com/anytypeio/anytype/persistence/UserSettingsCacheTest.kt
@@ -52,6 +52,39 @@ class UserSettingsCacheTest {
     }
 
     @Test
+    fun `last backgrounded stamp is null until written, then round-trips`() = runTest {
+        // Null is meaningful: LaunchAccount treats "never stamped" as not expired,
+        // so a fresh install or an upgrade does not bounce the user to the vault.
+        val cache = DefaultUserSettingsCache(
+            prefs = defaultPrefs,
+            context = ApplicationProvider.getApplicationContext(),
+            appDefaultDateFormatProvider = dateFormatProvider
+        )
+
+        assertEquals(expected = null, actual = cache.getLastBackgroundedAt())
+
+        cache.setLastBackgroundedAt(1_700_000_000L)
+        assertEquals(expected = 1_700_000_000L, actual = cache.getLastBackgroundedAt())
+
+        cache.setLastBackgroundedAt(1_700_000_500L)
+        assertEquals(expected = 1_700_000_500L, actual = cache.getLastBackgroundedAt())
+    }
+
+    @Test
+    fun `stamping the backgrounded time leaves the current space untouched`() = runTest {
+        val cache = DefaultUserSettingsCache(
+            prefs = defaultPrefs,
+            context = ApplicationProvider.getApplicationContext(),
+            appDefaultDateFormatProvider = dateFormatProvider
+        )
+
+        cache.setCurrentSpace(SpaceId("space-1"))
+        cache.setLastBackgroundedAt(1_700_000_000L)
+
+        assertEquals(expected = SpaceId("space-1"), actual = cache.getCurrentSpace())
+    }
+
+    @Test
     fun `kanban experimental flag defaults to true and round-trips`() = runTest {
         val cache = DefaultUserSettingsCache(
             prefs = defaultPrefs,

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/splash/SplashViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/splash/SplashViewModelTest.kt
@@ -401,6 +401,47 @@ class SplashViewModelTest {
     }
 
     @Test
+    fun `chat push still opens the chat when the last-space route has expired`() = runTest {
+        // DROID-4590: expiring the last-opened-space route must not divert a cold
+        // start from a chat push to the vault. The push branch takes its space and
+        // chat from the payload and never reads the stored space, which is what
+        // makes it safe — this pins that.
+        val response = Resultat.Success(Pair(AuthStatus.AUTHORIZED, Account(id = "id")))
+        val pushSpace = "push-space"
+        val pushChat = "push-chat"
+
+        stubCheckAuthStatus(response)
+        stubLaunchWallet()
+        stubLaunchAccount()
+        stubGetLastOpenedObject()
+
+        // The route has expired, so there is no stored space at all.
+        getLastOpenedSpace.stub {
+            onBlocking { async(Unit) } doReturn Resultat.Success(null)
+        }
+
+        initViewModel()
+
+        spaceManager.stub {
+            onBlocking { set(space = pushSpace) } doReturn Result.success(defaultSpaceConfig)
+        }
+
+        vm.commands.test {
+            assertEquals(SplashViewModel.Command.CheckAppStartIntent, awaitItem())
+
+            vm.onIntentTriggeredByChatPush(space = pushSpace, chat = pushChat)
+
+            assertEquals(
+                expected = SplashViewModel.Command.NavigateToChat(
+                    space = pushSpace,
+                    chat = pushChat
+                ),
+                actual = awaitItem()
+            )
+        }
+    }
+
+    @Test
     fun `should navigate to vault even if chat is available if given space has data ux type`() = runTest {
         // GIVEN
         val deeplink = "test-deeplink"


### PR DESCRIPTION
Closes DROID-4590

## Problem

The app restores you into your last opened space on every cold start, however long ago that was. Come back the next morning and you land in whatever space you happened to close the app in, rather than the vault.

## Behaviour

Open the app within an hour of backgrounding it and you land where you left off. Later than that, you land on the vault.

## Why the check sits in `LaunchAccount`

Three things read the stored space at launch, not one:

| site | use |
|---|---|
| `LaunchAccount.kt:39` | `AccountSelect.preferredSpaceId` — heart's lazy-load hint |
| `LaunchAccount.kt:53` | `spaceManager.set(...)` |
| `SplashViewModel.kt:441` | the actual route |

Expiring only the route would leave `preferredSpaceId` pointing at a space we then never open — heart goes into lazy mode and defers every *other* space while we land on the vault, which is the slow-vault path DROID-4589 just fixed. Clearing the stored space once, before any of the three reads, keeps them consistent.

It is deliberately **not** folded into `getCurrentSpace()`: during a long foreground session the last-backgrounded stamp goes stale, so runtime callers would start getting `null` mid-session.

## Edges

- **Never stamped** — fresh install, or upgrading from a build without this — counts as not expired, so an update doesn't bounce people to the vault once for no reason.
- **Stamp in the future** (clock moved backwards) counts as not expired.
- **Crash or OS kill** skips `onStop`, leaving the previous stamp. That errs toward expiring, which is the safe direction.
- **Push or deeplink** names its own space through `PreferredSpaceIdHolder` and still wins over an expired stored space.
- **Warm resume** doesn't go through splash, so the TTL only ever applies to cold starts.

## Push notifications are unaffected

Cold start from a chat push never reads the stored space. `SplashFragment` → `onIntentTriggeredByChatPush` takes both space and chat from the push payload and sends `NavigateToChat` directly, never touching `proceedWithVaultNavigation`. There's a regression test pinning it — it passes before this change too, so it's a characterization guard rather than a red-green driver: its job is to fail if someone later makes that branch consult the stored space.

## Noticed while verifying, not fixed here

`preferredSpaceIdHolder.set(space)` in `onIntentTriggeredByChatPush` runs *after* `LaunchAccount` has already consumed the holder, so a push cold start sends the **previously** opened space as `preferredSpaceId` — heart lazy-loads the wrong space and defers the one the pushed chat actually lives in. Pre-existing and orthogonal; worth its own issue.

## Tests

Test-first. The two that carry the feature were watched failing for the right reasons before implementing — `expected:<null> but was:<last-space>` and `NeverWantedButInvoked`.

- `LaunchAccountTest` — six cases: expires past the hour, keeps within it, keeps when never stamped, keeps when the clock moved backwards, doesn't set the space manager when expired, holder still wins.
- `AppStateServiceTest` (new) — stamps on background, doesn't stamp on foreground.
- `UserSettingsCacheTest` — null until written then round-trips; stamping leaves the current space untouched.
- `SplashViewModelTest` — push still opens the chat with the route expired.

1875 tests green across `:domain` `:data` `:persistence` `:device` `:presentation`, `:app:assembleDebug` clean.

## Not verified on device

adb lost the phone partway through this session, so this is unit-tested only — no on-device confirmation of the end-to-end cold-start behaviour.

https://claude.ai/code/session_01Rvb9PmwQ7d4YXxRdy3g449