### PR TITLE
DROID-4591 Quick Capture | Improvements to the capture sheet

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/di/feature/ObjectMenuDI.kt
+++ b/app/src/main/java/com/anytypeio/anytype/di/feature/ObjectMenuDI.kt
@@ -35,6 +35,7 @@ import com.anytypeio.anytype.domain.templates.CreateTemplateFromObject
 import com.anytypeio.anytype.domain.widgets.CreateWidget
 import com.anytypeio.anytype.domain.widgets.DeleteWidget
 import com.anytypeio.anytype.domain.workspace.SpaceManager
+import com.anytypeio.anytype.domain.workspace.spaceIdOrNull
 import com.anytypeio.anytype.presentation.analytics.AnalyticSpaceHelperDelegate
 import com.anytypeio.anytype.presentation.common.Action
 import com.anytypeio.anytype.presentation.common.Delegator
@@ -60,6 +61,7 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 
 
 @Subcomponent(modules = [ObjectMenuModuleBase::class, ObjectMenuModule::class])
@@ -208,8 +210,12 @@ object ObjectMenuModule {
         observePersonalFavoriteTargets: ObservePersonalFavoriteTargets,
         userPermissionProvider: UserPermissionProvider
     ): ObjectMenuOptionsProvider {
-        val spaceIdFlow = spaceManager.observe()
-            .map { SpaceId(it.space) }
+        // From the state, not the config flow: a space can be active without a config
+        // (SpaceManager.activate, used by quick capture to skip Workspace.Open), and the
+        // config flow stays silent in that case — which would leave this menu, opened from
+        // the quick-capture sheet, with no space at all.
+        val spaceIdFlow = spaceManager.state()
+            .mapNotNull { it.spaceIdOrNull() }
             .distinctUntilChanged()
         val personalFavoriteTargets = spaceIdFlow.flatMapLatest { space ->
             observePersonalFavoriteTargets(space).map { it.toSet() }
@@ -405,8 +411,12 @@ object ObjectSetMenuModule {
             }
             .distinctUntilChanged()
 
-        val spaceIdFlow = spaceManager.observe()
-            .map { SpaceId(it.space) }
+        // From the state, not the config flow: a space can be active without a config
+        // (SpaceManager.activate, used by quick capture to skip Workspace.Open), and the
+        // config flow stays silent in that case — which would leave this menu, opened from
+        // the quick-capture sheet, with no space at all.
+        val spaceIdFlow = spaceManager.state()
+            .mapNotNull { it.spaceIdOrNull() }
             .distinctUntilChanged()
         val personalFavoriteTargets = spaceIdFlow.flatMapLatest { space ->
             observePersonalFavoriteTargets(space).map { it.toSet() }

--- a/app/src/main/java/com/anytypeio/anytype/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/editor/EditorFragment.kt
@@ -542,11 +542,42 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
     @Inject
     lateinit var factory: EditorViewModelFactory
 
+    /**
+     * Whether the document may be opened before the view is inflated.
+     *
+     * Off by default: this fragment's one-shot collectors (toasts, snacks, navigation) attach
+     * in [onStart], so a screen that opens ahead of them can miss an event from a fast
+     * failure. Screens where the open dominates the time to first content opt in — inflating
+     * this layout costs about as much as the round trip does, and there is no reason for the
+     * two to run one after the other.
+     */
+    protected open val opensDocumentEagerly: Boolean = false
+
+    private var openedDocumentEagerly = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         pickerDelegate.initPicker(ctx)
         setupOnBackPressedDispatcher()
         getEditorSettings()
+        onConfigureViewModel()
+        // A non-null savedInstanceState is a recreation: the view model survived it, and
+        // onStart's own call is the one that belongs there.
+        if (opensDocumentEagerly && savedInstanceState == null) {
+            openDocument()
+            openedDocumentEagerly = true
+        }
+    }
+
+    /**
+     * Runs after injection and before any document open, so a subclass can configure the view
+     * model while that ordering still means something — [EditorViewModel.onStart]'s success
+     * path reads that configuration.
+     */
+    protected open fun onConfigureViewModel() = Unit
+
+    private fun openDocument() {
+        vm.onStart(id = extractDocumentId(), space = space, saveAsLastOpened = saveAsLastOpened())
     }
 
     override fun onStart() {
@@ -610,7 +641,9 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
                 }
             }
         }
-        vm.onStart(id = extractDocumentId(), space = space, saveAsLastOpened = saveAsLastOpened())
+        // Skipped exactly once, when onCreate already opened the document. Every later start
+        // — returning from background, where onStop closed it — opens again as before.
+        if (openedDocumentEagerly) openedDocumentEagerly = false else openDocument()
         super.onStart()
     }
 

--- a/app/src/main/java/com/anytypeio/anytype/ui/quickcapture/EditorQuickCaptureFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/quickcapture/EditorQuickCaptureFragment.kt
@@ -32,8 +32,20 @@ class EditorQuickCaptureFragment : EditorFragment() {
     // would float over the type-selection bar.
     override val showsBottomActionButtons: Boolean = false
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    // The draft's Object.Open is the single longest step in opening the sheet, and inflating
+    // the editor's layout (18 toolbar widgets, 10 ComposeViews) costs about as much again.
+    // Opening from onCreate runs the round trip while that inflation happens, instead of
+    // after it.
+    override val opensDocumentEagerly: Boolean = true
+
+    override fun onConfigureViewModel() {
+        // Before the open, not after: the open's success path branches on quick-capture mode
+        // to focus a restored draft's title (EditorViewModel.onStartFocusing). Enabling it
+        // from onViewCreated was in time only while the open started later still.
         vm.enableQuickCaptureMode()
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.topToolbar.hide()
         binding.recycler.addItemDecoration(firstItemPullUpDecoration)

--- a/app/src/main/java/com/anytypeio/anytype/ui/quickcapture/QuickCaptureFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/quickcapture/QuickCaptureFragment.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.lifecycleScope
 import com.anytypeio.anytype.R
 import com.anytypeio.anytype.core_models.Id
 import com.anytypeio.anytype.core_ui.syncstatus.SpaceSyncStatusScreen
+import com.anytypeio.anytype.core_utils.ext.fixBottomSheetNavigationBarGap
 import com.anytypeio.anytype.core_utils.ext.toast
 import com.anytypeio.anytype.core_utils.ui.BaseBottomSheetFragment
 import com.anytypeio.anytype.core_utils.ui.proceed
@@ -57,6 +58,18 @@ class QuickCaptureFragment : BaseBottomSheetFragment<FragmentQuickCaptureBinding
         super.onViewCreated(view, savedInstanceState)
         skipCollapsed()
         setFullHeightSheet()
+        // Own the status-bar inset instead of leaving it to BottomSheetDialog. Its
+        // EdgeToEdgeCallback pads the sheet by the inset, but it is only constructed on the
+        // first inset dispatch and only applies the padding from a state/slide callback —
+        // which on device landed ~900ms after the sheet was already on screen. Until then
+        // the sheet sits full-height at y=0 with the content under the status bar, and the
+        // padding then drops everything by the inset in one step: that is the open jump.
+        // The pass-through below is what keeps that callback from ever being built (the
+        // behavior itself installs no inset listener here — Widget.Design.BottomSheet.Modal
+        // sets none of the padding/margin inset flags and the peek height is auto).
+        fixBottomSheetNavigationBarGap(applyTopSystemBarInset = false)
+        applyTopInset()
+        binding.root.viewTreeObserver.addOnPreDrawListener(topInsetPreDrawListener)
         // The sheet's own rounded background paints the status-bar inset strip grey
         // (background_secondary). The layout paints its own surface, so drop it and let
         // that strip stay transparent over the dimmed vault.
@@ -98,11 +111,10 @@ class QuickCaptureFragment : BaseBottomSheetFragment<FragmentQuickCaptureBinding
         if (binding.quickCaptureEditorContainer.paddingBottom != covered) {
             binding.quickCaptureEditorContainer.updatePadding(bottom = covered)
         }
-        // frame.top is the status-bar height: keep the sheet surface below it so the strip
-        // above the drag handle stays transparent.
-        if (root.paddingTop != frame.top) {
-            root.updatePadding(top = frame.top)
-        }
+        // Bottom only. The status-bar inset is applied once, up front, and then kept in
+        // step by the insets listener in onViewCreated — driving it from the visible frame
+        // here as well would make it a per-layout output and hand it back the chance to
+        // move after the sheet is on screen.
     }
 
     private val dragCallback = object : BottomSheetBehavior.BottomSheetCallback() {
@@ -164,6 +176,52 @@ class QuickCaptureFragment : BaseBottomSheetFragment<FragmentQuickCaptureBinding
         }
     }
 
+    /**
+     * Runs after layout but before the frame is drawn, so a correction costs a dropped
+     * frame instead of a visible step: returning false here cancels this draw and re-runs
+     * the traversal with the new padding. A post-layout listener could only ever fix the
+     * position one frame *after* it was already shown wrong.
+     */
+    private val topInsetPreDrawListener = ViewTreeObserver.OnPreDrawListener {
+        if (!hasBinding()) return@OnPreDrawListener true
+        applyTopInset()
+    }
+
+    /**
+     * Holds the content below the status bar wherever the sheet itself is: the inset minus
+     * the sheet's own top, which is what BottomSheetDialog's edge-to-edge callback computes.
+     * The sheet passes through both configurations while opening — laid out below the status
+     * bar before the dialog goes edge to edge, at y=0 after — and this puts the content in
+     * the same place in each, so neither transition moves it.
+     *
+     * @return true when the padding already matched and the frame can be drawn as laid out.
+     */
+    private fun applyTopInset(): Boolean {
+        val target = (statusBarInsetTop() - (sheet?.top ?: 0)).coerceAtLeast(0)
+        if (binding.root.paddingTop == target) return true
+        binding.root.updatePadding(top = target)
+        return false
+    }
+
+    /**
+     * The dialog's own window has no insets in onViewCreated (verified on device:
+     * getRootWindowInsets is null there) and waiting for them is the jump this removes, so
+     * seed from the host activity's window — attached already, same status bar. A null means
+     * not attached; a zero is a real answer (the status bar can genuinely be hidden) and is
+     * returned as one. The framework dimension is the last resort.
+     */
+    private fun statusBarInsetTop(): Int {
+        val fromSheet = view?.let { ViewCompat.getRootWindowInsets(it) }
+        if (fromSheet != null) return fromSheet.getInsets(WindowInsetsCompat.Type.statusBars()).top
+        val fromActivity = activity?.window?.decorView
+            ?.let { ViewCompat.getRootWindowInsets(it) }
+        if (fromActivity != null) {
+            return fromActivity.getInsets(WindowInsetsCompat.Type.statusBars()).top
+        }
+        val id = resources.getIdentifier("status_bar_height", "dimen", "android")
+        return if (id > 0) resources.getDimensionPixelSize(id) else 0
+    }
+
     private fun hasBinding(): Boolean = view != null
 
     override fun onDestroyView() {
@@ -172,6 +230,7 @@ class QuickCaptureFragment : BaseBottomSheetFragment<FragmentQuickCaptureBinding
         // recording a boolean is harmless — onCleared does not fire for those.
         vm.onEditorDetached(hasEdits = editor()?.hasEdits() == true)
         binding.root.viewTreeObserver.removeOnGlobalLayoutListener(imeLayoutListener)
+        binding.root.viewTreeObserver.removeOnPreDrawListener(topInsetPreDrawListener)
         sheet?.let { view -> BottomSheetBehavior.from(view).removeBottomSheetCallback(dragCallback) }
         super.onDestroyView()
     }

