### PR TITLE
DROID-4592 Editor | Fix | Keep the select-mode chrome after a rotation

### DIFF
--- a/app/src/main/java/com/anytypeio/anytype/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/editor/EditorFragment.kt
@@ -658,8 +658,23 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
         outState.putParcelable(CURRENT_MEDIA_UPLOAD_KEY, vm.currentMediaUploadDescription)
     }
 
+    /** The toolbar sheets of the editor, in declaration order. */
+    private fun editorSheets(): List<View> = listOf(
+        binding.styleToolbarMain,
+        binding.styleToolbarOther,
+        binding.styleToolbarColors,
+        binding.blockActionToolbar,
+        binding.undoRedoToolbar,
+        binding.styleToolbarBackground,
+        binding.simpleTableWidget
+    )
+
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
         super.onViewStateRestored(savedInstanceState)
+        // DROID-4592. The hierarchy restore has just written the saved sheet state back into every
+        // BottomSheetBehavior, after onViewCreated hid them. Drop it here, before the first render,
+        // so that ControlPanelState stays the only source of truth for the editor chrome.
+        editorSheets().resetRestoredSheetState()
         if (savedInstanceState != null) {
             vm.onRestoreSavedState(savedInstanceState.getParcelable(CURRENT_MEDIA_UPLOAD_KEY))
         }
@@ -1082,15 +1097,7 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
         // screen. They start invisible (see layout) and a single state callback
         // toggles draw-visibility: a sheet is drawn only while it is not hidden,
         // so a hidden sheet can never peek regardless of its resting offset.
-        listOf(
-            binding.styleToolbarMain,
-            binding.styleToolbarOther,
-            binding.styleToolbarColors,
-            binding.blockActionToolbar,
-            binding.undoRedoToolbar,
-            binding.styleToolbarBackground,
-            binding.simpleTableWidget
-        ).forEach { sheet ->
+        editorSheets().forEach { sheet ->
             BottomSheetBehavior.from(sheet).apply {
                 state = BottomSheetBehavior.STATE_HIDDEN
                 addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
@@ -2434,6 +2441,13 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
                 doOnEnd { if (hasBinding) binding.topToolbar.visible() }
                 start()
             }
+        } else {
+            // DROID-4592. The select toolbar is already off screen, so no animation runs. The title
+            // toolbar has exactly one other restore point, the doOnEnd callback above, so it never
+            // comes back without this branch. A configuration change reaches this path: it inflates
+            // the select toolbar at its resting translation while the view model still reports
+            // select mode.
+            binding.topToolbar.visible()
         }
     }
 

--- a/app/src/main/java/com/anytypeio/anytype/ui/editor/EditorFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/editor/EditorFragment.kt
@@ -48,6 +48,7 @@ import androidx.core.os.bundleOf
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_STOP
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.doOnLayout
 import androidx.core.view.doOnPreDraw
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
@@ -256,6 +257,13 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
      * own chrome, and those buttons would float over the type-selection bar.
      */
     protected open val showsBottomActionButtons: Boolean = true
