### PR TITLE
DROID-4596 Chat | Fix | Read receipt races and widget section chevrons

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/di/feature/chats/ChatContainerModule.kt
+++ b/app/src/main/java/com/anytypeio/anytype/di/feature/chats/ChatContainerModule.kt
@@ -1,0 +1,33 @@
+package com.anytypeio.anytype.di.feature.chats
+
+import com.anytypeio.anytype.core_utils.di.scope.PerScreen
+import com.anytypeio.anytype.di.main.ConfigModule.DEFAULT_APP_COROUTINE_SCOPE
+import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
+import com.anytypeio.anytype.domain.block.repo.BlockRepository
+import com.anytypeio.anytype.domain.chats.ChatContainer
+import com.anytypeio.anytype.domain.chats.ChatEventChannel
+import com.anytypeio.anytype.domain.debugging.Logger
+import com.anytypeio.anytype.domain.library.StorelessSubscriptionContainer
+import dagger.Module
+import dagger.Provides
+import javax.inject.Named
+import kotlinx.coroutines.CoroutineScope
+
+/** Shared by chats and discussions, which both collect a ChatContainer. */
+@Module
+object ChatContainerModule {
+    @JvmStatic
+    @Provides
+    @PerScreen
+    fun provideChatContainer(
+        repo: BlockRepository,
+        channel: ChatEventChannel,
+        logger: Logger,
+        subscription: StorelessSubscriptionContainer,
+        @Named(DEFAULT_APP_COROUTINE_SCOPE) scope: CoroutineScope,
+        dispatchers: AppCoroutineDispatchers
+    ): ChatContainer = ChatContainer(
+        repo, channel, logger, subscription,
+        readScope = CoroutineScope(scope.coroutineContext + dispatchers.io)
+    )
+}

--- a/app/src/main/java/com/anytypeio/anytype/di/feature/chats/ChatsDI.kt
+++ b/app/src/main/java/com/anytypeio/anytype/di/feature/chats/ChatsDI.kt
@@ -8,6 +8,7 @@ import com.anytypeio.anytype.core_utils.di.scope.PerScreen
 import com.anytypeio.anytype.core_utils.notifications.NotificationPermissionManager
 import com.anytypeio.anytype.core_utils.tools.FeatureToggles
 import com.anytypeio.anytype.di.common.ComponentDependencies
+import com.anytypeio.anytype.di.main.ConfigModule.DEFAULT_APP_COROUTINE_SCOPE
 import com.anytypeio.anytype.domain.auth.repo.AuthRepository
 import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
 import com.anytypeio.anytype.domain.block.repo.BlockRepository
@@ -48,10 +49,13 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
 import dagger.Provides
+import javax.inject.Named
+import kotlinx.coroutines.CoroutineScope
 
 @Component(
     dependencies = [ChatComponentDependencies::class],
     modules = [
+        ChatContainerModule::class,
         ChatModule::class,
         ChatModule.Declarations::class
     ]
@@ -132,6 +136,7 @@ object ChatModule {
 }
 
 interface ChatComponentDependencies : ComponentDependencies {
+    @Named(DEFAULT_APP_COROUTINE_SCOPE) fun scope(): CoroutineScope
     fun blockRepository(): BlockRepository
     fun authRepo(): AuthRepository
     fun appCoroutineDispatchers(): AppCoroutineDispatchers

--- a/app/src/main/java/com/anytypeio/anytype/di/feature/discussions/DiscussionDI.kt
+++ b/app/src/main/java/com/anytypeio/anytype/di/feature/discussions/DiscussionDI.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.ViewModelProvider
 import com.anytypeio.anytype.core_models.UrlBuilder
 import com.anytypeio.anytype.core_utils.di.scope.PerScreen
 import com.anytypeio.anytype.di.common.ComponentDependencies
+import com.anytypeio.anytype.di.feature.chats.ChatContainerModule
+import com.anytypeio.anytype.di.main.ConfigModule.DEFAULT_APP_COROUTINE_SCOPE
 import com.anytypeio.anytype.domain.auth.repo.AuthRepository
 import com.anytypeio.anytype.domain.base.AppCoroutineDispatchers
 import com.anytypeio.anytype.domain.block.repo.BlockRepository
@@ -25,10 +27,13 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
 import dagger.Provides
+import javax.inject.Named
+import kotlinx.coroutines.CoroutineScope
 
 @Component(
     dependencies = [DiscussionComponentDependencies::class],
     modules = [
+        ChatContainerModule::class,
         DiscussionModule.Declarations::class,
         DiscussionModule.Providers::class
     ]
@@ -68,6 +73,7 @@ object DiscussionModule {
 }
 
 interface DiscussionComponentDependencies : ComponentDependencies {
+    @Named(DEFAULT_APP_COROUTINE_SCOPE) fun scope(): CoroutineScope
     fun blockRepository(): BlockRepository
     fun authRepo(): AuthRepository
     fun appCoroutineDispatchers(): AppCoroutineDispatchers

--- a/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetSection.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetSection.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -70,6 +72,7 @@ import com.anytypeio.anytype.ui.widgets.types.ListWidgetCard
 import com.anytypeio.anytype.ui.widgets.types.ObjectTypesGroupWidgetCard
 import com.anytypeio.anytype.ui.widgets.types.SpaceChatWidgetCard
 import com.anytypeio.anytype.ui.widgets.types.TreeWidgetCard
+import com.anytypeio.anytype.ui.widgets.types.getAnimatedRotation
 import com.anytypeio.anytype.ui.widgets.types.getPrettyName
 import kotlinx.coroutines.delay
 import sh.calvin.reorderable.ReorderableItem
@@ -603,65 +606,79 @@ fun WidgetEditModeButton(
 
 @Composable
 fun SpaceObjectTypesSectionHeader(
-    mode: InteractionMode,
+    isExpanded: Boolean,
     onSectionClicked: () -> Unit
 ) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(52.dp)
-            .noRippleClickable { onSectionClicked() }
-    ) {
-        Text(
-            modifier = Modifier
-                .align(Alignment.BottomStart)
-                .padding(start = 20.dp, bottom = 12.dp),
-            text = stringResource(R.string.widgets_section_object_types),
-            style = Title2,
-            color = colorResource(id = R.color.text_transparent_secondary)
-        )
-    }
+    CollapsibleWidgetSectionHeader(
+        title = stringResource(R.string.widgets_section_object_types),
+        isExpanded = isExpanded,
+        onSectionClicked = onSectionClicked
+    )
 }
 
 @Composable
 fun UnreadSectionHeader(
+    isExpanded: Boolean,
     onSectionClicked: () -> Unit,
 ) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(52.dp)
-            .noRippleClickable { onSectionClicked() }
-    ) {
-        Text(
-            modifier = Modifier
-                .align(Alignment.BottomStart)
-                .padding(start = 20.dp, bottom = 12.dp),
-            text = stringResource(R.string.widgets_section_unread),
-            style = Title2,
-            color = colorResource(id = R.color.text_transparent_secondary)
-        )
-    }
+    CollapsibleWidgetSectionHeader(
+        title = stringResource(R.string.widgets_section_unread),
+        isExpanded = isExpanded,
+        onSectionClicked = onSectionClicked
+    )
 }
 
 @Composable
 fun MyFavoritesSectionHeader(
+    isExpanded: Boolean,
     onSectionClicked: () -> Unit,
 ) {
+    CollapsibleWidgetSectionHeader(
+        title = stringResource(R.string.widgets_section_my_favorites),
+        isExpanded = isExpanded,
+        onSectionClicked = onSectionClicked
+    )
+}
+
+@Composable
+private fun CollapsibleWidgetSectionHeader(
+    title: String,
+    isExpanded: Boolean,
+    onSectionClicked: () -> Unit
+) {
+    val color = colorResource(R.color.text_transparent_secondary)
+    val rotation = getAnimatedRotation(isExpanded)
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .height(52.dp)
             .noRippleClickable { onSectionClicked() }
     ) {
-        Text(
+        Row(
             modifier = Modifier
                 .align(Alignment.BottomStart)
-                .padding(start = 20.dp, bottom = 12.dp),
-            text = stringResource(R.string.widgets_section_my_favorites),
-            style = Title2,
-            color = colorResource(id = R.color.text_transparent_secondary)
-        )
+                .fillMaxWidth()
+                .padding(start = 20.dp, end = 20.dp, bottom = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = title,
+                style = Title2,
+                color = color,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
+            )
+            Image(
+                painter = painterResource(R.drawable.ic_widget_tree_expand),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(color),
+                modifier = Modifier
+                    .padding(start = 8.dp)
+                    .size(18.dp)
+                    .graphicsLayer { rotationZ = rotation.value }
+            )
+        }
     }
 }
 