--- a/app/src/main/java/com/anytypeio/anytype/ui/quickcapture/QuickCaptureFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/quickcapture/QuickCaptureFragment.kt
@@ -87,6 +87,7 @@ class QuickCaptureFragment : BaseBottomSheetFragment<FragmentQuickCaptureBinding
         // instead and pad the editor container, so the editor's bottom-gravity type bar
         // and style toolbar ride the keyboard.
         binding.root.viewTreeObserver.addOnGlobalLayoutListener(imeLayoutListener)
+        binding.root.viewTreeObserver.addOnWindowFocusChangeListener(windowFocusListener)
         // Dismissing with the keyboard up looks broken if the IME collapses only after the
         // sheet has gone: two unsynchronized animations plus a window resize. Retract the
         // IME the instant the drag starts, so it travels with the sheet.
@@ -107,6 +108,12 @@ class QuickCaptureFragment : BaseBottomSheetFragment<FragmentQuickCaptureBinding
         // gesture/navigation bar. Padding by the full amount puts the editor's bottom
         // widgets exactly on the keyboard's top edge, and clear of the gesture bar when
         // the keyboard is down.
+        // Only while this window owns the keyboard. The space picker and the sheet's own
+        // dialogs are separate windows, and when one opens the IME goes with it: the visible
+        // frame then reports the keyboard as gone, which is true of the window in front and
+        // not of the sheet behind it. Acting on that measurement resized the editor by the
+        // keyboard's height under the picker and back again on dismissal — the blink.
+        if (!root.hasWindowFocus()) return@OnGlobalLayoutListener
         val covered = (root.rootView.height - frame.bottom).coerceAtLeast(0)
         if (binding.quickCaptureEditorContainer.paddingBottom != covered) {
             binding.quickCaptureEditorContainer.updatePadding(bottom = covered)
@@ -115,6 +122,20 @@ class QuickCaptureFragment : BaseBottomSheetFragment<FragmentQuickCaptureBinding
         // step by the insets listener in onViewCreated — driving it from the visible frame
         // here as well would make it a per-layout output and hand it back the chance to
         // move after the sheet is on screen.
+    }
+
+    /**
+     * The scrim is a window dim layer, and a window dim belongs to the window in front. While
+     * the space picker (or any of the sheet's dialogs) is up, the window manager composites
+     * this sheet's 0.9 layer above the sheet and the keyboard rather than behind them, and
+     * tearing that front window down flashes the whole app black for a few frames — the
+     * system bars, which are not app windows, stay lit and give the flash away.
+     *
+     * So the sheet only dims while it is the front window. Nothing looks lighter meanwhile:
+     * the picker paints a scrim of its own over everything behind it.
+     */
+    private val windowFocusListener = ViewTreeObserver.OnWindowFocusChangeListener { hasFocus ->
+        applyScrimDim(if (hasFocus) SCRIM_DIM_AMOUNT else 0f)
     }
 
     private val dragCallback = object : BottomSheetBehavior.BottomSheetCallback() {
@@ -231,6 +252,7 @@ class QuickCaptureFragment : BaseBottomSheetFragment<FragmentQuickCaptureBinding
         vm.onEditorDetached(hasEdits = editor()?.hasEdits() == true)
         binding.root.viewTreeObserver.removeOnGlobalLayoutListener(imeLayoutListener)
         binding.root.viewTreeObserver.removeOnPreDrawListener(topInsetPreDrawListener)
+        binding.root.viewTreeObserver.removeOnWindowFocusChangeListener(windowFocusListener)
         sheet?.let { view -> BottomSheetBehavior.from(view).removeBottomSheetCallback(dragCallback) }
         super.onDestroyView()
     }