+
+    /**
+     * Whether this editor shows the object top toolbar (the back arrow, the title and the `[...]`
+     * menu). Select mode hides that toolbar and restores it on exit, so a host that hides it for
+     * good must say so here. Quick capture and the multiple-template screen own their own header.
+     */
+    protected open val showsTopToolbar: Boolean = true
 
     private val sideEffect: OpenObjectNavigation.SideEffect
         get() {
@@ -1098,15 +1106,23 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
         // toggles draw-visibility: a sheet is drawn only while it is not hidden,
         // so a hidden sheet can never peek regardless of its resting offset.
         editorSheets().forEach { sheet ->
-            BottomSheetBehavior.from(sheet).apply {
-                state = BottomSheetBehavior.STATE_HIDDEN
-                addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
-                    override fun onStateChanged(bottomSheet: View, newState: Int) {
-                        bottomSheet.isInvisible = newState == BottomSheetBehavior.STATE_HIDDEN
-                    }
+            val behavior = BottomSheetBehavior.from(sheet)
+            behavior.state = BottomSheetBehavior.STATE_HIDDEN
+            behavior.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
+                override fun onStateChanged(bottomSheet: View, newState: Int) {
+                    bottomSheet.isInvisible = newState == BottomSheetBehavior.STATE_HIDDEN
+                }
 
-                    override fun onSlide(bottomSheet: View, slideOffset: Float) {}
-                })
+                override fun onSlide(bottomSheet: View, slideOffset: Float) {}
+            })
+            // DROID-4592. A state set before the first layout pass reaches no callback:
+            // BottomSheetBehavior writes the field directly while it holds no view, and
+            // onLayoutChild then places the sheet without a state change. render() runs at
+            // onStart, before that pass, so a sheet that the control panel state opens right
+            // after a rotation would sit at its expanded position and stay invisible. Sync the
+            // draw-visibility once, as soon as the sheet is laid out.
+            sheet.doOnLayout {
+                it.isInvisible = behavior.state == BottomSheetBehavior.STATE_HIDDEN
             }
         }
 