@@ -939,23 +956,14 @@ private fun sh.calvin.reorderable.ReorderableScope.MyFavoriteRow(
 
 @Composable
 fun RecentlyEditedSectionHeader(
+    isExpanded: Boolean,
     onSectionClicked: () -> Unit,
 ) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(52.dp)
-            .noRippleClickable { onSectionClicked() }
-    ) {
-        Text(
-            modifier = Modifier
-                .align(Alignment.BottomStart)
-                .padding(start = 20.dp, bottom = 12.dp),
-            text = stringResource(R.string.widgets_section_recently_edited),
-            style = Title2,
-            color = colorResource(id = R.color.text_transparent_secondary)
-        )
-    }
+    CollapsibleWidgetSectionHeader(
+        title = stringResource(R.string.widgets_section_recently_edited),
+        isExpanded = isExpanded,
+        onSectionClicked = onSectionClicked
+    )
 }
 
 /**

--- a/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreen.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/home/WidgetsScreen.kt
@@ -353,6 +353,7 @@ fun WidgetsScreen(
                                     key = SECTION_UNREAD,
                                 ) {
                                     UnreadSectionHeader(
+                                        isExpanded = !isUnreadSectionCollapsed,
                                         onSectionClicked = viewModel::onSectionUnreadClicked
                                     )
                                 }
@@ -419,7 +420,7 @@ fun WidgetsScreen(
                                 key = SECTION_OBJECT_TYPE,
                             ) {
                                 SpaceObjectTypesSectionHeader(
-                                    mode = mode,
+                                    isExpanded = !isObjectsSectionCollapsed,
                                     onSectionClicked = viewModel::onSectionTypesClicked
                                 )
                             }
@@ -462,6 +463,7 @@ fun WidgetsScreen(
                                     key = SECTION_RECENTLY_EDITED,
                                 ) {
                                     RecentlyEditedSectionHeader(
+                                        isExpanded = !isRecentlyEditedSectionCollapsed,
                                         onSectionClicked = viewModel::onSectionRecentlyEditedClicked
                                     )
                                 }
@@ -521,6 +523,7 @@ fun WidgetsScreen(
                                     key = SECTION_MY_FAVORITES,
                                 ) {
                                     MyFavoritesSectionHeader(
+                                        isExpanded = !isMyFavoritesSectionCollapsed,
                                         onSectionClicked = viewModel::onSectionMyFavoritesClicked
                                     )
                                 }

--- a/domain/src/main/java/com/anytypeio/anytype/domain/chats/ChatContainer.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/chats/ChatContainer.kt
@@ -12,7 +12,8 @@ import com.anytypeio.anytype.domain.debugging.Logger
 import com.anytypeio.anytype.domain.library.StoreSearchByIdsParams
 import com.anytypeio.anytype.domain.library.StorelessSubscriptionContainer
 import java.util.concurrent.ConcurrentHashMap
-import javax.inject.Inject
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
@@ -32,18 +33,21 @@ import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
-class ChatContainer @Inject constructor(
+class ChatContainer(
     private val repo: BlockRepository,
     private val channel: ChatEventChannel,
     private val logger: Logger,
-    private val subscription: StorelessSubscriptionContainer
+    private val subscription: StorelessSubscriptionContainer,
+    private val readScope: CoroutineScope
 ) {
 
     private val lastMessages = LinkedHashMap<Id, ChatMessageMeta>()
 
     private val payloads = MutableSharedFlow<List<Event.Command.Chats>>()
     private val commands = MutableSharedFlow<Transformation.Commands>(replay = 0)
+    private val readSession = AtomicReference<ChatReadSession?>()
 
     private val attachments = MutableStateFlow<Set<Id>>(emptySet())
     private val replies = MutableStateFlow<Set<Id>>(emptySet())
@@ -168,6 +172,7 @@ class ChatContainer @Inject constructor(
     }
 
     suspend fun stop(chat: Id) {
+        val pendingReads = readSession.get()?.takeIf { it.chat == chat }?.close()
         runCatching {
             repo.unsubscribeChat(chat)
             repo.cancelObjectSearchSubscription(
@@ -181,12 +186,30 @@ class ChatContainer @Inject constructor(
         }.onSuccess {
             logger.logInfo("DROID-2966 Successfully unsubscribed from chat")
         }
+        // Unsubscribe before suspending: the subscription id is shared with a reopened
+        // screen. Only read receipts may outlive this stop call, never its unsubscribe.
+        withTimeoutOrNull(READ_EXIT_WAIT_MS) { pendingReads?.join() }
     }
 
     fun watch(chat: Id, startAtMessage: Id? = null): Flow<ChatStreamState> = flow {
         coroutineScope {
-            val scope = this
+            val reads = ChatReadSession(chat, readScope, repo, logger)
+            readSession.set(reads)
+            try {
+                emitAll(watchMessages(chat, startAtMessage, reads))
+            } finally {
+                reads.close()
+                readSession.compareAndSet(reads, null)
+            }
+        }
+    }.catch { e ->
+        emit(ChatStreamState(emptyList()))
+        logger.logException(e, "DROID-2966 Exception occurred in the chat container: $chat")
+    }
 
+    private fun watchMessages(chat: Id, startAtMessage: Id?, reads: ChatReadSession): Flow<ChatStreamState> = flow {
+        coroutineScope {
+            val scope = this
             // Attach the event collector BEFORE the subscribe RPC: events arriving while the
             // initial window is being built are buffered and replayed into the fold below
             // instead of being dropped — events are only delivered to already-attached
@@ -204,21 +227,6 @@ class ChatContainer @Inject constructor(
                 }
             }
 
-            // Read receipts are side effects that must not block the event fold, but
-            // firing one coroutine per visible-range change floods the middleware with
-            // overlapping round-trips while the user scrolls. A CONFLATED channel
-            // drained by a single worker keeps only the newest range and at most one
-            // in-flight round-trip.
-            val visibleRangeReads = Channel<Pair<Chat.State, Chat.Message>>(capacity = Channel.CONFLATED)
-            scope.launch {
-                for ((counterState, bottomVisibleMessage) in visibleRangeReads) {
-                    // Reading messages older than bottomVisibleMessage
-                    readMessagesWithinVisibleRange(counterState, bottomVisibleMessage, chat)
-                    // Reading mentions older than bottomVisibleMessage
-                    readMentionsWithinVisibleRange(counterState, bottomVisibleMessage, chat)
-                }
-            }
-
             val response = repo.subscribeLastChatMessages(
                 command = Command.ChatCommand.SubscribeLastMessages(
                     chat = chat,
@@ -229,6 +237,16 @@ class ChatContainer @Inject constructor(
             }
 
             val initialState = response.chatState ?: Chat.State()
+            var fetchedState = initialState
+            val onFetchedState: (Chat.State) -> Unit = { newState ->
+                if (ChatStateUtils.shouldApplyNewChatState(newState.order, fetchedState.order)) {
+                    fetchedState = newState
+                }
+            }
+            fun ChatStreamState.withFetchedState(): ChatStreamState =
+                if (ChatStateUtils.shouldApplyNewChatState(fetchedState.order, state.order)) {
+                    copy(state = fetchedState)
+                } else this
 
             var intent: Intent = Intent.None
 
@@ -238,16 +256,11 @@ class ChatContainer @Inject constructor(
             // empty round-trips when the user keeps bouncing off the top of the chat.
             var noMoreMessagesBeforeOrder: Id? = null
 
-            // The newest message the UI last reported as visible, or null while no visible
-            // range has been reported yet. Scoped to this collection so it resets on
-            // re-subscription and can never leak between chats.
-            var newestVisibleMessageId: Id? = null
-
             // A requested start position (e.g. opening a search result at its message)
             // wins over the unread-section positioning; on failure (message deleted
             // between search and open) fall through to the default flow.
             val aroundStart = if (startAtMessage != null) {
-                runCatching { loadAroundMessage(chat = chat, msg = startAtMessage) }
+                runCatching { loadAroundMessage(chat = chat, msg = startAtMessage, onState = onFetchedState) }
                     .onFailure { logger.logWarning("DROID-2966 Could not load window around start message:\n${it.message}") }
                     .getOrNull()
             } else {
@@ -277,7 +290,8 @@ class ChatContainer @Inject constructor(
                         // Fetching the unread-messages window — un-read message section is not within the chat tail.
                         val aroundUnread = loadAroundMessageOrder(
                             chat = chat,
-                            order = initialState.oldestMessageOrderId.orEmpty()
+                            order = initialState.oldestMessageOrderId.orEmpty(),
+                            onState = onFetchedState
                         ).also { messages ->
                             val target = messages.find { it.order == initialState.oldestMessageOrderId }
                             if (target != null) {
@@ -310,9 +324,9 @@ class ChatContainer @Inject constructor(
                         state = initialState,
                         intent = intent,
                         initialUnreadSectionMessageId = initialUnreadSectionMessageId
-                    )
+                    ).withFetchedState()
                 ) { state, transform ->
-                    when (transform) {
+                    val updated = when (transform) {
                         Transformation.Commands.LoadPrevious -> {
                             val first = state.messages.firstOrNull()
                             if (first != null && first.order == noMoreMessagesBeforeOrder) {
@@ -320,7 +334,7 @@ class ChatContainer @Inject constructor(
                                 // skip the round-trip.
                                 state.copy(intent = Intent.None)
                             } else {
-                                val previousPage = loadThePreviousPage(first, chat)
+                                val previousPage = loadThePreviousPage(first, chat, onFetchedState)
                                 if (previousPage != null && previousPage.isEmpty() && first != null) {
                                     noMoreMessagesBeforeOrder = first.order
                                 }
@@ -339,7 +353,7 @@ class ChatContainer @Inject constructor(
                         }
                         Transformation.Commands.LoadNext -> {
                             ChatStreamState(
-                                messages = loadTheNextPage(state.messages, chat).trimKeepingNewest(),
+                                messages = loadTheNextPage(state.messages, chat, onFetchedState).trimKeepingNewest(),
                                 intent = Intent.None,
                                 state = state.state,
                                 // Preserved, mirroring LoadPrevious: the first forward page is
@@ -353,7 +367,8 @@ class ChatContainer @Inject constructor(
                             val messages = try {
                                 loadAroundMessage(
                                     chat = chat,
-                                    msg = transform.message
+                                    msg = transform.message,
+                                    onState = onFetchedState
                                 )
                             } catch (e: Exception) {
                                 logger.logException(e, "DROID-2966 Error while loading reply context")
@@ -384,7 +399,8 @@ class ChatContainer @Inject constructor(
                                             val messages = try {
                                                 loadAroundMessageOrder(
                                                     chat = chat,
-                                                    order = oldestReadOrderId
+                                                    order = oldestReadOrderId,
+                                                    onState = onFetchedState
                                                 )
                                             } catch (e: Exception) {
                                                 logger.logException(e, "DROID-2966 Error while loading reply context")
@@ -398,7 +414,7 @@ class ChatContainer @Inject constructor(
                                             )
                                         } else {
                                             val messages = try {
-                                                loadToEnd(chat)
+                                                loadToEnd(chat, onFetchedState)
                                             } catch (e: Exception) {
                                                 state.messages.also {
                                                     logger.logException(e, "DROID-2966 Error while scrolling to bottom")
@@ -413,7 +429,7 @@ class ChatContainer @Inject constructor(
                                         }
                                     } else {
                                         val messages = try {
-                                            loadToEnd(chat)
+                                            loadToEnd(chat, onFetchedState)
                                         } catch (e: Exception) {
                                             state.messages.also {
                                                 logger.logException(e, "DROID-2966 Error while scrolling to bottom")
@@ -435,7 +451,7 @@ class ChatContainer @Inject constructor(
                                         )
                                     } else {
                                         val messages = try {
-                                            loadToEnd(chat).also {
+                                            loadToEnd(chat, onFetchedState).also {
                                                 logger.logInfo("DROID-2966 Loaded chat tail because last message did not contained last visible message")
                                             }
                                         } catch (e: Exception) {
@@ -461,27 +477,15 @@ class ChatContainer @Inject constructor(
                                 val messages = try {
                                     loadAroundMessageOrder(
                                         chat = chat,
-                                        order = oldestMentionOrderId.orEmpty()
+                                        order = oldestMentionOrderId.orEmpty(),
+                                        onState = onFetchedState
                                     )
                                 } catch (e: Exception) {
                                     state.messages.also {
                                         logger.logException(e, "DROID-2966 Error while loading mention context")
                                     }
                                 }
-                                runCatching {
-                                    repo.readChatMessages(
-                                        command = Command.ChatCommand.ReadMessages(
-                                            chat = chat,
-                                            beforeOrderId = oldestMentionOrderId,
-                                            lastStateId = state.state.lastStateId,
-                                            isMention = true
-                                        )
-                                    )
-                                }.onFailure {
-                                    logger.logWarning("DROID-2966 Error while reading mentions: ${it.message}")
-                                }.onSuccess {
-                                    logger.logInfo("DROID-2966 Read mentions with success")
-                                }
+                                reads.readMention(oldestMentionOrderId.orEmpty(), state.withFetchedState().state)
                                 val target = messages.find { it.order == oldestMentionOrderId }
                                 ChatStreamState(
                                     messages = messages,
@@ -500,27 +504,13 @@ class ChatContainer @Inject constructor(
                                 intent = Intent.None
                             )
                         }
-                        is Transformation.Commands.UpdateVisibleRange -> {
-                            // [from] is the NEWEST visible message: the UI list is reversed,
-                            // so the lowest visible index is the most recent message.
-                            newestVisibleMessageId = transform.from
-                            val counterState = state.state
-                            val bottomVisibleMessage = state.messages.find { it.id == transform.from }
-                            if (bottomVisibleMessage != null) {
-                                // Conflated hand-off: never blocks the fold, and rapid
-                                // scroll bursts collapse to the newest range instead of
-                                // one read-receipt round-trip per emission.
-                                visibleRangeReads.trySend(counterState to bottomVisibleMessage)
-                            }
-                            state
-                        }
                         is Transformation.Events.Payload -> {
                             var strandedTailMessage = false
                             val reduced = state.reduce(transform.events) {
                                 strandedTailMessage = true
                             }
                             if (strandedTailMessage &&
-                                isParkedAtWindowTail(reduced.messages, newestVisibleMessageId)
+                                isParkedAtWindowTail(reduced.messages, reads.newestVisibleMessageId)
                             ) {
                                 // DROID-4556: the user is parked at the newest edge of a window
                                 // detached from the chat tail. Nothing is below them to scroll
@@ -540,7 +530,7 @@ class ChatContainer @Inject constructor(
                                 // the user. Looping until attached would instead block the fold
                                 // on N round-trips and let trimKeepingNewest evict the history
                                 // under the user's scroll anchor.
-                                val extended = loadTheNextPage(reduced.messages, chat)
+                                val extended = loadTheNextPage(reduced.messages, chat, onFetchedState)
                                 if (extended.size != reduced.messages.size) {
                                     reduced.copy(messages = extended.trimKeepingNewest())
                                 } else {
@@ -553,104 +543,21 @@ class ChatContainer @Inject constructor(
                             }
                         }
                     }
+                    updated.withFetchedState()
+                }.map { state ->
+                    state.copy(readSnapshot = reads.snapshot(state))
                 }.onEach {
                     logger.logInfo("DROID-2966 New emission with intent: ${it.intent}")
                 }.distinctUntilChanged()
             )
-        }
-    }.catch { e ->
-        emit(
-            value = ChatStreamState(emptyList())
-        ).also {
-            logger.logException(e, "DROID-2966 Exception occurred in the chat container: $chat")
-        }
-    }
-
-    /**
-     * Marks unread mention messages as read if they fall within the currently visible message range.
-     *
-     * This function checks whether there are any unread mention messages in the current chat state,
-     * and if the bottom-most visible message has an order ID greater than or equal to the order ID
-     * of the oldest unread mention. If so, it sends a command to mark those mentions as read.
-     *
-     * @param countersState The current state of the chat, including unread mention metadata.
-     * @param bottomVisibleMessage The lowest visible message in the current viewport.
-     * @param chat The ID of the chat where the messages are being read.
-     */
-    private suspend fun readMentionsWithinVisibleRange(
-        countersState: Chat.State,
-        bottomVisibleMessage: Chat.Message,
-        chat: Id
-    ) {
-        val oldestMentionOrderId = countersState.oldestMentionMessageOrderId
-        val bottomOrder = bottomVisibleMessage.order
-
-        if (
-            countersState.hasUnReadMentions &&
-            !oldestMentionOrderId.isNullOrEmpty() &&
-            bottomOrder >= oldestMentionOrderId
-        ) {
-            runCatching {
-                repo.readChatMessages(
-                    command = Command.ChatCommand.ReadMessages(
-                        chat = chat,
-                        beforeOrderId = bottomOrder,
-                        lastStateId = countersState.lastStateId.orEmpty(),
-                        isMention = true
-                    )
-                )
-            }.onFailure {
-                logger.logWarning("DROID-2966 Error while reading mentions: ${it.message}")
-            }.onSuccess {
-                logger.logInfo("DROID-2966 Read mentions with success")
-            }
-        }
-    }
-
-    /**
-     * Marks unread messages as read if they fall within the currently visible message range.
-     *
-     * This function checks whether there are any unread messages in the current chat state,
-     * and if the bottom-most visible message has an order ID greater than or equal to the order ID
-     * of the oldest unread message. If so, it sends a command to mark those messages as read.
-     *
-     * @param countersState The current state of the chat, including unread message metadata.
-     * @param bottomVisibleMessage The lowest visible message in the current viewport.
-     * @param chat The ID of the chat where the messages are being read.
-     */
-    private suspend fun readMessagesWithinVisibleRange(
-        countersState: Chat.State,
-        bottomVisibleMessage: Chat.Message,
-        chat: Id
-    ) {
-        val oldestMessageOrderId = countersState.oldestMessageOrderId
-        val bottomOrder = bottomVisibleMessage.order
-
-        if (
-            countersState.hasUnReadMessages &&
-            !oldestMessageOrderId.isNullOrEmpty() &&
-            bottomOrder >= oldestMessageOrderId
-        ) {
-            runCatching {
-                repo.readChatMessages(
-                    command = Command.ChatCommand.ReadMessages(
-                        chat = chat,
-                        beforeOrderId = bottomOrder,
-                        lastStateId = countersState.lastStateId.orEmpty()
-                    )
-                )
-            }.onFailure {
-                logger.logWarning("DROID-2966 Error while reading messages: ${it.message}")
-            }.onSuccess {
-                logger.logInfo("DROID-2966 Read messages with success")
-            }
         }
     }
 
     @Throws
     private suspend fun loadAroundMessage(
         chat: Id,
-        msg: Id
+        msg: Id,
+        onState: (Chat.State) -> Unit
     ): List<Chat.Message> {
 
         val replyMessage = repo.getChatMessagesByIds(
@@ -667,7 +574,7 @@ class ChatContainer @Inject constructor(
                     beforeOrderId = replyMessage.order,
                     limit = DEFAULT_CHAT_PAGING_SIZE / 2
                 )
-            ).messages
+            ).also { it.state?.let(onState) }.messages
 
             val loadedMessagesAfter = repo.getChatMessages(
                 Command.ChatCommand.GetMessages(
@@ -675,7 +582,7 @@ class ChatContainer @Inject constructor(
                     afterOrderId = replyMessage.order,
                     limit = DEFAULT_CHAT_PAGING_SIZE / 2
                 )
-            ).messages
+            ).also { it.state?.let(onState) }.messages
 
             return buildList {
                 addAll(loadedMessagesBefore)
@@ -690,7 +597,8 @@ class ChatContainer @Inject constructor(
     @Throws
     private suspend fun loadAroundMessageOrder(
         chat: Id,
-        order: Id
+        order: Id,
+        onState: (Chat.State) -> Unit
     ): List<Chat.Message> {
         val loadedMessagesBefore = repo.getChatMessages(
             Command.ChatCommand.GetMessages(
@@ -698,7 +606,7 @@ class ChatContainer @Inject constructor(
                 beforeOrderId = order,
                 limit = DEFAULT_CHAT_PAGING_SIZE / 2
             )
-        ).messages
+        ).also { it.state?.let(onState) }.messages
         val loadedMessagesAfter = repo.getChatMessages(
             Command.ChatCommand.GetMessages(
                 chat = chat,
@@ -706,7 +614,7 @@ class ChatContainer @Inject constructor(
                 limit = DEFAULT_CHAT_PAGING_SIZE / 2,
                 includeBoundary = true
             )
-        ).messages
+        ).also { it.state?.let(onState) }.messages
 
         return buildList {
             addAll(loadedMessagesBefore)
@@ -716,7 +624,8 @@ class ChatContainer @Inject constructor(
 
     private suspend fun loadTheNextPage(
         state: List<Chat.Message>,
-        chat: Id
+        chat: Id,
+        onState: (Chat.State) -> Unit
     ): List<Chat.Message> = try {
         val last = state.lastOrNull()
         if (last != null) {
@@ -727,6 +636,7 @@ class ChatContainer @Inject constructor(
                     limit = DEFAULT_CHAT_PAGING_SIZE
                 )
             )
+            next.state?.let(onState)
             // The window is rendered by a LazyColumn keyed on message id, and duplicate
             // keys throw — so a page overlapping the window (e.g. one echoing the boundary
             // message) must never introduce a duplicate.
@@ -751,7 +661,8 @@ class ChatContainer @Inject constructor(
      */
     private suspend fun loadThePreviousPage(
         first: Chat.Message?,
-        chat: Id
+        chat: Id,
+        onState: (Chat.State) -> Unit
     ): List<Chat.Message>? = try {
         if (first != null) {
             repo.getChatMessages(
@@ -760,7 +671,7 @@ class ChatContainer @Inject constructor(
                     beforeOrderId = first.order,
                     limit = DEFAULT_CHAT_PAGING_SIZE
                 )
-            ).messages
+            ).also { it.state?.let(onState) }.messages
         } else {
             logger.logWarning("DROID-2966 The first message not found in chat")
             null
@@ -815,7 +726,7 @@ class ChatContainer @Inject constructor(
     }
 
     @Throws
-    private suspend fun loadToEnd(chat: Id): List<Chat.Message> {
+    private suspend fun loadToEnd(chat: Id, onState: (Chat.State) -> Unit): List<Chat.Message> {
         return repo.getChatMessages(
             Command.ChatCommand.GetMessages(
                 chat = chat,
@@ -823,7 +734,7 @@ class ChatContainer @Inject constructor(
                 afterOrderId = null,
                 limit = DEFAULT_CHAT_PAGING_SIZE
             )
-        ).messages
+        ).also { it.state?.let(onState) }.messages
     }
 
     suspend fun onPayload(events: List<Event.Command.Chats>) {
@@ -957,6 +868,13 @@ class ChatContainer @Inject constructor(
         return ChatStreamState(
             messages = messageList,
             state = countersState,
+            // State/status events do not disturb the target's list position. Message
+            // changes can remove it or shift its index/date section, so cancel that
+            // scroll and let the UI's finally block restore visibility tracking.
+            intent = if (events.any {
+                    it is Event.Command.Chats.Add || it is Event.Command.Chats.Delete ||
+                        it is Event.Command.Chats.Update
+                }) Intent.None else intent,
             initialUnreadSectionMessageId = initialUnreadSectionMessageId
         )
     }
@@ -979,9 +897,11 @@ class ChatContainer @Inject constructor(
         commands.emit(Transformation.Commands.LoadEnd(msg))
     }
 
-    suspend fun onVisibleRangeChanged(from: Id, to: Id) {
-        logger.logInfo("DROID-2966 onVisibleRangeChanged")
-        commands.emit(Transformation.Commands.UpdateVisibleRange(from, to))
+    fun onVisibleRangeChanged(from: Id?, to: Id?, snapshot: ChatReadSnapshot? = null) {
+        // Record visibility before returning to the UI, so Back cannot overtake it.
+        // Null invalidates the viewport during programmatic scrolling or when no message
+        // qualifies; later state events must not read against an obsolete visible range.
+        readSession.get()?.visible(from.takeIf { to != null }, snapshot)
     }
 
     suspend fun onGoToMention() {
@@ -1037,8 +957,6 @@ class ChatContainer @Inject constructor(
              */
             data class LoadEnd(val lastVisibleMessage: Id?): Commands()
 
-            data class UpdateVisibleRange(val from: Id, val to: Id) : Commands()
-
             data object ClearIntent : Commands()
 
             data object GoToMention : Commands()
@@ -1046,6 +964,7 @@ class ChatContainer @Inject constructor(
     }
 
     companion object {
+        internal const val READ_EXIT_WAIT_MS = 1_000L
         const val DEFAULT_CHAT_PAGING_SIZE = 100
         // TODO reduce message size to reduce UI and VM overload.
         private const val MAX_CHAT_CACHE_SIZE = 1000
@@ -1102,7 +1021,8 @@ class ChatContainer @Inject constructor(
         val messages: List<Chat.Message>,
         val state: Chat.State = Chat.State(),
         val intent: Intent = Intent.None,
-        val initialUnreadSectionMessageId: String? = null
+        val initialUnreadSectionMessageId: String? = null,
+        val readSnapshot: ChatReadSnapshot? = null
     )
 
     sealed class Intent {

--- a/domain/src/main/java/com/anytypeio/anytype/domain/chats/ChatReadSession.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/chats/ChatReadSession.kt
@@ -1,0 +1,162 @@
+package com.anytypeio.anytype.domain.chats
+
+import com.anytypeio.anytype.core_models.Command
+import com.anytypeio.anytype.core_models.Id
+import com.anytypeio.anytype.core_models.chats.Chat
+import com.anytypeio.anytype.domain.block.repo.BlockRepository
+import com.anytypeio.anytype.domain.debugging.Logger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Owns read receipts for one collection of a chat. Visibility is recorded synchronously,
+ * before Back can unsubscribe or cancel the collector. RPCs run in a single worker.
+ *
+ * Pending receipts retain the order boundary AND the database state at which that boundary
+ * was observed. Taking the maximum of each independently could read a newly inserted message
+ * that was never visible. We only discard a receipt when another actually covers both bounds.
+ */
+internal class ChatReadSession(
+    val chat: Id,
+    scope: CoroutineScope,
+    private val repo: BlockRepository,
+    private val logger: Logger
+) {
+    private val lock = Any()
+    private val wake = Channel<Unit>(Channel.CONFLATED)
+    private var accepting = true
+    private var visibleMessage: Id? = null
+    private var inFlight: Receipt? = null
+    private val pending = mutableListOf<Receipt>()
+    private val completed = mutableListOf<Receipt>()
+    private val failed = mutableListOf<Receipt>()
+
+    val newestVisibleMessageId: Id?
+        get() = synchronized(lock) { visibleMessage }
+
+    private val worker = scope.launch {
+        for (signal in wake) drain()
+        // One final bounded retry batch after closing. There is only one drain owner,
+        // even when the screen is already gone or two exit paths both call close().
+        synchronized(lock) {
+            pending.addAll(failed)
+            failed.clear()
+        }
+        drain()
+    }
+
+    fun snapshot(stream: ChatContainer.ChatStreamState) = ChatReadSnapshot(
+        owner = this,
+        orders = stream.messages.associate { it.id to it.order },
+        state = stream.state
+    )
+
+    fun visible(from: Id?, snapshot: ChatReadSnapshot?) = synchronized(lock) {
+        if (snapshot != null && snapshot.owner !== this) return@synchronized
+        visibleMessage = from
+        val order = snapshot?.orders?.get(from) ?: return@synchronized
+        // Only the UI can acknowledge a new snapshot. A delayed callback from an older
+        // layout must never adopt the latest database watermark or read a new backfill.
+        completed.removeAll { it.stateOrder < snapshot.state.order }
+        enqueue(order, snapshot.state, isMention = false)
+        enqueue(order, snapshot.state, isMention = true)
+    }
+
+    fun readMention(beforeOrderId: Id, state: Chat.State) = synchronized(lock) {
+        enqueue(beforeOrderId, state, isMention = true)
+    }
+
+    private fun enqueue(before: Id, state: Chat.State, isMention: Boolean) {
+        if (!accepting) return
+        val unread = if (isMention) state.unreadMentions else state.unreadMessages
+        val lastStateId = state.lastStateId.orEmpty()
+        if (unread == null || unread.counter <= 0 || unread.olderOrderId.isEmpty() ||
+            before < unread.olderOrderId
+        ) return
+
+        val receipt = Receipt(
+            command = Command.ChatCommand.ReadMessages(
+                chat = chat,
+                beforeOrderId = before,
+                lastStateId = lastStateId,
+                isMention = isMention
+            ),
+            stateOrder = state.order
+        )
+        if (completed.any { it.covers(receipt) } || pending.any { it.covers(receipt) } ||
+            inFlight?.covers(receipt) == true || failed.any { it.covers(receipt) }
+        ) return
+
+        pending.removeAll { receipt.covers(it) }
+        failed.removeAll { receipt.covers(it) }
+        pending += receipt
+        wake.trySend(Unit)
+    }
+
+    /**
+     * Freeze visibility and drain on the application-owned worker. Closing a screen never
+     * cancels that worker, and waiting for a stalled native RPC must not block navigation.
+     */
+    fun close(): Job = synchronized(lock) {
+        accepting = false
+        wake.close()
+        worker
+    }
+
+    private suspend fun drain() {
+        while (true) {
+            val receipt = synchronized(lock) {
+                if (pending.isEmpty()) null else pending.removeAt(0).also { inFlight = it }
+            } ?: return
+            try {
+                val success = sendWithRetry(receipt.command)
+                synchronized(lock) {
+                    if (success) {
+                        completed.removeAll { receipt.covers(it) }
+                        failed.removeAll { receipt.covers(it) }
+                        completed += receipt
+                    } else {
+                        failed += receipt
+                    }
+                }
+            } catch (e: CancellationException) {
+                synchronized(lock) { pending.add(0, receipt) }
+                throw e
+            } finally {
+                synchronized(lock) { inFlight = null }
+            }
+        }
+    }
+
+    private suspend fun sendWithRetry(command: Command.ChatCommand.ReadMessages): Boolean {
+        repeat(3) { attempt ->
+            try {
+                repo.readChatMessages(command)
+                return true
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.logWarning("Error reading chat $chat through ${command.beforeOrderId} " +
+                    "at state ${command.lastStateId}, mention=${command.isMention}, " +
+                    "attempt=${attempt + 1}: ${e.message}")
+                if (attempt < 2) delay(250L * (attempt + 1))
+            }
+        }
+        return false
+    }
+
+    private data class Receipt(
+        val command: Command.ChatCommand.ReadMessages,
+        val stateOrder: Long
+    ) {
+        fun covers(other: Receipt): Boolean =
+            command.isMention == other.command.isMention &&
+                stateOrder >= other.stateOrder &&
+                command.beforeOrderId.orEmpty() >= other.command.beforeOrderId.orEmpty() &&
+                command.lastStateId.orEmpty() >= other.command.lastStateId.orEmpty()
+    }
+}

--- a/domain/src/main/java/com/anytypeio/anytype/domain/chats/ChatReadSnapshot.kt
+++ b/domain/src/main/java/com/anytypeio/anytype/domain/chats/ChatReadSnapshot.kt
@@ -1,0 +1,12 @@
+package com.anytypeio.anytype.domain.chats
+
+import com.anytypeio.anytype.core_models.Id
+import com.anytypeio.anytype.core_models.chats.Chat
+
+/** The message orders and chat state rendered together by the UI. */
+@ConsistentCopyVisibility
+data class ChatReadSnapshot internal constructor(
+    internal val owner: Any,
+    internal val orders: Map<Id, Id>,
+    val state: Chat.State
+)

--- a/domain/src/test/java/com/anytypeio/anytype/domain/chats/ChatContainerTest.kt
+++ b/domain/src/test/java/com/anytypeio/anytype/domain/chats/ChatContainerTest.kt
@@ -74,7 +74,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val msg = StubChatMessage(
@@ -141,7 +142,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val initialMsg = StubChatMessage(
@@ -218,7 +220,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val messageToDelete = StubChatMessage(
@@ -283,7 +286,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val initialMessage = StubChatMessage(order = "A")
@@ -347,7 +351,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val initialMsg = StubChatMessage(
@@ -425,7 +430,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val firstMessage = StubChatMessage(order = "B")
@@ -491,7 +497,8 @@ class ChatContainerTest {
                     repo = repo,
                     channel = channel,
                     logger = logger,
-                    subscription = storelessSubscriptionContainer
+                    subscription = storelessSubscriptionContainer,
+                    readScope = backgroundScope
                 )
 
                 val messages = buildList {
@@ -597,7 +604,8 @@ class ChatContainerTest {
                 repo = repo,
                 channel = channel,
                 logger = logger,
-                subscription = storelessSubscriptionContainer
+                subscription = storelessSubscriptionContainer,
+                readScope = backgroundScope
             )
 
             val messages = buildList {
@@ -666,7 +674,8 @@ class ChatContainerTest {
                 repo = repo,
                 channel = channel,
                 logger = logger,
-                subscription = storelessSubscriptionContainer
+                subscription = storelessSubscriptionContainer,
+                readScope = backgroundScope
             )
 
             val allMessages = buildList {
@@ -760,7 +769,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val initialState = Chat.State(order = 1L)
@@ -810,7 +820,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val newerState = Chat.State(order = 5L)
@@ -860,7 +871,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val currentState = Chat.State(order = 3L)
@@ -910,7 +922,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val firstState = Chat.State(order = 1L)
@@ -959,7 +972,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val initialState = Chat.State(order = 1L)
@@ -1016,7 +1030,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val older = StubChatMessage(order = "A")
@@ -1162,7 +1177,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val older = StubChatMessage(order = "A")
@@ -1296,7 +1312,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val older = StubChatMessage(order = "A")
@@ -1414,7 +1431,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val tail = StubChatMessage(order = "T")
@@ -1483,7 +1501,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val older = StubChatMessage(order = "A")
@@ -1632,7 +1651,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val first = StubChatMessage(order = "A")
@@ -1694,7 +1714,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val first = StubChatMessage(order = "A")
@@ -1763,7 +1784,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val read = StubChatMessage(order = "A")
@@ -1835,7 +1857,8 @@ class ChatContainerTest {
             repo = repo,
             channel = channel,
             logger = logger,
-            subscription = storelessSubscriptionContainer
+            subscription = storelessSubscriptionContainer,
+            readScope = backgroundScope
         )
 
         val deletedTarget = "deleted-quoted-message-id"

--- a/domain/src/test/java/com/anytypeio/anytype/domain/chats/ChatReadReceiptsTest.kt
+++ b/domain/src/test/java/com/anytypeio/anytype/domain/chats/ChatReadReceiptsTest.kt
@@ -1,0 +1,460 @@
+package com.anytypeio.anytype.domain.chats
+
+import com.anytypeio.anytype.core_models.Command
+import com.anytypeio.anytype.core_models.Event
+import com.anytypeio.anytype.core_models.chats.Chat
+import com.anytypeio.anytype.domain.block.repo.BlockRepository
+import com.anytypeio.anytype.domain.debugging.Logger
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.mock
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatReadReceiptsTest {
+    @Test
+    fun `back drains the final visibility update before returning`() = runTest {
+        val f = fixture(listOf(message("A"), message("B")), state("B", 2))
+        val job = f.start(backgroundScope)
+        runCurrent()
+        f.visible("A")
+        runCurrent()
+        f.visible("B")
+        // No scheduler turn between reporting B and exiting.
+        f.container.stop("chat")
+        assertEquals(setOf("A", "B"), f.readIds)
+        assertEquals(listOf("read:A", "unsubscribe", "read:B"), f.operations)
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `collector cancellation drains a receipt whose worker has not started`() = runTest {
+        val f = fixture(listOf(message("A")), state("A", 1))
+        val job = f.start(backgroundScope)
+        runCurrent()
+        f.visible("A")
+        job.cancelAndJoin()
+        assertEquals(setOf("A"), f.readIds)
+    }
+
+    @Test
+    fun `in flight read survives collector cancellation`() = runTest {
+        val f = fixture(listOf(message("A")), state("A", 1))
+        val gate = CompletableDeferred<Unit>()
+        f.beforeRead = { gate.await() }
+        val job = f.start(backgroundScope)
+        runCurrent()
+        f.visible("A")
+        runCurrent()
+        job.cancelAndJoin()
+        assertEquals(1, f.attempts.size)
+        assertTrue(f.readIds.isEmpty())
+        gate.complete(Unit)
+        runCurrent()
+        assertEquals(setOf("A"), f.readIds)
+    }
+
+    @Test
+    fun `scrolling backwards cannot replace a pending newer read`() = runTest {
+        val f = fixture(listOf(message("A"), message("B"), message("C")), state("C", 3))
+        val gate = CompletableDeferred<Unit>()
+        f.beforeRead = { if (it.beforeOrderId == "A") gate.await() }
+        val job = f.start(backgroundScope)
+        runCurrent()
+        f.visible("A")
+        runCurrent()
+        f.visible("C")
+        f.visible("B")
+        gate.complete(Unit)
+        runCurrent()
+        assertEquals(listOf("A", "C"), f.attempts.map { it.beforeOrderId })
+        assertEquals(setOf("A", "B", "C"), f.readIds)
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `receipt merging never combines an old viewport with a newer state watermark`() = runTest {
+        val repo = RecordingRepository(emptyList(), state("A", 1))
+        val reads = ChatReadSession("chat", backgroundScope, repo, mock())
+        val messages = listOf(message("A"), message("B"), message("C"))
+        val old = reads.snapshot(ChatContainer.ChatStreamState(messages, state("A", 3)))
+        reads.visible("C", old)
+        // A new message may have been inserted in history while the user moved back to B.
+        reads.visible("B", old)
+        reads.visible("B", reads.snapshot(ChatContainer.ChatStreamState(messages, state("B", 3, order = 2))))
+        reads.close().join()
+        assertEquals(listOf("C" to "A", "B" to "B"), repo.attempts.map { it.beforeOrderId to it.lastStateId })
+    }
+
+    @Test
+    fun `new state retries the same visible message after an older watermark excluded it`() = runTest {
+        val f = fixture(listOf(message("A"), message("B")), state("A", 2))
+        val job = f.start(backgroundScope)
+        runCurrent()
+        f.visible("B")
+        runCurrent()
+        assertEquals(setOf("A"), f.readIds)
+        f.update(state("B", 1, oldest = "B", order = 2))
+        runCurrent()
+        assertEquals(setOf("A", "B"), f.readIds)
+        assertEquals(listOf("A", "B"), f.attempts.map { it.lastStateId })
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `late unread counters read an unchanged viewport`() = runTest {
+        val f = fixture(listOf(message("A")), state("A", 0, oldest = ""))
+        val job = f.start(backgroundScope)
+        runCurrent()
+        f.visible("A")
+        runCurrent()
+        assertTrue(f.attempts.isEmpty())
+        f.update(state("A", 1, order = 2))
+        runCurrent()
+        assertEquals(setOf("A"), f.readIds)
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `hidden viewport is not reread when a new state arrives`() = runTest {
+        val f = fixture(listOf(message("A")), state("A", 0, oldest = ""))
+        val job = f.start(backgroundScope)
+        runCurrent()
+        f.visible("A")
+        f.hide()
+        f.update(state("A", 1, order = 2))
+        runCurrent()
+        assertTrue(f.attempts.isEmpty())
+        // Resuming with the same ids must report visibility again.
+        f.visible("A")
+        runCurrent()
+        assertEquals(setOf("A"), f.readIds)
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `forward paging applies response state before reporting new messages`() = runTest {
+        val f = fixture(listOf(message("A")), state("A", 1))
+        val job = f.start(backgroundScope)
+        runCurrent()
+        val b = message("B")
+        f.backend[b.id] = b
+        f.page = { Command.ChatCommand.GetMessages.Response(listOf(b), state("B", 2, order = 2)) }
+        f.container.onLoadNext()
+        runCurrent()
+        assertEquals("B", f.latest?.state?.lastStateId)
+        f.visible("B")
+        runCurrent()
+        assertEquals(setOf("A", "B"), f.readIds)
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `older paging state does not replace a newer event state`() = runTest {
+        val f = fixture(listOf(message("A")), state("A", 1))
+        val job = f.start(backgroundScope)
+        runCurrent()
+        f.update(state("C", 1, order = 3))
+        runCurrent()
+        f.page = { Command.ChatCommand.GetMessages.Response(emptyList(), state("B", 1, order = 2)) }
+        f.container.onLoadNext()
+        runCurrent()
+        assertEquals("C", f.latest?.state?.lastStateId)
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `messages and mentions are independent and serialized`() = runTest {
+        val f = fixture(listOf(message("A")), state("A", 1).copy(unreadMentions = Chat.State.UnreadState("A", 1)))
+        val gate = CompletableDeferred<Unit>()
+        f.beforeRead = { if (!it.isMention) gate.await() }
+        val job = f.start(backgroundScope)
+        runCurrent()
+        f.visible("A")
+        runCurrent()
+        assertEquals(1, f.attempts.size)
+        assertFalse(f.attempts.single().isMention)
+        gate.complete(Unit)
+        runCurrent()
+        assertEquals(listOf(false, true), f.attempts.map { it.isMention })
+        assertTrue(f.attempts.all { it.afterOrderId == null })
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `transient read failure retries without another visibility callback`() = runTest {
+        val f = fixture(listOf(message("A")), state("A", 1))
+        f.beforeRead = { if (f.attempts.size == 1) error("temporary failure") }
+        val job = f.start(backgroundScope)
+        runCurrent()
+        f.visible("A")
+        runCurrent()
+        advanceTimeBy(250)
+        runCurrent()
+        assertEquals(2, f.attempts.size)
+        assertEquals(setOf("A"), f.readIds)
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `permanent failure has bounded retries and does not hang exit`() = runTest {
+        val f = fixture(listOf(message("A")), state("A", 1))
+        f.beforeRead = { error("unavailable") }
+        val job = f.start(backgroundScope)
+        runCurrent()
+        f.visible("A")
+        val stop = launch { f.container.stop("chat") }
+        advanceTimeBy(2_000)
+        runCurrent()
+        assertTrue(stop.isCompleted)
+        assertEquals(6, f.attempts.size) // three attempts, then a final exit retry batch
+        assertEquals(listOf("unsubscribe"), f.operations)
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `a later unread state can reread the same order and watermark`() = runTest {
+        val f = fixture(listOf(message("A")), state("A", 1))
+        val job = f.start(backgroundScope)
+        runCurrent()
+        f.visible("A")
+        runCurrent()
+        f.update(state("A", 0, oldest = "", order = 2))
+        runCurrent()
+        f.update(state("A", 1, order = 3))
+        runCurrent()
+        assertEquals(2, f.attempts.size)
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `stalled receipt does not block exit or unsubscribe a reopened chat later`() = runTest {
+        val f = fixture(listOf(message("A"), message("B")), state("B", 2))
+        val gate = CompletableDeferred<Unit>()
+        f.beforeRead = { gate.await() }
+        val oldWatcher = f.start(backgroundScope)
+        runCurrent()
+        f.visible("A")
+        runCurrent()
+        f.visible("B")
+        val exit = launch { f.container.stop("chat") }
+        runCurrent()
+        assertFalse(exit.isCompleted)
+        assertEquals(listOf("unsubscribe"), f.operations)
+        oldWatcher.cancelAndJoin()
+        f.hide()
+        // Reopen even before the previous exit's bounded wait has completed.
+        val newWatcher = f.start(backgroundScope)
+        runCurrent()
+        advanceTimeBy(ChatContainer.READ_EXIT_WAIT_MS)
+        runCurrent()
+        assertTrue(exit.isCompleted)
+        assertTrue(f.readIds.isEmpty())
+        gate.complete(Unit)
+        runCurrent()
+        assertEquals(setOf("A", "B"), f.readIds)
+        assertEquals(listOf("A", "B"), f.attempts.map { it.beforeOrderId })
+        assertEquals(1, f.operations.count { it == "unsubscribe" })
+        newWatcher.cancelAndJoin()
+    }
+
+    @Test
+    fun `a new backfill snapshot cannot be read by an older viewport callback`() = runTest {
+        val repo = RecordingRepository(emptyList(), state("A", 1))
+        val reads = ChatReadSession("chat", backgroundScope, repo, mock())
+        val old = reads.snapshot(ChatContainer.ChatStreamState(listOf(message("A")), state("A", 1)))
+        reads.visible("A", old)
+        runCurrent()
+        val fresh = reads.snapshot(ChatContainer.ChatStreamState(listOf(message("0"), message("A")), state("B", 2, oldest = "0", order = 2)))
+        reads.visible("A", old)
+        runCurrent()
+        assertEquals(listOf("A"), repo.attempts.map { it.lastStateId })
+        reads.visible("A", fresh)
+        reads.close().join()
+        assertEquals(listOf("A", "B"), repo.attempts.map { it.lastStateId })
+    }
+
+    @Test
+    fun `snapshots from a previous session cannot mark the reopened chat read`() = runTest {
+        val repo = RecordingRepository(emptyList(), state("A", 1))
+        val previous = ChatReadSession("chat", backgroundScope, repo, mock())
+        val old = previous.snapshot(ChatContainer.ChatStreamState(listOf(message("A")), state("A", 1)))
+        previous.close().join()
+        val reopened = ChatReadSession("chat", backgroundScope, repo, mock())
+        reopened.visible("A", old)
+        reopened.close().join()
+        assertTrue(repo.attempts.isEmpty())
+    }
+
+    @Test
+    fun `legacy empty state watermark is preserved as an empty RPC bound`() = runTest {
+        val f = fixture(listOf(message("A")), state("", 1))
+        val job = f.start(backgroundScope)
+        runCurrent()
+        f.visible("A")
+        runCurrent()
+        assertEquals("", f.attempts.single().lastStateId)
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `successful wider receipt removes a covered failed receipt before exit`() = runTest {
+        val f = fixture(listOf(message("A"), message("B")), state("B", 2))
+        f.beforeRead = { if (it.beforeOrderId == "A") error("temporary failure") }
+        val job = f.start(backgroundScope)
+        runCurrent()
+        f.visible("A")
+        runCurrent()
+        f.visible("B")
+        advanceTimeBy(1_000)
+        runCurrent()
+        f.container.stop("chat")
+        assertEquals(listOf("A", "A", "A", "B"), f.attempts.map { it.beforeOrderId })
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `state events preserve an active scroll intent until the UI clears it`() = runTest {
+        val f = fixture(listOf(message("A")), state("A", 1))
+        val job = f.start(backgroundScope)
+        runCurrent()
+        val intent = f.latest?.intent
+        assertTrue(intent is ChatContainer.Intent.ScrollToMessage)
+        f.update(state("A", 0, oldest = "", order = 2))
+        runCurrent()
+        assertEquals(intent, f.latest?.intent)
+        f.container.onClearIntent()
+        runCurrent()
+        assertEquals(ChatContainer.Intent.None, f.latest?.intent)
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `deleting the scroll target cancels its intent instead of waiting on a missing index`() = runTest {
+        val f = fixture(listOf(message("A")), state("A", 1))
+        val job = f.start(backgroundScope)
+        runCurrent()
+        assertTrue(f.latest?.intent is ChatContainer.Intent.ScrollToMessage)
+        f.container.onPayload(listOf(Event.Command.Chats.Delete("chat", "A")))
+        runCurrent()
+        assertEquals(ChatContainer.Intent.None, f.latest?.intent)
+        assertTrue(f.latest?.messages.orEmpty().isEmpty())
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `backward paging and tail loads preserve fetched chat state`() = runTest {
+        for (loadPrevious in listOf(true, false)) {
+            val f = fixture(listOf(message("B")), state("B", 1, oldest = "B"))
+            val job = f.start(backgroundScope)
+            runCurrent()
+            f.page = { Command.ChatCommand.GetMessages.Response(listOf(message("C")), state("C", 2, order = 2)) }
+            if (loadPrevious) f.container.onLoadPrevious() else f.container.onLoadChatTail("B")
+            runCurrent()
+            assertEquals("C", f.latest?.state?.lastStateId)
+            job.cancelAndJoin()
+        }
+    }
+
+    @Test
+    fun `initial unread window keeps the newest state of both around queries`() = runTest {
+        val f = fixture(listOf(message("C")), state("C", 2, oldest = "A"))
+        f.page = { command ->
+            if (command.beforeOrderId != null) {
+                Command.ChatCommand.GetMessages.Response(emptyList(), state("D", 2, order = 2))
+            } else {
+                Command.ChatCommand.GetMessages.Response(listOf(message("A"), message("B")), state("E", 2, order = 3))
+            }
+        }
+        val job = f.start(backgroundScope)
+        runCurrent()
+        assertEquals("E", f.latest?.state?.lastStateId)
+        f.visible("B")
+        runCurrent()
+        assertEquals("E", f.attempts.single().lastStateId)
+        job.cancelAndJoin()
+    }
+
+    private fun TestScope.fixture(messages: List<Chat.Message>, state: Chat.State) =
+        Fixture(messages, state, backgroundScope)
+
+    private class Fixture(messages: List<Chat.Message>, state: Chat.State, readScope: CoroutineScope) : RecordingRepository(messages, state) {
+        private val events = MutableSharedFlow<List<Event.Command.Chats>>()
+        var latest: ChatContainer.ChatStreamState? = null
+        val container = ChatContainer(this, object : ChatEventChannel {
+            override fun observe(chat: String) = events
+            override fun subscribe(subscribe: String) = events
+        }, mock<Logger>(), mock(), readScope)
+
+        fun start(scope: CoroutineScope) = scope.launch {
+            container.watch("chat").collect {
+                latest = it
+                // Model Compose acknowledging a new UI snapshot even if the range is unchanged.
+                visibleId?.let { id -> container.onVisibleRangeChanged(id, id, it.readSnapshot) }
+            }
+        }
+
+        private var visibleId: String? = null
+        fun visible(id: String) {
+            visibleId = id
+            container.onVisibleRangeChanged(id, id, latest?.readSnapshot)
+        }
+        fun hide() {
+            visibleId = null
+            container.onVisibleRangeChanged(null, null)
+        }
+        suspend fun update(state: Chat.State) = events.emit(listOf(Event.Command.Chats.UpdateState("chat", state)))
+    }
+
+    private open class RecordingRepository(
+        private val initial: List<Chat.Message>,
+        private val initialState: Chat.State
+    ) : BlockRepository by mock() {
+        val attempts = mutableListOf<Command.ChatCommand.ReadMessages>()
+        val operations = mutableListOf<String>()
+        val readIds = mutableSetOf<String>()
+        val backend = initial.associateByTo(linkedMapOf()) { it.id }
+        var beforeRead: suspend (Command.ChatCommand.ReadMessages) -> Unit = {}
+        var page: (Command.ChatCommand.GetMessages) -> Command.ChatCommand.GetMessages.Response = {
+            Command.ChatCommand.GetMessages.Response(emptyList())
+        }
+
+        override suspend fun subscribeLastChatMessages(command: Command.ChatCommand.SubscribeLastMessages) =
+            Command.ChatCommand.SubscribeLastMessages.Response(initial, 0, initialState)
+
+        override suspend fun getChatMessages(command: Command.ChatCommand.GetMessages) = page(command)
+
+        override suspend fun readChatMessages(command: Command.ChatCommand.ReadMessages) {
+            attempts += command
+            beforeRead(command)
+            operations += "read:${command.beforeOrderId}"
+            // Simulate Heart's inclusive order and insertion-state bounds. Fixture message
+            // ids double as insertion state ids, independently of command state.order.
+            if (!command.isMention) backend.values.filter {
+                it.order <= command.beforeOrderId.orEmpty() && it.id <= command.lastStateId.orEmpty()
+            }.forEach { readIds += it.id }
+        }
+
+        override suspend fun unsubscribeChat(chat: String) { operations += "unsubscribe" }
+        override suspend fun cancelObjectSearchSubscription(subscriptions: List<String>) = Unit
+    }
+
+    companion object {
+        private fun message(id: String) = Chat.Message(id, id, "someone", 0, 0, null)
+        private fun state(last: String, count: Int, oldest: String = "A", order: Long = 1) = Chat.State(
+            unreadMessages = Chat.State.UnreadState(oldest, count), lastStateId = last, order = order
+        )
+    }
+}

--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/presentation/ChatView.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/presentation/ChatView.kt
@@ -1,5 +1,6 @@
 package com.anytypeio.anytype.feature_chats.presentation
 
+import com.anytypeio.anytype.domain.chats.ChatReadSnapshot
 import androidx.compose.runtime.Immutable
 import com.anytypeio.anytype.core_models.Block
 import com.anytypeio.anytype.core_models.Hash
@@ -264,6 +265,7 @@ data class ChatViewState(
     val intent: ChatContainer.Intent = ChatContainer.Intent.None,
     val counter: Counter = Counter(),
     val isLoading: Boolean = false,
+    val readSnapshot: ChatReadSnapshot? = null,
 ) {
     @Immutable
     data class Counter(

--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/presentation/ChatViewModel.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/presentation/ChatViewModel.kt
@@ -1,5 +1,6 @@
 package com.anytypeio.anytype.feature_chats.presentation
 
+import com.anytypeio.anytype.domain.chats.ChatReadSnapshot
 import androidx.lifecycle.viewModelScope
 import com.anytypeio.anytype.analytics.base.Analytics
 import com.anytypeio.anytype.analytics.base.EventsDictionary
@@ -164,12 +165,6 @@ class ChatViewModel @Inject constructor(
     PinObjectAsWidgetDelegate by pinObjectAsWidgetDelegate,
     BackHistoryDelegate by backHistoryDelegate {
     private val preloadingJobs = mutableListOf<Job>()
-
-    private val visibleRangeUpdates = MutableSharedFlow<Pair<Id, Id>>(
-        replay = 0,
-        extraBufferCapacity = 1,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST
-    )
 
     val header = MutableStateFlow<HeaderView>(HeaderView.Init)
     val uiState = MutableStateFlow(ChatViewState(isLoading = true))
@@ -370,14 +365,6 @@ class ChatViewModel @Inject constructor(
                 }
                 // Note: if wrapper is null for chat object, header remains Init until wrapper is available
             }
-        }
-
-        viewModelScope.launch {
-            visibleRangeUpdates
-                .distinctUntilChanged()
-                .collect { (from, to) ->
-                    chatContainer.onVisibleRangeChanged(from, to)
-                }
         }
 
         viewModelScope.launch {
@@ -597,6 +584,7 @@ class ChatViewModel @Inject constructor(
                     messages = result.state.unreadMessages?.counter ?: 0,
                     mentions = result.state.unreadMentions?.counter ?: 0
                 ),
+                readSnapshot = result.readSnapshot,
                 isLoading = false
             )
         }.flowOn(dispatchers.io)
@@ -2619,11 +2607,12 @@ class ChatViewModel @Inject constructor(
     }
 
     fun onVisibleRangeChanged(
-        from: Id,
-        to: Id
+        from: Id?,
+        to: Id?,
+        snapshot: ChatReadSnapshot?
     ) {
         Timber.d("DROID-2966 onVisibleRangeChanged, from: $from, to: $to")
-        visibleRangeUpdates.tryEmit(from to to)
+        chatContainer.onVisibleRangeChanged(from, to, snapshot)
     }
 
     fun onUrlPasted(url: Url) {

--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/ChatPreviews.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/ChatPreviews.kt
@@ -217,7 +217,7 @@ fun ChatScreenPreview() {
         onScrollToReplyClicked = {},
         onClearIntent = {},
         onScrollToBottomClicked = {},
-        onVisibleRangeChanged = { _, _ -> },
+        onVisibleRangeChanged = { _, _, _ -> },
         onUrlInserted = {},
         onGoToMentionClicked = {},
         onAddMembersClick = {},

--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/ChatReadVisibility.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/ChatReadVisibility.kt
@@ -1,0 +1,32 @@
+package com.anytypeio.anytype.feature_chats.ui
+
+import com.anytypeio.anytype.core_models.Id
+import com.anytypeio.anytype.domain.chats.ChatReadSnapshot
+
+internal data class ChatReadVisibility(
+    val range: Pair<Id, Id>?,
+    val snapshot: ChatReadSnapshot?,
+    val generation: Int
+)
+
+internal fun isChatReadLayoutCurrent(
+    keys: List<String>,
+    totalItemsCount: Int,
+    visibleKeys: List<Pair<Int, Any>>
+): Boolean = totalItemsCount == keys.size && visibleKeys.all { (index, key) -> keys.getOrNull(index) == key }
+
+/** Ordinary messages must fit on screen; oversized messages must fill the viewport. */
+internal fun isMessageVisibleForReading(
+    offset: Int,
+    size: Int,
+    viewportStart: Int,
+    viewportEnd: Int
+): Boolean {
+    if (size <= 0 || viewportEnd <= viewportStart) return false
+    val end = offset.toLong() + size
+    return if (size <= viewportEnd.toLong() - viewportStart) {
+        offset >= viewportStart && end <= viewportEnd
+    } else {
+        offset <= viewportStart && end >= viewportEnd
+    }
+}

--- a/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/ChatScreen.kt
+++ b/feature-chats/src/main/java/com/anytypeio/anytype/feature_chats/ui/ChatScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
@@ -51,9 +52,13 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.anytypeio.anytype.core_models.Block
 import com.anytypeio.anytype.core_models.Id
+import com.anytypeio.anytype.domain.chats.ChatReadSnapshot
 import com.anytypeio.anytype.core_models.Url
 import com.anytypeio.anytype.core_models.multiplayer.SpaceInviteLinkAccessLevel
 import com.anytypeio.anytype.core_models.multiplayer.SpaceUxType
@@ -126,17 +131,8 @@ fun ChatScreenWrapper(
         val clipboard = LocalClipboardManager.current
         val lazyListState = rememberLazyListState()
 
-        val messages by remember(vm) { vm.uiState.map { it.messages } }
-            .collectAsStateWithLifecycle(emptyList())
-
-        val counter by remember(vm) { vm.uiState.map { it.counter } }
-            .collectAsStateWithLifecycle(ChatViewState.Counter())
-
-        val intent by remember(vm) { vm.uiState.map { it.intent } }
-            .collectAsStateWithLifecycle(ChatContainer.Intent.None)
-
-        val isLoading by remember(vm) { vm.uiState.map { it.isLoading } }
-            .collectAsStateWithLifecycle(vm.uiState.value.isLoading)
+        // Messages and their read watermark must come from the same emission.
+        val chatState by vm.uiState.collectAsStateWithLifecycle()
 
         val chatBoxMode by vm.chatBoxMode.collectAsStateWithLifecycle()
 
@@ -147,12 +143,13 @@ fun ChatScreenWrapper(
         val spaceUxType by vm.currentSpaceUxType.collectAsStateWithLifecycle()
 
         ChatScreen(
-            isLoading = isLoading,
+            isLoading = chatState.isLoading,
             isSyncing = vm.isSyncing.collectAsStateWithLifecycle().value,
             chatBoxMode = chatBoxMode,
-            messages = messages,
-            counter = counter,
-            intent = intent,
+            messages = chatState.messages,
+            counter = chatState.counter,
+            intent = chatState.intent,
+            readSnapshot = chatState.readSnapshot,
             attachments = vm.chatBoxAttachments.collectAsState().value,
             inviteLinkAccessLevel = inviteLinkAccessLevel,
             onMessageSent = { text, spans ->
@@ -466,7 +463,7 @@ fun ChatScreen(
     onScrollToReplyClicked: (Id) -> Unit,
     onClearIntent: () -> Unit,
     onScrollToBottomClicked: (Id?) -> Unit,
-    onVisibleRangeChanged: (Id, Id) -> Unit,
+    onVisibleRangeChanged: (Id?, Id?, ChatReadSnapshot?) -> Unit,
     onUrlInserted: (Url) -> Unit,
     onGoToMentionClicked: () -> Unit,
     onAddMembersClick: () -> Unit,
@@ -481,7 +478,8 @@ fun ChatScreen(
     spaceUxType: SpaceUxType? = null,
     onOpenAttachmentInBrowser: (ChatView.Message) -> Unit = {},
     onOpenAttachmentFile: (ChatView.Message) -> Unit = {},
-    onOpenAttachmentAsObject: (ChatView.Message) -> Unit = {}
+    onOpenAttachmentAsObject: (ChatView.Message) -> Unit = {},
+    readSnapshot: ChatReadSnapshot? = null
 ) {
 
     val scope = rememberCoroutineScope()
@@ -529,73 +527,123 @@ fun ChatScreen(
     val keyboardController = LocalSoftwareKeyboardController.current
 
     val isPerformingScrollIntent = remember { mutableStateOf(false) }
+    var visibilityGeneration by remember { mutableIntStateOf(0) }
 
     val offsetPx = with(LocalDensity.current) { 50.dp.toPx().toInt() }
 
     // Applying view model intents
     LaunchedEffect(intent) {
         Timber.d("DROID-2966 New intent: $intent")
-        when (intent) {
-            is ChatContainer.Intent.ScrollToMessage -> {
-                isPerformingScrollIntent.value = true
-                val index = messages.indexOfFirst {
-                    it is ChatView.Message && it.id == intent.id
-                }
-                if (index >= 0) {
-                    snapshotFlow { lazyListState.layoutInfo.totalItemsCount }
-                        .first { it > index }
-                    if (intent.smooth) {
-                        lazyListState.animateScrollToItem(index)
-                    } else {
-                        if (intent.startOfUnreadMessageSection) {
-                            lazyListState.scrollToItem(index, scrollOffset = -offsetPx)
+        if (intent == ChatContainer.Intent.None) return@LaunchedEffect
+        isPerformingScrollIntent.value = true
+        onVisibleRangeChanged(null, null, null)
+        try {
+            when (intent) {
+                is ChatContainer.Intent.ScrollToMessage -> {
+                    val index = messages.indexOfFirst {
+                        it is ChatView.Message && it.id == intent.id
+                    }
+                    if (index >= 0) {
+                        snapshotFlow { lazyListState.layoutInfo.totalItemsCount }
+                            .first { it > index }
+                        if (intent.smooth) {
+                            lazyListState.animateScrollToItem(index)
                         } else {
-                            lazyListState.scrollToItem(index)
+                            if (intent.startOfUnreadMessageSection) {
+                                lazyListState.scrollToItem(index, scrollOffset = -offsetPx)
+                            } else {
+                                lazyListState.scrollToItem(index)
+                            }
                         }
-                    }
-                    awaitFrame()
+                        awaitFrame()
 
-                    if (intent.highlight) {
-                        highlightedMessageId = intent.id
-                        delay(500)
-                        highlightedMessageId = null
+                        if (intent.highlight) {
+                            highlightedMessageId = intent.id
+                            delay(500)
+                            highlightedMessageId = null
+                        }
+                    } else {
+                        Timber.d("DROID-2966 COMPOSE Could not find the scrolling target for the intent")
                     }
-                } else {
-                    Timber.d("DROID-2966 COMPOSE Could not find the scrolling target for the intent")
                 }
-                onClearIntent()
-                isPerformingScrollIntent.value = false
+                is ChatContainer.Intent.ScrollToBottom -> {
+                    Timber.d("DROID-2966 COMPOSE scroll to bottom")
+                    smoothScrollToBottom(lazyListState)
+                    awaitFrame()
+                }
+                ChatContainer.Intent.None -> Unit
             }
-            is ChatContainer.Intent.ScrollToBottom -> {
-                Timber.d("DROID-2966 COMPOSE scroll to bottom")
-                isPerformingScrollIntent.value = true
-                smoothScrollToBottom(lazyListState)
-                awaitFrame()
-                isPerformingScrollIntent.value = false
-                onClearIntent()
-            }
-            ChatContainer.Intent.None -> Unit
+        } finally {
+            isPerformingScrollIntent.value = false
+            highlightedMessageId = null
+            // A missing target/no-op scroll can finish before snapshotFlow observes true.
+            // Force it to restore the range even when the visible ids have not changed.
+            visibilityGeneration++
         }
+        onClearIntent()
     }
 
     // Tracking visible range
-    val currentMessages by rememberUpdatedState(messages)
-    LaunchedEffect(lazyListState) {
+    val messagesById = remember(messages) {
+        messages.filterIsInstance<ChatView.Message>().associateBy { it.id }
+    }
+    val currentMessagesById by rememberUpdatedState(messagesById)
+    val messageKeys = remember(messages) {
+        messages.map { msg ->
+            when (msg) {
+                is ChatView.Message -> msg.id
+                is ChatView.DateSection -> "$DATE_KEY_PREFIX${msg.timeInMillis}"
+            }
+        }
+    }
+    val currentMessageKeys by rememberUpdatedState(messageKeys)
+    val currentReadSnapshot by rememberUpdatedState(readSnapshot)
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    val reportVisibleRange by rememberUpdatedState(onVisibleRangeChanged)
+    DisposableEffect(lifecycle) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                visibilityGeneration++
+            } else if (!lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+                reportVisibleRange(null, null, null)
+                visibilityGeneration++
+            }
+        }
+        lifecycle.addObserver(observer)
+        onDispose {
+            lifecycle.removeObserver(observer)
+            reportVisibleRange(null, null, null)
+        }
+    }
+    LaunchedEffect(lazyListState, lifecycle) {
         snapshotFlow {
             val layoutInfo = lazyListState.layoutInfo
             var from: ChatView.Message? = null
             var to: ChatView.Message? = null
-            if (layoutInfo.totalItemsCount > 0 && !isPerformingScrollIntent.value) {
-                val viewportHeight = layoutInfo.viewportSize.height
-                val msgs = currentMessages
+            if (layoutInfo.totalItemsCount > 0 && !isPerformingScrollIntent.value &&
+                lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED) &&
+                isChatReadLayoutCurrent(
+                    currentMessageKeys,
+                    layoutInfo.totalItemsCount,
+                    layoutInfo.visibleItemsInfo.map { it.index to it.key }
+                )
+            ) {
+                val msgs = currentMessagesById
                 var fromIndex = Int.MAX_VALUE
                 var toIndex = Int.MIN_VALUE
                 layoutInfo.visibleItemsInfo.forEach { item ->
-                    val itemBottom = item.offset + item.size
-                    val isFullyVisible = item.offset >= 0 && itemBottom <= viewportHeight
-                    if (isFullyVisible) {
-                        val msg = msgs.getOrNull(item.index)
-                        if (msg is ChatView.Message) {
+                    if (isMessageVisibleForReading(
+                            offset = item.offset,
+                            size = item.size,
+                            viewportStart = layoutInfo.viewportStartOffset,
+                            viewportEnd = layoutInfo.viewportEndOffset
+                        )
+                    ) {
+                        // The message list can update before LazyColumn has remeasured.
+                        // Its stable key, unlike the old layout index, still identifies
+                        // the message whose geometry was actually measured.
+                        val msg = msgs[item.key]
+                        if (msg != null) {
                             if (item.index < fromIndex) {
                                 fromIndex = item.index
                                 from = msg
@@ -610,13 +658,17 @@ fun ChatScreen(
             }
             val first = from
             val last = to
-            if (first != null && last != null) first.id to last.id else null
+            ChatReadVisibility(
+                range = if (first != null && last != null) first.id to last.id else null,
+                snapshot = currentReadSnapshot,
+                generation = visibilityGeneration
+            )
         }
             .distinctUntilChanged()
-            .collect { range ->
-                if (range != null) {
-                    onVisibleRangeChanged(range.first, range.second)
-                }
+            .collect { visible ->
+                // ON_PAUSE may invalidate visibility while a snapshot is already queued.
+                val range = visible.range.takeIf { lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED) }
+                reportVisibleRange(range?.first, range?.second, visible.snapshot)
             }
     }
 

--- a/feature-chats/src/test/java/com/anytypeio/anytype/feature_chats/ui/ChatReadVisibilityTest.kt
+++ b/feature-chats/src/test/java/com/anytypeio/anytype/feature_chats/ui/ChatReadVisibilityTest.kt
@@ -1,0 +1,100 @@
+package com.anytypeio.anytype.feature_chats.ui
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.snapshots.Snapshot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatReadVisibilityTest {
+    @Test
+    fun `ordinary messages must be fully visible including exact viewport edges`() {
+        assertTrue(isMessageVisibleForReading(0, 100, 0, 600))
+        assertTrue(isMessageVisibleForReading(500, 100, 0, 600))
+        assertFalse(isMessageVisibleForReading(-1, 100, 0, 600))
+        assertFalse(isMessageVisibleForReading(501, 100, 0, 600))
+    }
+
+    @Test
+    fun `a final message taller than the screen is readable at the bottom`() {
+        assertTrue(isMessageVisibleForReading(0, 900, 0, 600))
+        assertTrue(isMessageVisibleForReading(-100, 900, 0, 600))
+        assertFalse(isMessageVisibleForReading(300, 900, 0, 600))
+        assertFalse(isMessageVisibleForReading(-400, 900, 0, 600))
+    }
+
+    @Test
+    fun `visibility uses the viewport offsets including content padding`() {
+        assertTrue(isMessageVisibleForReading(-20, 100, -20, 580))
+        assertFalse(isMessageVisibleForReading(-21, 100, -20, 580))
+        assertTrue(isMessageVisibleForReading(-20, 900, -20, 580))
+    }
+
+    @Test
+    fun `unmeasured viewport or message is not readable`() {
+        assertFalse(isMessageVisibleForReading(0, 100, 0, 0))
+        assertFalse(isMessageVisibleForReading(0, 0, 0, 600))
+    }
+
+    @Test
+    fun `layout must match current keys including date sections before reading`() {
+        val keys = listOf("B", "A", "date-1")
+        assertTrue(isChatReadLayoutCurrent(keys, 3, listOf(0 to "B", 1 to "A", 2 to "date-1")))
+        assertFalse(isChatReadLayoutCurrent(keys, 2, listOf(0 to "A", 1 to "date-1")))
+        assertFalse(isChatReadLayoutCurrent(keys, 3, listOf(0 to "A", 1 to "B")))
+        assertFalse(isChatReadLayoutCurrent(keys, 3, listOf(2 to "date-2")))
+    }
+
+    @Test
+    fun `same ids are reported again after a scroll that starts and finishes between snapshots`() = runTest {
+        var scrolling by mutableStateOf(false)
+        var generation by mutableIntStateOf(0)
+        val reports = mutableListOf<ChatReadVisibility>()
+        backgroundScope.launch {
+            snapshotFlow {
+                ChatReadVisibility(if (scrolling) null else "B" to "A", null, generation)
+            }.collect { reports += it }
+        }
+        runCurrent()
+        // The missing-target branch invalidates the session synchronously. Compose may
+        // never observe scrolling=true, so the generation must restore the unchanged range.
+        scrolling = true
+        scrolling = false
+        generation++
+        Snapshot.sendApplyNotifications()
+        runCurrent()
+        assertEquals(listOf("B" to "A", "B" to "A"), reports.map { it.range })
+    }
+
+    @Test
+    fun `pause and resume can restore the same viewport without a scroll`() = runTest {
+        var resumed by mutableStateOf(true)
+        var generation by mutableIntStateOf(0)
+        val reports = mutableListOf<ChatReadVisibility>()
+        backgroundScope.launch {
+            snapshotFlow {
+                ChatReadVisibility(if (resumed) "B" to "A" else null, null, generation)
+            }.collect { reports += it }
+        }
+        runCurrent()
+        resumed = false
+        generation++
+        Snapshot.sendApplyNotifications()
+        runCurrent()
+        resumed = true
+        generation++
+        Snapshot.sendApplyNotifications()
+        runCurrent()
+        assertEquals(listOf("B" to "A", null, "B" to "A"), reports.map { it.range })
+    }
+}


### PR DESCRIPTION
- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/open/blob/main/templates/CLA.md)

### Description

Scrolling to the newest message and leaving a chat could leave one message unread: reverse scrolling could replace the pending final receipt, Back could cancel its worker, and unchanged visible IDs would not trigger a read after chat state caught up.

Visibility callbacks now carry the message orders and chat state rendered together. A single application-owned IO worker preserves complete boundary/state pairs, serializes message and mention reads, retries failures, and drains queued receipts after the screen closes. Exit waits are bounded, and unsubscribe happens before waiting so an old screen cannot later unsubscribe a reopened chat.

Paging retains newer response state. Visibility validates stable layout keys, handles messages taller than the viewport, and resumes after lifecycle or scroll cancellation. Chats and discussions use the same scoped provider module.

Unread, Types, Recently Edited, and My Favorites section headers now show animated chevrons that follow their collapsed or expanded state, with 20dp trailing padding.

### What type of PR is this?

- [x] 🐛 Bug Fix
- [x] ✅ Test

### Related Tickets & Documents

Fixes [DROID-4596](https://linear.app/anytype/issue/DROID-4596/chat-fix-one-message-remains-unread-after-scrolling-to-the-bottom).

### Validation

- 64 targeted tests passed: 57 domain chat tests and 7 `ChatReadVisibilityTest` cases. Coverage includes reverse scrolling, Back during queued/in-flight RPCs, reopening, stale snapshots, paging state, retry bounds, tall messages, and interrupted intents.
- `:app:compileDebugKotlin` (including Dagger generation) and `:app:assembleDebug` passed.
- Installed and cold-launched the debug APK on Nothing A142; the app was foreground with no startup crash entries. A manual check of read counters on the connected phone was reported working.
- Three independent review agents covered lifecycle/cancellation, RPC/data semantics, and UI/scroll behavior; no remaining findings.

### Mobile & Desktop Screenshots/Recordings

Widget chevrons were checked on the connected Nothing A142: Types expanded shows a downward chevron, and Recently Edited collapsed shows a right-facing chevron.

### Added tests?

- [x] 👍 yes

### Added to documentation?

- [x] 🙅 no documentation needed