--- a/app/src/main/java/com/anytypeio/anytype/ui/vault/VaultFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/vault/VaultFragment.kt
@@ -124,6 +124,7 @@ class VaultFragment : BaseComposeFragment() {
                 onSpaceSettings = vm::onSpaceSettingsClicked,
                 onDeleteOrLeaveSpace = vm::onDeleteSpaceClicked,
                 onSearchBarClicked = {
+                    vm.onSearchBarClicked()
                     // safeNavigate: a double tap must not push the screen twice.
                     runCatching {
                         findNavController().safeNavigate(
@@ -135,6 +136,7 @@ class VaultFragment : BaseComposeFragment() {
                         Timber.e(it, "Error opening search from vault")
                     }
                 },
+                showSearchHighlight = vm.showSearchHighlight.collectAsStateWithLifecycle().value,
                 showQuickCaptureFab = vm.showQuickCapture.collectAsStateWithLifecycle().value,
                 onQuickCaptureClicked = vm::onQuickCaptureClicked,
                 quickCaptureSuccess = vm.quickCaptureSuccess.collectAsStateWithLifecycle().value,

--- a/core-ui/src/main/java/com/anytypeio/anytype/core_ui/foundation/BreathingGlow.kt
+++ b/core-ui/src/main/java/com/anytypeio/anytype/core_ui/foundation/BreathingGlow.kt
@@ -1,0 +1,110 @@
+package com.anytypeio.anytype.core_ui.foundation
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.anytypeio.anytype.core_ui.R
+import com.anytypeio.anytype.core_ui.common.DefaultPreviews
+
+/**
+ * A soft halo that breathes around a rounded element to pull the eye to it once,
+ * the way Material's feature-discovery pattern pulses a tap target.
+ *
+ * The halo is a stack of rounded-rect strokes fanning outward from the element's
+ * edge, each fainter than the last, whose alpha rises and falls on an infinite
+ * reverse tween. Stacked strokes rather than a blur mask so the look is identical
+ * on every API level and needs no offscreen layer. Drawn outside the element's
+ * bounds, so the caller must leave [spread] of room around it.
+ *
+ * When [visible] is false the modifier is a no-op: no animation is started, so an
+ * already-dismissed hint costs nothing per frame.
+ */
+@Composable
+fun Modifier.breathingGlow(
+    visible: Boolean,
+    cornerRadius: Dp,
+    color: Color = colorResource(id = R.color.color_accent),
+    spread: Dp = 8.dp
+): Modifier {
+    if (!visible) return this
+
+    val transition = rememberInfiniteTransition(label = "breathing glow")
+    val breath by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = BREATH_MILLIS, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "breathing glow alpha"
+    )
+
+    return this.drawBehind {
+        val spreadPx = spread.toPx()
+        val radiusPx = cornerRadius.toPx()
+        // The halo fades with distance from the edge; the whole stack fades with
+        // the breath. A thin, brighter line sits right on the edge so the field
+        // reads as outlined even at the bottom of the breath.
+        for (layer in 0 until LAYERS) {
+            val fraction = (layer + 1f) / LAYERS
+            val inset = spreadPx * fraction
+            val alpha = MAX_EDGE_ALPHA * (1f - fraction) * (MIN_BREATH + (1f - MIN_BREATH) * breath)
+            drawRoundRect(
+                color = color.copy(alpha = alpha),
+                topLeft = Offset(-inset, -inset),
+                size = Size(size.width + inset * 2, size.height + inset * 2),
+                cornerRadius = CornerRadius(radiusPx + inset),
+                style = Stroke(width = spreadPx / LAYERS * 2)
+            )
+        }
+        drawRoundRect(
+            color = color.copy(alpha = OUTLINE_ALPHA * (MIN_BREATH + (1f - MIN_BREATH) * breath)),
+            cornerRadius = CornerRadius(radiusPx),
+            style = Stroke(width = OUTLINE_WIDTH.toPx())
+        )
+    }
+}
+
+private const val BREATH_MILLIS = 1100
+private const val LAYERS = 6
+private const val MAX_EDGE_ALPHA = 0.35f
+private const val OUTLINE_ALPHA = 0.9f
+private const val MIN_BREATH = 0.15f
+private val OUTLINE_WIDTH = 1.5.dp
+
+@DefaultPreviews
+@Composable
+private fun BreathingGlowPreview() {
+    Box(
+        modifier = Modifier
+            .padding(24.dp)
+            .fillMaxWidth()
+            .height(40.dp)
+            .breathingGlow(visible = true, cornerRadius = 10.dp)
+            .background(
+                color = colorResource(id = R.color.shape_transparent),
+                shape = RoundedCornerShape(10.dp)
+            )
+    )
+}

--- a/data/src/main/java/com/anytypeio/anytype/data/auth/repo/UserSettingsCache.kt
+++ b/data/src/main/java/com/anytypeio/anytype/data/auth/repo/UserSettingsCache.kt
@@ -67,6 +67,8 @@ interface UserSettingsCache {
     suspend fun setHasShownSpacesIntroduction(hasShown: Boolean)
     suspend fun getHasSeenCreateSpaceBadge(): Boolean
     suspend fun setHasSeenCreateSpaceBadge(hasSeen: Boolean)
+    suspend fun getHasSeenVaultSearchHighlight(): Boolean
+    suspend fun setHasSeenVaultSearchHighlight(hasSeen: Boolean)
 
     suspend fun getRunProfilerOnStartup(): Boolean
     suspend fun setRunProfilerOnStartup(enabled: Boolean)

--- a/data/src/main/java/com/anytypeio/anytype/data/auth/repo/UserSettingsDataRepository.kt
+++ b/data/src/main/java/com/anytypeio/anytype/data/auth/repo/UserSettingsDataRepository.kt
@@ -175,6 +175,14 @@ class UserSettingsDataRepository(private val cache: UserSettingsCache) : UserSet
         cache.setHasSeenCreateSpaceBadge(hasSeen)
     }
 
+    override suspend fun getHasSeenVaultSearchHighlight(): Boolean {
+        return cache.getHasSeenVaultSearchHighlight()
+    }
+
+    override suspend fun setHasSeenVaultSearchHighlight(hasSeen: Boolean) {
+        cache.setHasSeenVaultSearchHighlight(hasSeen)
+    }
+
     override suspend fun getRunProfilerOnStartup(): Boolean {
         return cache.getRunProfilerOnStartup()
     }

--- a/domain/src/main/java/com/anytypeio/anytype/domain/config/UserSettingsRepository.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/config/UserSettingsRepository.kt
@@ -80,6 +80,15 @@ interface UserSettingsRepository {
     suspend fun getHasSeenCreateSpaceBadge(): Boolean
     suspend fun setHasSeenCreateSpaceBadge(hasSeen: Boolean)
 
+    /**
+     * One-time attention glow on the vault search bar, pointing existing users at
+     * the search now that it covers every space. Device-wide, like the create-space
+     * badge. Set on the first tap, or pre-set at splash when there is no account on
+     * the device yet so fresh installs never see it.
+     */
+    suspend fun getHasSeenVaultSearchHighlight(): Boolean
+    suspend fun setHasSeenVaultSearchHighlight(hasSeen: Boolean)
+
     suspend fun getRunProfilerOnStartup(): Boolean
     suspend fun setRunProfilerOnStartup(enabled: Boolean)
 

--- a/domain/src/main/java/com/anytypeio/anytype/domain/search/HasInstanceOfObjectTypeSubscriptionManager.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/search/HasInstanceOfObjectTypeSubscriptionManager.kt
@@ -3,9 +3,11 @@ package com.anytypeio.anytype.domain.search
 import com.anytypeio.anytype.core_models.primitives.SpaceId
 import com.anytypeio.anytype.domain.subscriptions.GlobalSubscription
 import com.anytypeio.anytype.domain.workspace.SpaceManager
+import com.anytypeio.anytype.domain.workspace.spaceIdOrNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
@@ -27,13 +29,19 @@ class HasInstanceOfObjectTypeSubscriptionManager(
     fun onStart() {
         job?.cancel()
         job = scope.launch {
-            spaceManager.state().collect { state ->
+            spaceManager.state()
+                .distinctUntilChangedBy { state -> state.spaceIdOrNull() }
+                .collect { state ->
                 when (state) {
                     is SpaceManager.State.Space.Active -> {
                         // Active space: start observing type instances
                         container.start(space = SpaceId(state.config.space))
                     }
-                    is SpaceManager.State.Space.Idle,
+                    is SpaceManager.State.Space.Idle -> {
+                        // A space activated without Workspace.Open (quick capture): active
+                        // for every purpose this subscription has, which is the space id.
+                        container.start(space = state.space)
+                    }
                     is SpaceManager.State.NoSpace -> {
                         // No active space: stop observing
                         container.stop()

--- a/domain/src/main/java/com/anytypeio/anytype/domain/search/ObjectTypesSubscriptionManager.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/search/ObjectTypesSubscriptionManager.kt
@@ -8,11 +8,13 @@ import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.core_models.primitives.SpaceId
 import com.anytypeio.anytype.domain.subscriptions.GlobalSubscription
 import com.anytypeio.anytype.domain.workspace.SpaceManager
+import com.anytypeio.anytype.domain.workspace.spaceIdOrNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
@@ -25,16 +27,18 @@ class ObjectTypesSubscriptionManager (
 ): GlobalSubscription {
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val pipeline get() = spaceManager.state().flatMapLatest { state ->
+    val pipeline get() = spaceManager.state()
+        .distinctUntilChangedBy { state -> state.spaceIdOrNull() }
+        .flatMapLatest { state ->
         when(state) {
             is SpaceManager.State.Space.Active -> {
-                val params = buildParams(state.config)
+                val params = buildParams(SpaceId(state.config.space))
                 container.observe(params)
             }
             is SpaceManager.State.Space.Idle -> {
-                flow {
-                    emit(ObjectTypesSubscriptionContainer.Index.empty())
-                }
+                // A space activated without Workspace.Open (quick capture). The params below
+                // are built from the space id alone, so there is nothing a config would add.
+                container.observe(buildParams(state.space))
             }
             is SpaceManager.State.NoSpace -> {
                 flow {
@@ -66,9 +70,11 @@ class ObjectTypesSubscriptionManager (
     }
 
     companion object {
-        fun buildParams(config: Config) =
+        fun buildParams(config: Config) = buildParams(SpaceId(config.space))
+
+        fun buildParams(space: SpaceId) =
             ObjectTypesSubscriptionContainer.Params(
-                space = SpaceId(config.space),
+                space = space,
                 subscription = ObjectTypesSubscriptionContainer.SUBSCRIPTION_ID,
                 filters = listOf(
                     DVFilter(

--- a/domain/src/main/java/com/anytypeio/anytype/domain/search/RelationOptionsSubscriptionManager.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/search/RelationOptionsSubscriptionManager.kt
@@ -11,11 +11,13 @@ import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.core_models.primitives.SpaceId
 import com.anytypeio.anytype.domain.subscriptions.GlobalSubscription
 import com.anytypeio.anytype.domain.workspace.SpaceManager
+import com.anytypeio.anytype.domain.workspace.spaceIdOrNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
@@ -26,16 +28,18 @@ class RelationOptionsSubscriptionManager(
     private val spaceManager: SpaceManager
 ) : GlobalSubscription {
 
-    val pipeline get() = spaceManager.state().flatMapLatest { state ->
+    val pipeline get() = spaceManager.state()
+        .distinctUntilChangedBy { state -> state.spaceIdOrNull() }
+        .flatMapLatest { state ->
         when (state) {
             is SpaceManager.State.Space.Active -> {
-                val params = buildParams(state.config)
+                val params = buildParams(SpaceId(state.config.space))
                 container.observe(params)
             }
             is SpaceManager.State.Space.Idle -> {
-                flow {
-                    emit(RelationOptionsSubscriptionContainer.Index.empty())
-                }
+                // A space activated without Workspace.Open (quick capture). The params below
+                // are built from the space id alone, so there is nothing a config would add.
+                container.observe(buildParams(state.space))
             }
             is SpaceManager.State.NoSpace -> {
                 flow {
@@ -67,9 +71,11 @@ class RelationOptionsSubscriptionManager(
     }
 
     companion object {
-        fun buildParams(config: Config) =
+        fun buildParams(config: Config) = buildParams(SpaceId(config.space))
+
+        fun buildParams(space: SpaceId) =
             RelationOptionsSubscriptionContainer.Params(
-                space = SpaceId(config.space),
+                space = space,
                 subscription = RelationOptionsSubscriptionContainer.SUBSCRIPTION_ID,
                 filters = listOf(
                     DVFilter(

--- a/domain/src/main/java/com/anytypeio/anytype/domain/search/RelationsSubscriptionManager.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/search/RelationsSubscriptionManager.kt
@@ -9,12 +9,14 @@ import com.anytypeio.anytype.core_models.Relations
 import com.anytypeio.anytype.core_models.primitives.SpaceId
 import com.anytypeio.anytype.domain.subscriptions.GlobalSubscription
 import com.anytypeio.anytype.domain.workspace.SpaceManager
+import com.anytypeio.anytype.domain.workspace.spaceIdOrNull
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
@@ -25,7 +27,9 @@ class RelationsSubscriptionManager @Inject constructor(
     private val container: RelationsSubscriptionContainer,
     private val spaceManager: SpaceManager
 ): GlobalSubscription {
-    val pipeline get() = spaceManager.state().flatMapLatest { state ->
+    val pipeline get() = spaceManager.state()
+        .distinctUntilChangedBy { state -> state.spaceIdOrNull() }
+        .flatMapLatest { state ->
         when(state) {
             is SpaceManager.State.Space.Active -> {
                 // DROID-2916 TODO provide other spaces or add new subscription
@@ -35,9 +39,9 @@ class RelationsSubscriptionManager @Inject constructor(
                 container.observe(params)
             }
             is SpaceManager.State.Space.Idle -> {
-                flow {
-                    emit(RelationsSubscriptionContainer.Index.empty())
-                }
+                // A space activated without Workspace.Open (quick capture). The params below
+                // are built from the space id alone, so there is nothing a config would add.
+                container.observe(buildParams(space = state.space))
             }
             is SpaceManager.State.NoSpace -> {
                 flow {

--- a/domain/src/main/java/com/anytypeio/anytype/domain/vault/SetVaultSearchHighlightSeen.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/vault/SetVaultSearchHighlightSeen.kt
@@ -1,0 +1,25 @@
+package com.anytypeio.anytype.domain.vault
+
+import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
+import com.anytypeio.anytype.domain.base.ResultInteractor
+import com.anytypeio.anytype.domain.config.UserSettingsRepository
+import javax.inject.Inject
+
+/**
+ * Marks the one-time vault search glow as seen, device-wide.
+ *
+ * Called from two places:
+ * - the vault, when the user taps the highlighted search bar;
+ * - the splash, when it finds no account on the device. A fresh install has never
+ *   seen the vault, so the cross-space search is not new to them and the glow is
+ *   pre-dismissed before they ever reach the vault.
+ */
+class SetVaultSearchHighlightSeen @Inject constructor(
+    private val settings: UserSettingsRepository,
+    dispatchers: AppCoroutineDispatchers
+) : ResultInteractor<Unit, Unit>(dispatchers.io) {
+
+    override suspend fun doWork(params: Unit) {
+        settings.setHasSeenVaultSearchHighlight(true)
+    }
+}

--- a/domain/src/main/java/com/anytypeio/anytype/domain/workspace/WorkspaceManager.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/workspace/WorkspaceManager.kt
@@ -10,6 +10,8 @@ import javax.inject.Inject
 import kotlin.math.log
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.withContext
@@ -21,6 +23,20 @@ interface SpaceManager {
 
     suspend fun get(): Id
     suspend fun set(space: Id, withChat: Boolean = false): Result<Config>
+
+    /**
+     * Points the app's space-scoped subscriptions (types, relations, relation options, sync
+     * status) at [space] without opening the workspace, leaving the manager in
+     * [State.Space.Idle] — active, config unknown.
+     *
+     * Workspace.Open exists to produce a [Config], and on a cold space it is expensive:
+     * measured at ~5s on device, against ~1.2s for the Object.Create that follows it. Every
+     * subscription built off the active space needs nothing from that config but the space
+     * id, and Object.Create/Object.Open carry the space themselves — so a screen that only
+     * writes an object into a space (quick capture) can activate it and skip the open. Use
+     * [set] wherever the config itself is needed: widgets, home, tech space, profile.
+     */
+    fun activate(space: Id)
 
     fun getConfig(): Config?
     fun getConfig(space: SpaceId) : Config?
@@ -38,7 +54,14 @@ interface SpaceManager {
     ) : SpaceManager {
 
         private val currentSpace = MutableStateFlow(NO_SPACE)
-        private val info = mutableMapOf<Id, Config>()
+
+        /**
+         * A flow rather than a plain map because a config can arrive for a space that is
+         * already the current one — a full [set] after a lightweight [activate]. With a map,
+         * [state] and [observe] are driven by [currentSpace] alone, which does not change in
+         * that case, so both would stay stuck on the id-only reading forever.
+         */
+        private val configs = MutableStateFlow<Map<Id, Config>>(emptyMap())
 
         override suspend fun get(): Id {
             val curr = currentSpace.value
@@ -51,14 +74,21 @@ interface SpaceManager {
         override fun getConfig(): Config? {
             val curr = currentSpace.value
             return if (curr.isNotEmpty()) {
-                info[curr]
+                configs.value[curr]
             } else {
                 null
             }
         }
 
         override fun getConfig(space: SpaceId): Config? {
-            return info[space.id]
+            return configs.value[space.id]
+        }
+
+        override fun activate(space: Id) {
+            logger.logInfo("SPACE MANAGER: activating space without workspace open: $space")
+            // Deliberately does not touch [configs]: a config this space already has (opened
+            // earlier in the session) stays valid and keeps the state Active.
+            currentSpace.value = space
         }
 
         override suspend fun set(space: Id, withChat: Boolean) : Result<Config> = withContext(dispatchers.io) {
@@ -67,7 +97,7 @@ interface SpaceManager {
                 result.fold(
                     onSuccess = { config ->
                         logger.logInfo("SPACE MANAGER: space opened: $space")
-                        info[space] = config
+                        configs.value = configs.value + (space to config)
                         currentSpace.value = space
                     },
                     onFailure = { error ->
@@ -84,52 +114,37 @@ interface SpaceManager {
         }
 
         override fun observe(): Flow<Config> {
-            return currentSpace.mapNotNull { space ->
-                if (space.isEmpty()) {
-                    null
-                } else {
-                    info[space]
-                }
-            }
+            return combine(currentSpace, configs) { space, known ->
+                if (space.isEmpty()) null else known[space]
+            }.filterNotNull()
         }
 
         override fun observe(space: SpaceId): Flow<Config> {
-            return currentSpace.mapNotNull {
-                info[space.id]
-            }
+            return combine(currentSpace, configs) { _, known ->
+                known[space.id]
+            }.filterNotNull()
         }
 
         override fun state(): Flow<State> {
-            return currentSpace.map { space ->
-                if (space == NO_SPACE) {
-                    State.NoSpace
-                } else {
-                    val config = info[space]
-                    if (config != null) {
-                        State.Space.Active(config)
-                    } else {
-                        State.Space.Idle(SpaceId(space))
-                    }
-                }
+            return combine(currentSpace, configs) { space, known ->
+                stateOf(space, known)
             }
         }
 
-        override fun getState(): State {
-            val space = currentSpace.value
-            return if (space == NO_SPACE) {
-                State.NoSpace
+        override fun getState(): State = stateOf(currentSpace.value, configs.value)
+
+        private fun stateOf(space: Id, known: Map<Id, Config>): State {
+            if (space == NO_SPACE) return State.NoSpace
+            val config = known[space]
+            return if (config != null) {
+                State.Space.Active(config)
             } else {
-                val config = info[space]
-                if (config != null) {
-                    State.Space.Active(config)
-                } else {
-                    State.Space.Idle(SpaceId(space))
-                }
+                State.Space.Idle(SpaceId(space))
             }
         }
 
         override fun clear() {
-            info.clear()
+            configs.value = emptyMap()
             currentSpace.value = NO_SPACE
         }
 
@@ -151,6 +166,20 @@ interface SpaceManager {
             data class Active(val config: Config): Space()
         }
     }
+}
+
+/**
+ * The space the state points at, or null when there is none to follow.
+ *
+ * [SpaceManager.State.Space.Active] and [SpaceManager.State.Space.Idle] answer with the same
+ * id on purpose: subscriptions are built from the id alone, so a config arriving after an
+ * [SpaceManager.activate] must not restart them.
+ */
+fun SpaceManager.State.spaceIdOrNull(): SpaceId? = when (this) {
+    is SpaceManager.State.Space.Active -> SpaceId(config.space)
+    is SpaceManager.State.Space.Idle -> space
+    is SpaceManager.State.NoSpace -> null
+    is SpaceManager.State.Init -> null
 }
 
 @Deprecated("Do not use.")

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModel.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModel.kt
@@ -65,6 +65,7 @@ import com.anytypeio.anytype.domain.spaces.SetHomepage
 import com.anytypeio.anytype.domain.spaces.SaveCurrentSpace
 import com.anytypeio.anytype.domain.vault.SetCreateSpaceBadgeSeen
 import com.anytypeio.anytype.domain.vault.SetSpaceOrder
+import com.anytypeio.anytype.domain.vault.SetVaultSearchHighlightSeen
 import com.anytypeio.anytype.domain.vault.ShouldShowCreateSpaceBadge
 import com.anytypeio.anytype.domain.vault.UnpinSpace
 import com.anytypeio.anytype.domain.wallpaper.GetSpaceWallpapers
@@ -140,6 +141,7 @@ class VaultViewModel(
     private val getSpaceWallpapers: GetSpaceWallpapers,
     private val shouldShowCreateSpaceBadge: ShouldShowCreateSpaceBadge,
     private val setCreateSpaceBadgeSeen: SetCreateSpaceBadgeSeen,
+    private val setVaultSearchHighlightSeen: SetVaultSearchHighlightSeen,
     private val appInfo: AppInfo,
     private val searchOneToOneChatByIdentity: SearchOneToOneChatByIdentity,
     private val createSpace: CreateSpace,
@@ -169,6 +171,14 @@ class VaultViewModel(
 
     // Track whether to show the blue dot badge on "Create a new space" button
     val showCreateSpaceBadge = MutableStateFlow(false)
+
+    /**
+     * One-time breathing glow on the search bar that points existing users at the
+     * search now that it covers every space. Splash pre-marks it as seen when the
+     * device has no account, so only users who upgraded into this build see it.
+     * Hidden, and persisted as seen, on the first tap.
+     */
+    val showSearchHighlight = MutableStateFlow(false)
 
     val isLocalOnly: Boolean
         get() = networkModeProvider.get().networkMode == NetworkMode.LOCAL
@@ -473,6 +483,15 @@ class VaultViewModel(
                     showCreateSpaceBadge.value = false
                 }
             )
+        }
+
+        viewModelScope.launch {
+            showSearchHighlight.value = runCatching {
+                !userSettingsRepository.getHasSeenVaultSearchHighlight()
+            }.getOrElse { e ->
+                Timber.w(e, "Error checking vault search highlight visibility")
+                false
+            }
         }
 
         // Sync spaces to OS home screen widget (debounced to avoid excessive updates)
@@ -1096,6 +1115,18 @@ class VaultViewModel(
                 showCreateSpaceBadge.value = false
                 Timber.d("Create space badge dismissed")
             }
+        }
+    }
+
+    fun onSearchBarClicked() {
+        if (!showSearchHighlight.value) return
+        // Hide first so a slow write never leaves the glow up behind the search screen.
+        showSearchHighlight.value = false
+        viewModelScope.launch {
+            setVaultSearchHighlightSeen.async(Unit).fold(
+                onSuccess = { Timber.d("Vault search highlight marked as seen") },
+                onFailure = { e -> Timber.w(e, "Error marking vault search highlight as seen") }
+            )
         }
     }
 

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModelFactory.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModelFactory.kt
@@ -31,6 +31,7 @@ import com.anytypeio.anytype.domain.spaces.SaveCurrentSpace
 import com.anytypeio.anytype.domain.spaces.SetHomepage
 import com.anytypeio.anytype.domain.vault.SetCreateSpaceBadgeSeen
 import com.anytypeio.anytype.domain.vault.SetSpaceOrder
+import com.anytypeio.anytype.domain.vault.SetVaultSearchHighlightSeen
 import com.anytypeio.anytype.domain.vault.ShouldShowCreateSpaceBadge
 import com.anytypeio.anytype.domain.vault.UnpinSpace
 import com.anytypeio.anytype.domain.wallpaper.GetSpaceWallpapers
@@ -69,6 +70,7 @@ class VaultViewModelFactory @Inject constructor(
     private val getSpaceWallpapers: GetSpaceWallpapers,
     private val shouldShowCreateSpaceBadge: ShouldShowCreateSpaceBadge,
     private val setCreateSpaceBadgeSeen: SetCreateSpaceBadgeSeen,
+    private val setVaultSearchHighlightSeen: SetVaultSearchHighlightSeen,
     private val appInfo: AppInfo,
     private val searchOneToOneChatByIdentity: SearchOneToOneChatByIdentity,
     private val createSpace: CreateSpace,
@@ -112,6 +114,7 @@ class VaultViewModelFactory @Inject constructor(
         getSpaceWallpapers = getSpaceWallpapers,
         shouldShowCreateSpaceBadge = shouldShowCreateSpaceBadge,
         setCreateSpaceBadgeSeen = setCreateSpaceBadgeSeen,
+        setVaultSearchHighlightSeen = setVaultSearchHighlightSeen,
         appInfo = appInfo,
         searchOneToOneChatByIdentity = searchOneToOneChatByIdentity,
         createSpace = createSpace,

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/ui/VaultScreen.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/ui/VaultScreen.kt
@@ -72,6 +72,7 @@ fun VaultScreen(
     onSpaceSettings: (Id) -> Unit,
     onDeleteOrLeaveSpace: (Id, Boolean) -> Unit,
     onSearchBarClicked: (() -> Unit)? = null,
+    showSearchHighlight: Boolean = false,
     showQuickCaptureFab: Boolean = false,
     onQuickCaptureClicked: () -> Unit = {},
     quickCaptureSuccess: VaultViewModel.QuickCaptureSuccess? = null,
@@ -105,7 +106,8 @@ fun VaultScreen(
                 onUpdateSearchQuery = { query ->
                     searchQuery = query
                 },
-                onSearchBarClicked = onSearchBarClicked
+                onSearchBarClicked = onSearchBarClicked,
+                showSearchHighlight = showSearchHighlight
             )
         },
         floatingActionButton = {

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/ui/VaultScreenToolbar.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/ui/VaultScreenToolbar.kt
@@ -35,6 +35,7 @@ import com.anytypeio.anytype.core_models.ui.AccountProfile
 import com.anytypeio.anytype.core_models.ui.ObjectIcon.Profile.Avatar
 import com.anytypeio.anytype.core_models.ui.ProfileIconView
 import com.anytypeio.anytype.core_ui.foundation.DefaultSearchBar
+import com.anytypeio.anytype.core_ui.foundation.breathingGlow
 import com.anytypeio.anytype.core_ui.foundation.noRippleThrottledClickable
 import com.anytypeio.anytype.core_ui.views.Title1
 import com.anytypeio.anytype.core_ui.widgets.ListWidgetObjectIcon
@@ -56,7 +57,8 @@ fun VaultScreenTopToolbar(
     onJoinViaQrClicked: () -> Unit,
     onCreateChannelMenuDismissed: () -> Unit,
     onSettingsClicked: () -> Unit,
-    onSearchBarClicked: (() -> Unit)? = null
+    onSearchBarClicked: (() -> Unit)? = null,
+    showSearchHighlight: Boolean = false
 ) {
     Column(
         modifier = Modifier
@@ -77,43 +79,47 @@ fun VaultScreenTopToolbar(
             onSettingsClicked = onSettingsClicked,
             isLoading = isLoading
         )
-        if (isLoading) {
-            Spacer(
+        // The bar is on screen from the first frame. It needs nothing from the
+        // space list, and hiding it while previews load (seconds on a cold
+        // start) read as the field being missing.
+        if (onSearchBarClicked != null) {
+            // The bar is a pure entry point into the unified search
+            // surface — tapping it opens search v2 instead of filtering
+            // the space cards in place.
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(60.dp)
-            )
-        } else {
-            if (onSearchBarClicked != null) {
-                // The bar is a pure entry point into the unified search
-                // surface — tapping it opens search v2 instead of filtering
-                // the space cards in place.
+                    .padding(horizontal = 16.dp, vertical = 10.dp)
+            ) {
+                DefaultSearchBar(
+                    value = "",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        // One-time hint for existing users, started once the
+                        // vault has settled so it doesn't compete with the
+                        // loading spinner. The halo draws outside the bar, into
+                        // the 10dp vertical padding above.
+                        .breathingGlow(
+                            visible = showSearchHighlight && !isLoading,
+                            cornerRadius = 10.dp
+                        ),
+                    hint = R.string.vault_search_hint,
+                    onQueryChanged = {}
+                )
                 Box(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 10.dp)
-                ) {
-                    DefaultSearchBar(
-                        value = "",
-                        modifier = Modifier.fillMaxWidth(),
-                        hint = R.string.vault_search_hint,
-                        onQueryChanged = {}
-                    )
-                    Box(
-                        modifier = Modifier
-                            .matchParentSize()
-                            .noRippleThrottledClickable { onSearchBarClicked() }
-                    )
-                }
-            } else {
-                DefaultSearchBar(
-                    value = searchQuery,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 10.dp),
-                    onQueryChanged = onUpdateSearchQuery
+                        .matchParentSize()
+                        .noRippleThrottledClickable { onSearchBarClicked() }
                 )
             }
+        } else {
+            DefaultSearchBar(
+                value = searchQuery,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 10.dp),
+                onQueryChanged = onUpdateSearchQuery
+            )
         }
     }
 }

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/ui/VaultScreenToolbar.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/ui/VaultScreenToolbar.kt
@@ -96,6 +96,7 @@ fun VaultScreenTopToolbar(
                     DefaultSearchBar(
                         value = "",
                         modifier = Modifier.fillMaxWidth(),
+                        hint = R.string.vault_search_hint,
                         onQueryChanged = {}
                     )
                     Box(

--- a/feature-vault/src/test/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModelFabric.kt
+++ b/feature-vault/src/test/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModelFabric.kt
@@ -30,6 +30,7 @@ import com.anytypeio.anytype.domain.spaces.SetHomepage
 import com.anytypeio.anytype.domain.spaces.SaveCurrentSpace
 import com.anytypeio.anytype.domain.vault.SetCreateSpaceBadgeSeen
 import com.anytypeio.anytype.domain.vault.SetSpaceOrder
+import com.anytypeio.anytype.domain.vault.SetVaultSearchHighlightSeen
 import com.anytypeio.anytype.domain.vault.ShouldShowCreateSpaceBadge
 import com.anytypeio.anytype.domain.vault.UnpinSpace
 import com.anytypeio.anytype.domain.wallpaper.GetSpaceWallpapers
@@ -78,6 +79,7 @@ object VaultViewModelFabric {
             on { runBlocking { async(any()) } }.thenReturn(com.anytypeio.anytype.domain.base.Resultat.Success(false))
         },
         setCreateSpaceBadgeSeen: SetCreateSpaceBadgeSeen = mock(),
+        setVaultSearchHighlightSeen: SetVaultSearchHighlightSeen = mock(),
         appInfo: AppInfo = mock {
             on { versionName }.thenReturn("1.0.0-test")
         },
@@ -125,6 +127,7 @@ object VaultViewModelFabric {
         getSpaceWallpapers = getSpaceWallpaper,
         shouldShowCreateSpaceBadge = shouldShowCreateSpaceBadge,
         setCreateSpaceBadgeSeen = setCreateSpaceBadgeSeen,
+        setVaultSearchHighlightSeen = setVaultSearchHighlightSeen,
         appInfo = appInfo,
         participantContainer = participantSubscriptionContainer,
         searchOneToOneChatByIdentity = searchOneToOneChatByIdentity,

--- a/feature-vault/src/test/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModelTest.kt
+++ b/feature-vault/src/test/java/com/anytypeio/anytype/feature_vault/presentation/VaultViewModelTest.kt
@@ -23,7 +23,9 @@ import com.anytypeio.anytype.domain.multiplayer.ParticipantSubscriptionContainer
 import com.anytypeio.anytype.domain.multiplayer.SpaceViewSubscriptionContainer
 import com.anytypeio.anytype.domain.multiplayer.UserPermissionProvider
 import com.anytypeio.anytype.domain.resources.StringResourceProvider
+import com.anytypeio.anytype.domain.config.UserSettingsRepository
 import com.anytypeio.anytype.domain.vault.SetCreateSpaceBadgeSeen
+import com.anytypeio.anytype.domain.vault.SetVaultSearchHighlightSeen
 import com.anytypeio.anytype.domain.vault.SetSpaceOrder
 import com.anytypeio.anytype.domain.vault.ShouldShowCreateSpaceBadge
 import com.anytypeio.anytype.domain.vault.UnpinSpace
@@ -35,6 +37,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -42,6 +45,9 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -2046,6 +2052,98 @@ class VaultViewModelTest {
                 assertEquals(0, spaceView.unreadMentionCount)
             }
         }
+    }
+
+    //endregion
+
+    //region Search highlight
+
+    private fun stubSettings(hasSeenSearchHighlight: Boolean): UserSettingsRepository = mock {
+        on { observeCompactModeEnabled() }.thenReturn(flowOf(false))
+        on { observeQuickCaptureEnabled() }.thenReturn(flowOf(false))
+        onBlocking { getVaultSortKeys() }.thenReturn(emptyMap())
+        onBlocking { getHasSeenVaultSearchHighlight() }.thenReturn(hasSeenSearchHighlight)
+    }
+
+    private fun createViewModelForSearchHighlight(
+        settings: UserSettingsRepository,
+        setVaultSearchHighlightSeen: SetVaultSearchHighlightSeen
+    ): VaultViewModel {
+        whenever(spaceViewSubscriptionContainer.observe()).thenReturn(flowOf(emptyList()))
+        whenever(chatPreviewContainer.observePreviewsWithAttachments()).thenReturn(
+            flowOf(ChatPreviewContainer.PreviewState.Ready(emptyList()))
+        )
+        whenever(userPermissionProvider.all()).thenReturn(flowOf(emptyMap()))
+        whenever(notificationPermissionManager.permissionState()).thenReturn(
+            MutableStateFlow(NotificationPermissionManagerImpl.PermissionState.Granted)
+        )
+        return VaultViewModelFabric.create(
+            spaceViewSubscriptionContainer = spaceViewSubscriptionContainer,
+            chatPreviewContainer = chatPreviewContainer,
+            userPermissionProvider = userPermissionProvider,
+            notificationPermissionManager = notificationPermissionManager,
+            getSpaceWallpaper = getSpaceWallpapers,
+            chatsDetailsContainer = chatsDetailsSubscriptionContainer,
+            participantSubscriptionContainer = participantSubscriptionContainer,
+            userSettingsRepository = settings,
+            setVaultSearchHighlightSeen = setVaultSearchHighlightSeen
+        )
+    }
+
+    @Test
+    fun `search highlight is shown while it has not been seen`() = runTest {
+        val viewModel = createViewModelForSearchHighlight(
+            settings = stubSettings(hasSeenSearchHighlight = false),
+            setVaultSearchHighlightSeen = mock()
+        )
+        advanceUntilIdle()
+
+        assertTrue(viewModel.showSearchHighlight.value)
+    }
+
+    @Test
+    fun `search highlight stays hidden once it has been seen`() = runTest {
+        val viewModel = createViewModelForSearchHighlight(
+            settings = stubSettings(hasSeenSearchHighlight = true),
+            setVaultSearchHighlightSeen = mock()
+        )
+        advanceUntilIdle()
+
+        assertFalse(viewModel.showSearchHighlight.value)
+    }
+
+    @Test
+    fun `tapping the highlighted search bar hides the highlight and persists it as seen`() = runTest {
+        val setSeen = mock<SetVaultSearchHighlightSeen> {
+            onBlocking { async(Unit) }.thenReturn(Resultat.Success(Unit))
+        }
+        val viewModel = createViewModelForSearchHighlight(
+            settings = stubSettings(hasSeenSearchHighlight = false),
+            setVaultSearchHighlightSeen = setSeen
+        )
+        advanceUntilIdle()
+        assertTrue(viewModel.showSearchHighlight.value)
+
+        viewModel.onSearchBarClicked()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.showSearchHighlight.value)
+        verify(setSeen, times(1)).async(Unit)
+    }
+
+    @Test
+    fun `tapping the search bar without a highlight does not touch settings`() = runTest {
+        val setSeen = mock<SetVaultSearchHighlightSeen>()
+        val viewModel = createViewModelForSearchHighlight(
+            settings = stubSettings(hasSeenSearchHighlight = true),
+            setVaultSearchHighlightSeen = setSeen
+        )
+        advanceUntilIdle()
+
+        viewModel.onSearchBarClicked()
+        advanceUntilIdle()
+
+        verifyNoInteractions(setSeen)
     }
 
     //endregion

--- a/localization/src/main/res/values/strings.xml
+++ b/localization/src/main/res/values/strings.xml
@@ -2034,7 +2034,7 @@
     <string name="version_history_error_get_members">Error getting members</string>
     <string name="new_object">New object</string>
     <string name="vault_my_spaces">My Channels</string>
-    <string name="vault_search_hint">Search and filter objects, messages</string>
+    <string name="vault_search_hint">Search everything</string>
     <string name="vault_unread_section_title">Unread</string>
     <string name="vault_all_section_title">All</string>
     <string name="vault_pinned_section_title">Pinned</string>

--- a/localization/src/main/res/values/strings.xml
+++ b/localization/src/main/res/values/strings.xml
@@ -2034,6 +2034,7 @@
     <string name="version_history_error_get_members">Error getting members</string>
     <string name="new_object">New object</string>
     <string name="vault_my_spaces">My Channels</string>
+    <string name="vault_search_hint">Search and filter objects, messages</string>
     <string name="vault_unread_section_title">Unread</string>
     <string name="vault_all_section_title">All</string>
     <string name="vault_pinned_section_title">Pinned</string>

--- a/persistence/src/main/java/com/anytypeio/anytype/persistence/repo/DefaultUserSettingsCache.kt
+++ b/persistence/src/main/java/com/anytypeio/anytype/persistence/repo/DefaultUserSettingsCache.kt
@@ -925,6 +925,16 @@ class DefaultUserSettingsCache(
             .apply()
     }
 
+    override suspend fun getHasSeenVaultSearchHighlight(): Boolean {
+        return prefs.getBoolean(HAS_SEEN_VAULT_SEARCH_HIGHLIGHT_KEY, false)
+    }
+
+    override suspend fun setHasSeenVaultSearchHighlight(hasSeen: Boolean) {
+        prefs.edit()
+            .putBoolean(HAS_SEEN_VAULT_SEARCH_HIGHLIGHT_KEY, hasSeen)
+            .apply()
+    }
+
     override suspend fun getRunProfilerOnStartup(): Boolean {
         return prefs.getBoolean(RUN_PROFILER_ON_STARTUP_KEY, false)
     }
@@ -1141,6 +1151,7 @@ class DefaultUserSettingsCache(
 
         const val HAS_SHOWN_SPACES_INTRODUCTION_KEY = "prefs.device.has_shown_spaces_introduction"
         const val HAS_SEEN_CREATE_SPACE_BADGE_KEY = "prefs.device.has_seen_create_space_badge"
+        const val HAS_SEEN_VAULT_SEARCH_HIGHLIGHT_KEY = "prefs.device.has_seen_vault_search_highlight"
         const val RUN_PROFILER_ON_STARTUP_KEY = "prefs.device.run_profiler_on_startup"
         const val DEBUG_MENU_ENABLED_KEY = "prefs.device.debug_menu_enabled"
         const val COMPACT_MODE_ENABLED_KEY = "prefs.device.compact_mode_enabled"

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/quickcapture/QuickCaptureViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/quickcapture/QuickCaptureViewModel.kt
@@ -213,7 +213,7 @@ class QuickCaptureViewModel(
         draftSpaces
     ) { all, permissions, selected, recencyMap, drafts ->
         all.filter { view -> view.isEditable(permissions) }
-            .sortedWith(spaceComparator(recencyMap))
+            .sortedWith(pickerComparator(recencyMap = recencyMap, drafts = drafts))
             .map { view ->
                 SpaceView(
                     space = view,
@@ -506,6 +506,22 @@ class QuickCaptureViewModel(
      * top — 1:1 conversations always sort last — and uses device-local capture recency
      * where the vault uses chat-message recency.
      */
+    /**
+     * Picker order: a space already holding an unsent draft comes first, whatever it is —
+     * a 1:1 space included. An unfinished thought is the strongest statement of where the
+     * user is going next, and the pencil beside it explains why the row is at the top.
+     *
+     * Deliberately not [spaceComparator], which orders auto-selection on open: opening the
+     * sheet into a different space because a draft happens to live there would take the
+     * choice away, which is why the draft is signalled rather than followed (handoff §3).
+     */
+    private fun pickerComparator(
+        recencyMap: Map<Id, Long>,
+        drafts: Set<Id>
+    ): Comparator<ObjectWrapper.SpaceView> =
+        compareByDescending<ObjectWrapper.SpaceView> { view -> view.targetSpaceId in drafts }
+            .then(spaceComparator(recencyMap))
+
     private fun spaceComparator(
         recencyMap: Map<Id, Long>
     ): Comparator<ObjectWrapper.SpaceView> {

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/quickcapture/QuickCaptureViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/quickcapture/QuickCaptureViewModel.kt
@@ -521,27 +521,27 @@ class QuickCaptureViewModel(
     }
 
     /**
-     * Activates the target space (workspaceOpen + store swap; no navigation, no
-     * SaveCurrentSpace) and ensures its draft. [preValidatedDraft], when given, was already
-     * checked by [resolveInitialSpace] — skip the duplicate lookup.
+     * Activates the target space and ensures its draft.
+     *
+     * Activation points the app's space-scoped subscriptions (types, relations, relation
+     * options, sync status) at the space WITHOUT Workspace.Open. That open is what the sheet
+     * used to wait on, and on a cold space it cost ~5s of the ~6.7s between tapping the
+     * pencil and seeing the draft (measured on device) — all of it for a config the capture
+     * path never reads. Object.Create and Object.Open carry the space id themselves, and
+     * every subscription here is built from that id alone.
+     *
+     * [preValidatedDraft], when given, was already checked by [resolveInitialSpace] — skip
+     * the duplicate lookup.
      */
     private suspend fun proceedWithSpace(space: SpaceId, preValidatedDraft: Id? = null) {
         screenState.value = ScreenState.Loading
-        spaceManager.set(space.id).fold(
-            onFailure = {
-                Timber.e(it, "Quick capture: could not open space ${space.id}")
-                sendToast(SOMETHING_WENT_WRONG)
-                _commands.send(Command.Dismiss())
-            },
-            onSuccess = {
-                markSelectedSpace(space)
-                if (preValidatedDraft != null) {
-                    screenState.value = ScreenState.Ready(space = space, draft = preValidatedDraft)
-                } else {
-                    ensureDraft(space)
-                }
-            }
-        )
+        spaceManager.activate(space.id)
+        markSelectedSpace(space)
+        if (preValidatedDraft != null) {
+            screenState.value = ScreenState.Ready(space = space, draft = preValidatedDraft)
+        } else {
+            ensureDraft(space)
+        }
     }
 
     private suspend fun ensureDraft(space: SpaceId) {
@@ -556,7 +556,10 @@ class QuickCaptureViewModel(
                 // another device) or it named something else.
                 runCatching { settings.setQuickCaptureDraft(space = space, obj = existing) }
                     .onFailure { Timber.w(it, "Quick capture: could not point at draft") }
-                refreshDraftSpaces()
+                // Not awaited: this is the cross-space query, and it only feeds the picker's
+                // pencils. Awaiting it put a second full discovery pass (~640ms cold,
+                // measured) between the draft being known and the sheet showing it.
+                viewModelScope.launch { refreshDraftSpaces() }
             }
             screenState.value = ScreenState.Ready(space = space, draft = existing)
             return
@@ -766,49 +769,44 @@ class QuickCaptureViewModel(
             proceedWithSpace(SpaceId(target))
             return
         }
-        spaceManager.set(target).fold(
-            onFailure = {
-                Timber.e(it, "Quick capture: could not open space $target")
-                sendToast(SOMETHING_WENT_WRONG)
-            },
-            onSuccess = {
-                markSelectedSpace(SpaceId(target))
-                when {
-                    mode == SwitchMode.DISCARD_CURRENT -> {
-                        // Loading detaches the editor first. Without it the editor stays bound
-                        // to the object about to be deleted, still firing text writes at it,
-                        // and the re-entrancy guard above stays disarmed for the whole round
-                        // trip. Same reason the other branches take it.
-                        screenState.value = ScreenState.Loading
-                        discardDraft(current)
-                        ensureDraft(SpaceId(target))
-                    }
-                    // The current draft stays put; the target opens its own. Still detach:
-                    // the type/relation stores have already switched space beneath it.
-                    mode == SwitchMode.KEEP_CURRENT -> {
-                        // No cleanup here: the user was asked and said keep. This branch is
-                        // only reachable with a source the editor reported as non-empty, so
-                        // deleting on a second opinion could only ever contradict them.
-                        screenState.value = ScreenState.Loading
-                        ensureDraft(SpaceId(target))
-                    }
-                    isSourceDraftEmpty() -> {
-                        // Nothing typed — just open/create the target space's own draft.
-                        // The source's cleanup is fired and forgotten: it is a different
-                        // object, and awaiting a read + delete + cross-space refresh would
-                        // hold the sheet on Loading for no benefit to the user.
-                        screenState.value = ScreenState.Loading
-                        deleteSourceIfEmpty(current)
-                        ensureDraft(SpaceId(target))
-                    }
-                    else -> {
-                        // Includes the "subscription hasn't confirmed emptiness yet" case:
-                        // moving a possibly-empty draft is harmless, dropping typed text is not.
-                        retargetDraft(from = current, to = SpaceId(target))
-                    }
-                }
+        // Same activation as the open path: no Workspace.Open, so switching into a space
+        // this session has not touched costs a store re-point rather than a cold space load.
+        spaceManager.activate(target)
+        markSelectedSpace(SpaceId(target))
+        when {
+            mode == SwitchMode.DISCARD_CURRENT -> {
+                // Loading detaches the editor first. Without it the editor stays bound
+                // to the object about to be deleted, still firing text writes at it,
+                // and the re-entrancy guard above stays disarmed for the whole round
+                // trip. Same reason the other branches take it.
+                screenState.value = ScreenState.Loading
+                discardDraft(current)
+                ensureDraft(SpaceId(target))
             }
-        )
+            // The current draft stays put; the target opens its own. Still detach:
+            // the type/relation stores have already switched space beneath it.
+            mode == SwitchMode.KEEP_CURRENT -> {
+                // No cleanup here: the user was asked and said keep. This branch is
+                // only reachable with a source the editor reported as non-empty, so
+                // deleting on a second opinion could only ever contradict them.
+                screenState.value = ScreenState.Loading
+                ensureDraft(SpaceId(target))
+            }
+            isSourceDraftEmpty() -> {
+                // Nothing typed — just open/create the target space's own draft.
+                // The source's cleanup is fired and forgotten: it is a different
+                // object, and awaiting a read + delete + cross-space refresh would
+                // hold the sheet on Loading for no benefit to the user.
+                screenState.value = ScreenState.Loading
+                deleteSourceIfEmpty(current)
+                ensureDraft(SpaceId(target))
+            }
+            else -> {
+                // Includes the "subscription hasn't confirmed emptiness yet" case:
+                // moving a possibly-empty draft is harmless, dropping typed text is not.
+                retargetDraft(from = current, to = SpaceId(target))
+            }
+        }
     }
 
     /**
@@ -892,12 +890,12 @@ class QuickCaptureViewModel(
                     // would destroy a real, published note.
                     //
                     // isDisposableDraft re-establishes the FULL precondition here, now that
-                    // the target space is actually open: still an unpublished draft, and
+                    // the target space is the active one: still an unpublished draft, and
                     // empty. Checking only "does it still exist" would trust the emptiness
-                    // decision taken back in onSpaceSelected — which ran before
-                    // spaceManager.set(), against a possibly stale index, and which treats a
-                    // failed fetch as "no content". A single transient error there would
-                    // otherwise land here as a permanent delete of someone's note.
+                    // decision taken back in onSpaceSelected — which ran before the space was
+                    // activated, against a possibly stale index, and which treats a failed
+                    // fetch as "no content". A single transient error there would otherwise
+                    // land here as a permanent delete of someone's note.
                     if (replaced != null && replaced != newDraft) {
                         if (isDisposableDraft(space = to, draft = replaced)) {
                             deleteObjects.async(DeleteObjects.Params(listOf(replaced))).fold(
@@ -920,15 +918,10 @@ class QuickCaptureViewModel(
                 sendToast(SOMETHING_WENT_WRONG)
                 // Fall back to the original draft — the thought is never lost.
                 markSelectedSpace(from.space)
-                spaceManager.set(from.space.id).fold(
-                    onSuccess = { screenState.value = from },
-                    onFailure = { error ->
-                        // Cannot restore a coherent editor (stores belong to another space) —
-                        // close the sheet; the draft and its pointer are intact.
-                        Timber.e(error, "Quick capture: could not re-open source space")
-                        _commands.send(Command.Dismiss())
-                    }
-                )
+                // Re-point the stores at the space the draft never left. Activation cannot
+                // fail, so the rollback no longer has a rollback of its own.
+                spaceManager.activate(from.space.id)
+                screenState.value = from
             }
         )
     }
@@ -1086,7 +1079,7 @@ class QuickCaptureViewModel(
     /**
      * Real teardown only (dismiss, back, navigation away) — NOT config changes, which
      * recreate the view but retain this VM. viewModelScope is already cancelled here, so
-     * no in-flight `spaceManager.set()` can resurrect the space after this clear; the
+     * no in-flight space activation can resurrect the space after this clear; the
      * draft ids-subscription is closed by [draftDetails]' onCompletion. The draft itself
      * (with its pointer) is kept — it restores on the next pencil tap.
      */

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/splash/SplashViewModel.kt
@@ -38,6 +38,7 @@ import com.anytypeio.anytype.domain.search.SearchObjects
 import com.anytypeio.anytype.domain.page.CreateObjectByTypeAndTemplate
 import com.anytypeio.anytype.domain.spaces.GetLastOpenedSpace
 import com.anytypeio.anytype.domain.subscriptions.GlobalSubscriptionManager
+import com.anytypeio.anytype.domain.vault.SetVaultSearchHighlightSeen
 import com.anytypeio.anytype.domain.workspace.SpaceManager
 import com.anytypeio.anytype.presentation.analytics.AnalyticSpaceHelperDelegate
 import com.anytypeio.anytype.presentation.auth.account.MigrationHelperDelegate
@@ -80,7 +81,8 @@ class SplashViewModel(
     private val deepLinkResolver: DeepLinkResolver,
     private val pendingIntentStore: PendingIntentStore,
     private val searchObjects: SearchObjects,
-    private val preferredSpaceIdHolder: PreferredSpaceIdHolder
+    private val preferredSpaceIdHolder: PreferredSpaceIdHolder,
+    private val setVaultSearchHighlightSeen: SetVaultSearchHighlightSeen
 ) : ViewModel(),
     AnalyticSpaceHelperDelegate by analyticSpaceHelperDelegate,
     MigrationHelperDelegate by migration {
@@ -164,11 +166,26 @@ class SplashViewModel(
                 onSuccess = { (status, account) ->
                     Timber.i("Authorization status: $status")
                     if (status == AuthStatus.UNAUTHORIZED) {
+                        markVaultSearchHighlightSeen()
                         commandsChannel.send(Command.NavigateToAuthStart)
                     } else {
                         proceedWithLaunchingWallet()
                     }
                 }
+            )
+        }
+    }
+
+    /**
+     * No account on this device means the user has never seen the vault, so its
+     * cross-space search is not new to them: pre-dismiss the one-time search glow.
+     * Anyone who arrives here already signed in is exactly who the glow is for.
+     */
+    private fun markVaultSearchHighlightSeen() {
+        viewModelScope.launch {
+            setVaultSearchHighlightSeen.async(Unit).fold(
+                onSuccess = { Timber.d("Vault search highlight pre-dismissed for a fresh install") },
+                onFailure = { e -> Timber.w(e, "Error pre-dismissing vault search highlight") }
             )
         }
     }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/splash/SplashViewModelFactory.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/splash/SplashViewModelFactory.kt
@@ -17,6 +17,7 @@ import com.anytypeio.anytype.domain.search.SearchObjects
 import com.anytypeio.anytype.domain.page.CreateObjectByTypeAndTemplate
 import com.anytypeio.anytype.domain.spaces.GetLastOpenedSpace
 import com.anytypeio.anytype.domain.subscriptions.GlobalSubscriptionManager
+import com.anytypeio.anytype.domain.vault.SetVaultSearchHighlightSeen
 import com.anytypeio.anytype.domain.workspace.SpaceManager
 import com.anytypeio.anytype.presentation.analytics.AnalyticSpaceHelperDelegate
 import com.anytypeio.anytype.presentation.auth.account.MigrationHelperDelegate
@@ -45,7 +46,8 @@ class SplashViewModelFactory @Inject constructor(
     private val deepLinkResolver: DeepLinkResolver,
     private val pendingIntentStore: PendingIntentStore,
     private val searchObjects: SearchObjects,
-    private val preferredSpaceIdHolder: PreferredSpaceIdHolder
+    private val preferredSpaceIdHolder: PreferredSpaceIdHolder,
+    private val setVaultSearchHighlightSeen: SetVaultSearchHighlightSeen
 ) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
@@ -68,6 +70,7 @@ class SplashViewModelFactory @Inject constructor(
             deepLinkResolver = deepLinkResolver,
             pendingIntentStore = pendingIntentStore,
             searchObjects = searchObjects,
-            preferredSpaceIdHolder = preferredSpaceIdHolder
+            preferredSpaceIdHolder = preferredSpaceIdHolder,
+            setVaultSearchHighlightSeen = setVaultSearchHighlightSeen
         ) as T
 }

--- a/presentation/src/main/java/com/anytypeio/anytype/presentation/sync/SpaceSyncAndP2PStatusProvider.kt
+++ b/presentation/src/main/java/com/anytypeio/anytype/presentation/sync/SpaceSyncAndP2PStatusProvider.kt
@@ -5,11 +5,13 @@ import com.anytypeio.anytype.core_models.multiplayer.SpaceSyncAndP2PStatusState
 import com.anytypeio.anytype.core_models.multiplayer.SpaceSyncUpdate
 import com.anytypeio.anytype.domain.event.interactor.SpaceSyncAndP2PStatusProvider
 import com.anytypeio.anytype.domain.workspace.SpaceManager
+import com.anytypeio.anytype.domain.workspace.spaceIdOrNull
 import com.anytypeio.anytype.domain.workspace.SyncAndP2PStatusChannel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.mapNotNull
 import timber.log.Timber
 
 class SpaceSyncAndP2PStatusProviderImpl @Inject constructor(
@@ -19,12 +21,16 @@ class SpaceSyncAndP2PStatusProviderImpl @Inject constructor(
 
     override fun observe(): Flow<SpaceSyncAndP2PStatusState> =
         combine(
-            spaceManager.observe(),
+            // The active space id rather than its config: a space can be active without one
+            // (SpaceManager.activate, used by quick capture to skip Workspace.Open), and the
+            // id is all this needs. Driving it from the config flow left the sheet's sync
+            // badge blank in exactly that case.
+            spaceManager.state().mapNotNull { state -> state.spaceIdOrNull() },
             spaceSyncStatusChannel.p2pStatus(),
             spaceSyncStatusChannel.syncStatus()
         ) { activeSpace, p2pStatus, syncStatus ->
-            val p2PStatusUpdate = p2pStatus[activeSpace.space]
-            val spaceSyncUpdate = syncStatus[activeSpace.space]
+            val p2PStatusUpdate = p2pStatus[activeSpace.id]
+            val spaceSyncUpdate = syncStatus[activeSpace.id]
 
             if (p2PStatusUpdate == null && spaceSyncUpdate == null) {
                 SpaceSyncAndP2PStatusState.Init

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/quickcapture/QuickCaptureViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/quickcapture/QuickCaptureViewModelTest.kt
@@ -416,6 +416,65 @@ class QuickCaptureViewModelTest {
     }
 
     /**
+     * The pencil says a space holds an unfinished draft; the order should say it too, rather
+     * than leaving the user to find it below spaces they pinned months ago.
+     */
+    @Test
+    fun `lists spaces holding a draft before the rest`() = runTest {
+        val draftSpace = MockDataFactory.randomUuid()
+        // targetSpace is pinned, so without the draft it would sort first.
+        spaceViews.stub {
+            on { observe() } doReturn MutableStateFlow(
+                listOf(
+                    StubSpaceView(targetSpaceId = targetSpace, spaceOrder = "a"),
+                    StubSpaceView(targetSpaceId = draftSpace)
+                )
+            )
+        }
+        userPermissionProvider.stub {
+            on { all() } doReturn flowOf(
+                mapOf(
+                    targetSpace to SpaceMemberPermissions.OWNER,
+                    draftSpace to SpaceMemberPermissions.OWNER
+                )
+            )
+        }
+        searchQuickCaptureDrafts.stub {
+            onBlocking { async(any()) } doReturn Resultat.success(
+                SearchQuickCaptureDrafts.Result(
+                    drafts = listOf(
+                        ObjectWrapper.Basic(
+                            mapOf(
+                                Relations.ID to MockDataFactory.randomUuid(),
+                                Relations.SPACE_ID to draftSpace,
+                                Relations.IS_HIDDEN to true,
+                                Relations.IS_DRAFT to true
+                            )
+                        )
+                    ),
+                    isComplete = true
+                )
+            )
+        }
+
+        val vm = vm()
+        // Subscribed before onStart: the list is shared WhileSubscribed, so without a
+        // collector it never leaves its initial empty value.
+        vm.spaces.test {
+            vm.onStart()
+            coroutineTestRule.advanceUntilIdle()
+            val listed = expectMostRecentItem()
+            assertEquals(draftSpace, listed.first().space.targetSpaceId)
+            assertTrue(listed.first().hasDraft)
+            cancelAndIgnoreRemainingEvents()
+        }
+        // Ordering the picker must not change which space the sheet opened into.
+        val state = vm.screenState.value
+        assertTrue(state is QuickCaptureViewModel.ScreenState.Ready)
+        assertEquals(targetSpace, state.space.id, "auto-selection must not follow the draft")
+    }
+
+    /**
      * A partial cross-space result means "unknown", not "no drafts". Creating one here is how
      * a space that already holds a draft ends up with two.
      */

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/quickcapture/QuickCaptureViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/quickcapture/QuickCaptureViewModelTest.kt
@@ -54,6 +54,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyBlocking
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -169,10 +170,24 @@ class QuickCaptureViewModelTest {
         assertEquals(draftId, state.draft)
     }
 
+    /**
+     * Workspace.Open costs ~5s on a space this session has not touched (measured on device)
+     * and produces a config the capture path never reads: Object.Create and Object.Open both
+     * carry the space id, and the space-scoped subscriptions are built from that id alone.
+     */
     @Test
-    fun `space open failure dismisses the sheet`() = runTest {
-        spaceManager.stub {
-            onBlocking { set(targetSpace, false) } doReturn Result.failure(
+    fun `activates the target space without opening the workspace`() = runTest {
+        val vm = vm()
+        vm.onStart()
+        coroutineTestRule.advanceUntilIdle()
+        verify(spaceManager).activate(targetSpace)
+        verifyBlocking(spaceManager, never()) { set(any(), any()) }
+    }
+
+    @Test
+    fun `a draft that cannot be created dismisses the sheet`() = runTest {
+        createObject.stub {
+            onBlocking { async(any()) } doReturn Resultat.failure(
                 IllegalStateException("space is not ready")
             )
         }

--- a/presentation/src/test/java/com/anytypeio/anytype/presentation/splash/SplashViewModelTest.kt
+++ b/presentation/src/test/java/com/anytypeio/anytype/presentation/splash/SplashViewModelTest.kt
@@ -17,6 +17,7 @@ import com.anytypeio.anytype.domain.auth.interactor.LaunchWallet
 import com.anytypeio.anytype.domain.auth.model.AuthStatus
 import com.anytypeio.anytype.domain.base.Either
 import com.anytypeio.anytype.domain.base.Resultat
+import com.anytypeio.anytype.domain.vault.SetVaultSearchHighlightSeen
 import com.anytypeio.anytype.domain.block.repo.BlockRepository
 import com.anytypeio.anytype.domain.config.UserSettingsRepository
 import com.anytypeio.anytype.domain.misc.LocaleProvider
@@ -48,6 +49,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 
 class SplashViewModelTest {
@@ -105,6 +107,9 @@ class SplashViewModelTest {
     @Mock
     lateinit var migrationHelperDelegate: MigrationHelperDelegate
 
+    @Mock
+    lateinit var setVaultSearchHighlightSeen: SetVaultSearchHighlightSeen
+
     lateinit var vm: SplashViewModel
 
     private val defaultSpaceConfig = StubConfig()
@@ -140,7 +145,8 @@ class SplashViewModelTest {
             deepLinkResolver = mock(),
             pendingIntentStore = mock(),
             searchObjects = mock(),
-            preferredSpaceIdHolder = mock()
+            preferredSpaceIdHolder = mock(),
+            setVaultSearchHighlightSeen = setVaultSearchHighlightSeen
         )
     }
 
@@ -179,6 +185,43 @@ class SplashViewModelTest {
 
         runBlocking {
             verify(launchWallet, times(1)).invoke(any())
+        }
+    }
+
+    @Test
+    fun `should pre-dismiss the vault search highlight when there is no account on the device`() {
+
+        val response: Resultat.Success<Pair<AuthStatus, Account?>> =
+            Resultat.Success(Pair(AuthStatus.UNAUTHORIZED, null))
+
+        stubCheckAuthStatus(response)
+        setVaultSearchHighlightSeen.stub {
+            onBlocking { async(eq(Unit)) } doReturn Resultat.Success(Unit)
+        }
+
+        initViewModel()
+
+        runBlocking {
+            verify(setVaultSearchHighlightSeen, times(1)).async(eq(Unit))
+        }
+    }
+
+    @Test
+    fun `should leave the vault search highlight for a signed-in user`() {
+
+        val status = AuthStatus.AUTHORIZED
+
+        val response = Resultat.Success(Pair(status, Account(id = "id")))
+
+        stubCheckAuthStatus(response)
+        stubLaunchWallet()
+        stubLaunchAccount()
+        stubGetLastOpenedObject()
+
+        initViewModel()
+
+        runBlocking {
+            verifyNoInteractions(setVaultSearchHighlightSeen)
         }
     }
 


### PR DESCRIPTION
Six changes to the quick-capture sheet, all measured on device, plus two to the vault search bar. Quick capture has not shipped, so they land together rather than as separate PRs.

### Opening the sheet

**The sheet no longer opens too high and then drops** (DROID-4591). `BottomSheetDialog`'s `EdgeToEdgeCallback` pads the sheet by the status-bar inset, but it is only built on the first inset dispatch and only applies from a state/slide callback — ~900ms after the sheet was on screen. The sheet takes that inset over: a pass-through insets listener stops the callback being built, and an `OnPreDrawListener` keeps the content padded by `inset - sheet.top`, so a correction costs a dropped frame rather than a visible step.

**Tap to rendered draft: 6.7s → 0.99s cold** (DROID-4593). The sheet waited on `spaceManager.set()` — `Workspace.Open` — for the target space, ~5s of that on a space the session had not touched, for a `Config` the capture path never reads. `SpaceManager.activate()` points the app's space-scoped subscriptions at a space without opening the workspace; they take a `Config` only to read `config.space` out of it, and `Object.Create`/`Object.Open` carry the space id themselves. Two consequences of a space being active without a config are fixed alongside: the config map became observable (a config arriving for a space that is already current could not re-emit), and `ObjectMenuDI` now derives its space id from the state rather than the config flow, so the menu opened from the sheet has a space.

Also here: `Ready` no longer waits on the cross-space draft discovery (~640ms cold), and the editor may open its document from `onCreate` so the round trip runs during inflation. That last one measured neutral and is kept deliberately — `Object.Open` finishes ~440ms after the sheet starts whether it is issued at +100ms or +300ms, because it is queued behind other middleware work, so what changes is that the app side is no longer on the critical path.

Worth knowing for future measurements: on a non-debuggable build the same cold open is ~0.52s. The debug build roughly doubles it.

### Using the sheet

**Spaces holding a draft are listed first in the picker** (DROID-4594) — a 1:1 space included, since the pencil on the row explains why it is at the top. Picker only: auto-selection on open still ignores drafts, because opening into a different space because a draft lives there would take the choice away.

**The app no longer flashes black around the space picker** (DROID-4595). The scrim is a 0.9 window dim, and a dim layer belongs to the window in front: while the picker is up the window manager composites ours above the sheet and the keyboard, and tearing that window down leaves it there for a few frames. The system bars stayed lit through the flash, which is the tell. The sheet now dims only while it is the front window. Separately, it measured the keyboard from a frame the picker had taken the IME out of, repadding the editor 883px → 63px under the picker and back on dismissal; it now follows the keyboard only while it has focus.

### Vault search

**The bar says "Search everything"** rather than "Search", now that it covers objects and chat messages across spaces.

**Existing users get a one-time glow on it.** A breathing accent halo around the field — Material's feature-discovery pulse, adapted to a wide target — until it is tapped; then that is persisted device-wide and never shown again. Who sees it is decided at splash, not from install tracking: when the splash finds no account it pre-marks the glow as seen, so a fresh install never gets a hint for a search it never knew otherwise. Anyone arriving signed in is exactly who the hint is for. (The existing `ShouldShowFeatureIntroduction` path was not used: its fresh-install signal is consumed by whichever caller runs `InitializeAppInstallationData` first, so by the time the vault checks, fresh installs already look like existing users.)

The bar is also on screen from the first frame now. It used to hide behind the loading spinner, which since DROID-4589 also covers the seconds it takes chat previews to arrive, and that read as the field being missing. The glow waits for that to settle so it does not compete with the spinner.

### Testing

1366 presentation + 420 domain unit tests pass. For the vault search: all 42 feature-vault tests and the 11 `SplashViewModelTest` tests pass, six of them new (glow shown until seen, hidden once seen, tap hides and persists, no write without a glow; splash pre-dismisses when unauthorized and leaves a signed-in user alone). Checked on a Nothing Phone (2a): bar visible from the first frame, glow after previews settle, tap ends it. The obsolete `space open failure dismisses the sheet` is replaced by `activates the target space without opening the workspace` plus a create-failure dismissal test, and the picker ordering has a test that was checked to fail without the change.

The picker flash fix is the one change not yet re-verified on device (the phone locked during the build); the diagnosis behind it is frame-by-frame from a screen recording, and lowering the dim to 0.32 confirmed the cause.