@@ -2438,7 +2454,7 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
             ).apply {
                 duration = SELECT_BUTTON_HIDE_ANIMATION_DURATION
                 interpolator = DecelerateInterpolator()
-                doOnEnd { if (hasBinding) binding.topToolbar.visible() }
+                doOnEnd { if (hasBinding) restoreTopToolbar() }
                 start()
             }
         } else {
@@ -2447,8 +2463,13 @@ open class EditorFragment : NavigationFragment<FragmentEditorBinding>(R.layout.f
             // comes back without this branch. A configuration change reaches this path: it inflates
             // the select toolbar at its resting translation while the view model still reports
             // select mode.
-            binding.topToolbar.visible()
+            restoreTopToolbar()
         }
+    }
+
+    /** Shows the top toolbar again after select mode, unless the host hides it for good. */
+    private fun restoreTopToolbar() {
+        if (showsTopToolbar) binding.topToolbar.visible()
     }
 
     private fun showSelectButton() {

--- a/app/src/main/java/com/anytypeio/anytype/ui/editor/EditorSheetState.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/editor/EditorSheetState.kt
@@ -1,0 +1,23 @@
+package com.anytypeio.anytype.ui.editor
+
+import android.view.View
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+
+/**
+ * Drops the sheet state that the view hierarchy restored after a configuration change (DROID-4592).
+ *
+ * The editor holds the state of every toolbar sheet in `ControlPanelState`, which the view model
+ * owns and a rotation preserves. [BottomSheetBehavior] saves a second copy into the view hierarchy.
+ * It restores that copy with a direct field write, so no state callback runs, and the restore runs
+ * after `onViewCreated`. The freshly inflated sheet is therefore invisible while its behavior
+ * reports `STATE_EXPANDED`, and every guard in `EditorFragment.render` reads the behavior and skips
+ * the setup of a sheet that the user cannot see.
+ *
+ * Call this after the hierarchy restore and before the first render. The control panel state is
+ * then the only source of truth for the chrome.
+ */
+fun Iterable<View>.resetRestoredSheetState() {
+    forEach { sheet ->
+        BottomSheetBehavior.from(sheet).state = BottomSheetBehavior.STATE_HIDDEN
+    }
+}

--- a/app/src/main/java/com/anytypeio/anytype/ui/quickcapture/EditorQuickCaptureFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/quickcapture/EditorQuickCaptureFragment.kt
@@ -32,6 +32,10 @@ class EditorQuickCaptureFragment : EditorFragment() {
     // would float over the type-selection bar.
     override val showsBottomActionButtons: Boolean = false
 
+    // The sheet owns its own header, and topToolbar is hidden in onViewCreated. Select mode
+    // must not bring it back (DROID-4592).
+    override val showsTopToolbar: Boolean = false
+
     // The draft's Object.Open is the single longest step in opening the sheet, and inflating
     // the editor's layout (18 toolbar widgets, 10 ComposeViews) costs about as much again.
     // Opening from onCreate runs the round trip while that inflation happens, instead of

--- a/app/src/main/java/com/anytypeio/anytype/ui/templates/EditorTemplateFragment.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/templates/EditorTemplateFragment.kt
@@ -37,6 +37,11 @@ class EditorTemplateFragment : EditorFragment() {
             else -> R.id.editorModalScreen
         }
 
+    // initializeBinding hides topToolbar for good on the multiple-template screen. Select mode
+    // must not bring it back (DROID-4592).
+    override val showsTopToolbar: Boolean
+        get() = fragmentType != TYPE_TEMPLATE_MULTIPLE
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initializeBinding()

--- a/app/src/test/java/com/anytypeio/anytype/ui/editor/EditorSheetStateRestoreTest.kt
+++ b/app/src/test/java/com/anytypeio/anytype/ui/editor/EditorSheetStateRestoreTest.kt
@@ -1,0 +1,95 @@
+package com.anytypeio.anytype.ui.editor
+
+import android.content.Context
+import android.os.Build
+import android.os.Parcelable
+import android.util.SparseArray
+import android.view.View
+import android.view.ViewGroup
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.test.core.app.ApplicationProvider
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import kotlin.test.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * DROID-4592. The editor holds the state of every toolbar sheet in `ControlPanelState`, which the
+ * view model owns and a rotation preserves. [BottomSheetBehavior] also saves its own state into the
+ * view hierarchy. It restores that state with a direct field write, so no state callback runs, and
+ * the restore runs after `onViewCreated`.
+ *
+ * A rotation therefore gives `render()` a fresh, invisible sheet whose behavior reports
+ * `STATE_EXPANDED`. Each guard in `render()` reads the behavior, concludes that the sheet is open,
+ * and skips the setup. The block action toolbar stays invisible, and `showSelectButton()` never
+ * moves the select toolbar back on screen.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+class EditorSheetStateRestoreTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private companion object {
+        const val PANELS_ID = 1001
+        const val SHEET_ID = 1002
+    }
+
+    private class Panels(
+        val root: CoordinatorLayout,
+        val sheet: View,
+        val behavior: BottomSheetBehavior<View>
+    )
+
+    /** Builds the `panels` container with one hideable sheet, as `fragment_editor.xml` declares it. */
+    private fun buildPanels(): Panels {
+        val sheetBehavior = BottomSheetBehavior<View>().apply { isHideable = true }
+        val sheet = View(context).apply {
+            id = SHEET_ID
+            visibility = View.INVISIBLE
+            layoutParams = CoordinatorLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            ).apply { behavior = sheetBehavior }
+        }
+        val root = CoordinatorLayout(context).apply {
+            id = PANELS_ID
+            addView(sheet)
+        }
+        return Panels(root, sheet, sheetBehavior)
+    }
+
+    /** Saves the hierarchy of an open sheet, then restores it onto a fresh hierarchy. */
+    private fun rotate(): Panels {
+        val before = buildPanels()
+        before.behavior.state = BottomSheetBehavior.STATE_EXPANDED
+
+        val container = SparseArray<Parcelable>()
+        before.root.saveHierarchyState(container)
+
+        val after = buildPanels()
+        // `onViewCreated` hides every sheet, and it runs before the hierarchy restore.
+        after.behavior.state = BottomSheetBehavior.STATE_HIDDEN
+        after.root.restoreHierarchyState(container)
+        return after
+    }
+
+    @Test
+    fun `a rotation restores the expanded state onto a fresh invisible sheet`() {
+        val after = rotate()
+        // This is the trap the fix exists for: the two sources of truth disagree.
+        assertEquals(BottomSheetBehavior.STATE_EXPANDED, after.behavior.state)
+        assertEquals(View.INVISIBLE, after.sheet.visibility)
+    }
+
+    @Test
+    fun `resetRestoredSheetState drops the stale state, so render can drive the sheet`() {
+        val after = rotate()
+
+        listOf(after.sheet).resetRestoredSheetState()
+
+        assertEquals(BottomSheetBehavior.STATE_HIDDEN, after.behavior.state)
+    }
+}


