### PR TITLE
DROID-4598 Chat | Fix | Restore the space background

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,8 @@ window. The editor keeps the capped column, because a full width line of text is
 `contentColumnMaxWidth()` holds the rule.
 
 `MainActivity.setupContentColumnWidth()` also sets the backdrop. The widgets screen, the
-collection screen, and the vault show the wallpaper of the space through their content, so the
-root paints the wallpaper there. Every other screen paints an opaque background over the column.
+collection screen, the vault, and the chat show the wallpaper of the space through their content,
+so the root paints the wallpaper there. Every other screen paints an opaque background over the column.
 The wallpaper then reaches the eye only in the strip beside a capped column. The root paints
 `@color/background_primary` there: white in the light theme, black in the dark theme.
 `showsWallpaper()` holds the rule.

--- a/app/src/main/java/com/anytypeio/anytype/ui/main/ContentColumnWidth.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/main/ContentColumnWidth.kt
@@ -30,7 +30,8 @@ private val FULL_WIDTH_DESTINATIONS = setOf(
 private val WALLPAPER_DESTINATIONS = setOf(
     R.id.homeScreen,
     R.id.homeScreenWidgets,
-    R.id.vaultScreen
+    R.id.vaultScreen,
+    R.id.chatScreen
 )
 
 /**

--- a/app/src/main/java/com/anytypeio/anytype/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/anytypeio/anytype/ui/main/MainActivity.kt
@@ -640,9 +640,9 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), AppNavigation.Pr
     }
 
     /**
-     * The root paints the backdrop of the window. The widgets screen, the collection screen, and
-     * the vault show the wallpaper of the space through their content, so the root paints the
-     * wallpaper there. Every other screen paints an opaque background over the content column. The
+     * The root paints the backdrop of the window. The widgets screen, the collection screen, the
+     * vault, and the chat show the wallpaper of the space through their content, so the root paints
+     * the wallpaper there. Every other screen paints an opaque background over the content column. The
      * wallpaper then reaches the eye only in the strip beside a capped column. The root paints the
      * plain backdrop there: white in the light theme, black in the dark theme.
      */

--- a/app/src/test/java/com/anytypeio/anytype/ui/main/ContentColumnWidthTest.kt
+++ b/app/src/test/java/com/anytypeio/anytype/ui/main/ContentColumnWidthTest.kt
@@ -87,7 +87,7 @@ class ContentColumnWidthTest {
     }
 
     @Test
-    fun `should paint the plain backdrop on the chat`() {
-        assertFalse(showsWallpaper(R.id.chatScreen))
+    fun `should show the wallpaper on the chat`() {
+        assertTrue(showsWallpaper(R.id.chatScreen))
     }
 }


### PR DESCRIPTION
### Description

Opening a chat shows a plain background instead of the space color or wallpaper; the background briefly returns during back navigation. The backdrop rule introduced in #3347 omitted chat even though its content is transparent.

Include `chatScreen` in the wallpaper destinations so the space background remains visible while the chat is open. Update the existing backdrop test and the accompanying documentation.

### What type of PR is this?

- [x] 🐛 Bug Fix

### Related Tickets & Documents

Fixes [DROID-4598](https://linear.app/anytype/issue/DROID-4598/chat-fix-restore-the-space-background).

### Mobile & Desktop Screenshots/Recordings

Verified on the connected Android phone: the same chat changed from a black background to its configured space color. Before/after screenshots were captured locally; they contain private chat content and are omitted here.

### Added tests?

- [x] 👍 yes — updated the existing chat backdrop assertion.

Validation:
- `:app:testDebugUnitTest --tests com.anytypeio.anytype.ui.main.ContentColumnWidthTest` — all 10 tests pass.
- `:app:assembleDebug` — succeeds.
- Installed the debug APK and verified the background on the phone.

### Added to documentation?

Updated `CLAUDE.md` and the backdrop code comments.

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/open/blob/main/templates/CLA.md)