### PR DESCRIPTION
## Problem

Select a block in the editor, then rotate the device. The selection top bar and the bottom action toolbar disappear, while the block stays highlighted and `EditorMode` stays `Select`. Press Back: the FABs return, but the title top bar with the `[...]` menu never returns. The user must leave the object and open it again.

The portrait lock hid this defect. DROID-4402 removed the lock, so a rotation now recreates the fragment view.

## Root cause

`BottomSheetBehavior` keeps a second copy of the sheet state in the view hierarchy. `onRestoreInstanceState` writes that copy straight into the `state` field, so no state callback runs, and the restore runs after `onViewCreated`.

A rotation therefore gives `render()` a freshly inflated, invisible sheet whose behavior already reports `STATE_EXPANDED`. The guard in `render()` reads the behavior, concludes the sheet is open, and skips the whole select-mode setup:

* `blockActionToolbar` keeps the `android:visibility="invisible"` of the layout.
* `showSelectButton()` never runs, so `multiSelectTopToolbar` stays at its resting `translationY = -120dp`.

A second, independent defect hides the title toolbar. `hideSelectButton()` restores `topToolbar` only in the `doOnEnd` callback of an animation, and that animation runs only when `translationY >= 0`. After a rotation the value is `-120dp`, so no animation runs and the title bar never returns.

## Fix

* `EditorSheetState.kt` — a new `resetRestoredSheetState()` drops the restored behavior state.
* `EditorFragment.onViewStateRestored` calls it, before the first `render()`. `ControlPanelState` becomes the only source of truth for the editor chrome. The same repair covers the style toolbars, the simple table widget and the undo/redo toolbar, which carry the same hazard.
* `hideSelectButton()` restores `topToolbar` in an `else` branch, so the title bar returns on every path.

## Tests

`EditorSheetStateRestoreTest` is a Robolectric test. It saves an expanded sheet, restores it onto a fresh hierarchy, and asserts both the trap and the repair. It fails without the fix.

`make test_debug_all` passes.

## Manual verification

Device A063, `io.anytype.app.dev`. Node presence from `uiautomator dump`:

| Node | Portrait, select mode | After rotation | After Back |
| -- | -- | -- | -- |
| `multiSelectTopToolbar` | `[0,136][1080,262]` | `[413,95][1988,221]` | absent (correct) |
| `blockActionToolbar` | `[0,2004][1080,2337]` | `[413,684][1988,1017]` | absent (correct) |
| `topToolbar` | absent (correct) | absent (correct) | `[413,95][1988,211]` |
| `fabCreate`, `fabSearchOnPage` | absent (correct) | absent (correct) | present |

The reverse rotation holds the selection too. The style sheet also survives a rotation now.

## Review follow-up

Two defects came out of the review.

* The `else` branch of `hideSelectButton()` runs on almost every `render()`, because the select toolbar rests off screen outside select mode. `EditorQuickCaptureFragment` and `EditorTemplateFragment` hide `topToolbar` for good, and neither overrides the method, so the editor top toolbar drew over their own header. A new `showsTopToolbar`, next to the existing `showsBottomActionButtons`, gates both restore points.
* A sheet state set before the first layout pass reaches no callback: the behavior writes the field directly while it holds no view, and `onLayoutChild` then places the sheet without a state change. The `styleExtraToolbar` branch expands its sheet synchronously, so after a rotation that sheet sat at its expanded position and stayed invisible. A `doOnLayout` now syncs the draw-visibility of every sheet once.

The manual run above covers the first commit. The two review fixes carry unit tests and a build only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoEhHECC3pkaZKwAbfg1DC
