### PR TITLE
DROID-4599 Vault | Fix | Preserve top position and update license allowlist

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,7 @@ licensee {
     allow("Apache-2.0")
     allow("MIT")
     allow("BSD-3-Clause")
+    allow("CC0-1.0") // Reactive Streams, via ML Kit GenAI
 
     // Google/Android SDK Terms
     allowUrl("https://developer.android.com/studio/terms.html") {

--- a/app/src/androidTest/java/com/anytypeio/anytype/features/vault/VaultScrollTest.kt
+++ b/app/src/androidTest/java/com/anytypeio/anytype/features/vault/VaultScrollTest.kt
@@ -1,0 +1,156 @@
+package com.anytypeio.anytype.features.vault
+
+import android.os.Bundle
+import android.os.SystemClock
+import androidx.fragment.app.testing.FragmentScenario
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.anytypeio.anytype.R
+import com.anytypeio.anytype.feature_vault.presentation.VaultUiState
+import com.anytypeio.anytype.features.vault.VaultScrollTestFragment.Companion.space
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class VaultScrollTest {
+    @Test
+    fun insertingSpaceAtTopKeepsEveryFrameAtTop() = withVault { scenario ->
+        update(scenario) { it.copy(mainSpaces = listOf(space("new-space")) + it.mainSpaces) }
+        assertAtTop(scenario, "new-space")
+    }
+
+    @Test
+    fun movingSpaceFromFiveToZeroKeepsEveryFrameAtTop() = withVault { scenario ->
+        update(scenario) { sections ->
+            val spaces = sections.mainSpaces.toMutableList()
+            spaces.add(0, spaces.removeAt(5))
+            sections.copy(mainSpaces = spaces)
+        }
+        assertAtTop(scenario, "space-5")
+    }
+
+    @Test
+    fun pinningSpaceAboveMainSectionKeepsEveryFrameAtTop() = withVault { scenario ->
+        update(scenario) {
+            it.copy(pinnedSpaces = listOf(space("space-5", pinned = true)),
+                mainSpaces = it.mainSpaces.filterNot { space -> space.space.id == "space-5" })
+        }
+        assertAtTop(scenario, "space-5")
+    }
+
+    @Test
+    fun reorderingPinnedSpacesKeepsEveryFrameAtTop() = withVault { scenario ->
+        update(scenario) { it.copy(pinnedSpaces = (0..5).map { space("pinned-$it", pinned = true) }) }
+        update(scenario) { it.copy(pinnedSpaces = it.pinnedSpaces.reversed()) }
+        assertAtTop(scenario, "pinned-5")
+    }
+
+    @Test
+    fun insertingSpacePreservesScrolledCardAndOffset() = withVault(index = 8, offset = 37) { scenario ->
+        update(scenario) { it.copy(mainSpaces = listOf(space("new-space")) + it.mainSpaces) }
+        assertAnchor(scenario, "space-8", 37)
+    }
+
+    @Test
+    fun movingSpacePreservesPartiallyScrolledFirstCard() = withVault(offset = 37) { scenario ->
+        update(scenario) { sections ->
+            val spaces = sections.mainSpaces.toMutableList()
+            spaces.add(0, spaces.removeAt(5))
+            sections.copy(mainSpaces = spaces)
+        }
+        assertAnchor(scenario, "space-0", 37)
+    }
+
+    @Test
+    fun subscriptionUpdateDoesNotCancelAnActiveScroll() = withVault { scenario ->
+        lateinit var scroll: Job
+        scenario.onFragment { fixture ->
+            scroll = fixture.scope.launch(start = CoroutineStart.UNDISPATCHED) {
+                fixture.listState.scroll { awaitCancellation() }
+            }
+            assertTrue(fixture.listState.isScrollInProgress)
+        }
+        try {
+            update(scenario) { it.copy(mainSpaces = listOf(space("new-space")) + it.mainSpaces) }
+            scenario.onFragment { assertTrue("Subscription update cancelled scrolling", scroll.isActive) }
+        } finally {
+            scenario.onFragment { scroll.cancel() }
+        }
+    }
+
+    private fun assertAtTop(scenario: FragmentScenario<VaultScrollTestFragment>, key: String) {
+        scenario.onFragment { fixture ->
+            assertEquals(key, fixture.viewport().key)
+            assertTrue("No rendered frames recorded", fixture.frames.isNotEmpty())
+            fixture.frames.forEach { frame ->
+                assertEquals("Viewport jumped: $frame", 0, frame.index)
+                assertEquals("Viewport jumped: $frame", 0, frame.offset)
+            }
+        }
+    }
+
+    private fun assertAnchor(scenario: FragmentScenario<VaultScrollTestFragment>, key: String, offset: Int) {
+        scenario.onFragment { fixture ->
+            assertTrue("No rendered frames recorded", fixture.frames.isNotEmpty())
+            fixture.frames.forEach { frame ->
+                assertEquals("Visible card changed: $frame", key, frame.key)
+                assertEquals("Viewport jumped: $frame", offset, frame.offset)
+            }
+        }
+    }
+
+    private fun update(
+        scenario: FragmentScenario<VaultScrollTestFragment>,
+        transform: (VaultUiState.Sections) -> VaultUiState.Sections
+    ) {
+        lateinit var updated: VaultUiState.Sections
+        scenario.onFragment { fixture ->
+            fixture.frames.clear()
+            updated = transform(fixture.sections.value)
+            fixture.sections.value = updated
+        }
+        await(scenario) { it.renderedSections == updated && it.frames.isNotEmpty() }
+        // Keep item animations enabled and sample draws throughout the placement transition.
+        SystemClock.sleep(500)
+    }
+
+    private fun withVault(index: Int = 0, offset: Int = 0, block: (FragmentScenario<VaultScrollTestFragment>) -> Unit) {
+        val scenario = launchFragmentInContainer<VaultScrollTestFragment>(
+            fragmentArgs = Bundle().apply { putInt("index", index); putInt("offset", offset) },
+            themeResId = R.style.AppTheme
+        )
+        try {
+            await(scenario) { it.frames.isNotEmpty() }
+            scenario.onFragment {
+                assertEquals(index, it.viewport().index)
+                assertEquals(offset, it.viewport().offset)
+            }
+            block(scenario)
+        } finally {
+            scenario.close()
+        }
+    }
+
+    private fun await(scenario: FragmentScenario<VaultScrollTestFragment>, ready: (VaultScrollTestFragment) -> Boolean) {
+        val deadline = SystemClock.uptimeMillis() + 5_000
+        do {
+            var satisfied = false
+            scenario.onFragment { satisfied = ready(it) }
+            if (satisfied) return
+            SystemClock.sleep(16)
+        } while (SystemClock.uptimeMillis() < deadline)
+        scenario.onFragment {
+            throw AssertionError("Vault list did not finish rendering: " +
+                "state=${it.viewport()}, frames=${it.frames.size}, " +
+                "updated=${it.renderedSections == it.sections.value}")
+        }
+    }
+}

--- a/app/src/androidTest/java/com/anytypeio/anytype/features/vault/VaultScrollTestFragment.kt
+++ b/app/src/androidTest/java/com/anytypeio/anytype/features/vault/VaultScrollTestFragment.kt
@@ -1,0 +1,98 @@
+package com.anytypeio.anytype.features.vault
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.anytypeio.anytype.core_models.ObjectWrapper
+import com.anytypeio.anytype.core_models.ui.SpaceIconView
+import com.anytypeio.anytype.feature_vault.presentation.VaultSpaceView
+import com.anytypeio.anytype.feature_vault.presentation.VaultUiState
+import com.anytypeio.anytype.feature_vault.ui.VaultScreenContent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/** Exercises the production list with subscription updates and no backend dependencies. */
+class VaultScrollTestFragment : Fragment() {
+    val sections = MutableStateFlow(VaultUiState.Sections(mainSpaces = (0..29).map { space("space-$it") }))
+    lateinit var listState: LazyListState
+    lateinit var scope: CoroutineScope
+    var renderedSections: VaultUiState.Sections? = null
+    val frames = mutableListOf<Viewport>()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
+        ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                listState = rememberLazyListState(
+                    initialFirstVisibleItemIndex = arguments?.getInt("index") ?: 0,
+                    initialFirstVisibleItemScrollOffset = arguments?.getInt("offset") ?: 0
+                )
+                scope = rememberCoroutineScope()
+                val currentSections = sections.collectAsStateWithLifecycle().value
+                MaterialTheme {
+                    VaultScreenContent(
+                        sections = currentSections,
+                        lazyListState = listState,
+                        paddings = PaddingValues(0.dp),
+                        searchQuery = "",
+                        onSpaceClicked = {},
+                        onCreateSpaceClicked = {},
+                        onMuteSpace = {},
+                        onUnmuteSpace = {},
+                        onSetSpaceNotificationMode = { _, _ -> },
+                        onPinSpace = {},
+                        onUnpinSpace = {},
+                        onOrderChanged = { _, _ -> },
+                        onSpaceSettings = {},
+                        onDeleteOrLeaveSpace = { _, _ -> }
+                    )
+                }
+                SideEffect { renderedSections = currentSections }
+            }
+            viewTreeObserver.addOnPreDrawListener {
+                if (this@VaultScrollTestFragment::listState.isInitialized &&
+                    listState.layoutInfo.totalItemsCount > 0
+                ) {
+                    frames += viewport()
+                }
+                // Key anchoring can leave identical pixels and skip invalidation entirely.
+                // Keep drawing so even that case is sampled during a subscription update.
+                postInvalidateOnAnimation()
+                true
+            }
+        }
+
+    fun viewport() = Viewport(
+        index = listState.firstVisibleItemIndex,
+        offset = listState.firstVisibleItemScrollOffset,
+        key = listState.layoutInfo.visibleItemsInfo
+            .firstOrNull { it.index == listState.firstVisibleItemIndex }?.key
+    )
+
+    data class Viewport(val index: Int, val offset: Int, val key: Any?)
+
+    companion object {
+        fun space(id: String, pinned: Boolean = false) = VaultSpaceView.DataSpace(
+            space = ObjectWrapper.SpaceView(mapOf(
+                "id" to id,
+                "name" to id,
+                "spaceOrder" to if (pinned) id else null
+            )),
+            icon = SpaceIconView.DataSpace.Placeholder(name = id),
+            accessType = "Owner",
+            isOwner = true
+        )
+    }
+}

--- a/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/ui/VaultScreen.kt
+++ b/feature-vault/src/main/java/com/anytypeio/anytype/feature_vault/ui/VaultScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.stringResource
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -251,6 +252,24 @@ fun VaultScreenContent(
             onCreateSpaceClicked = onCreateSpaceClicked
         )
     } else {
+        val firstSpaceId = filteredPinnedSpaces.firstOrNull()?.space?.id
+            ?: filteredMainSpaces.firstOrNull()?.space?.id
+        SideEffect {
+            // Read the last measured viewport before the new items are laid out. At the top,
+            // keep index zero instead of following the old first space's key to its new index.
+            // Requesting the next measure avoids a corrective scroll after a displaced frame
+            // and preserves animateItem placement animations. Elsewhere, keep key anchoring.
+            val previousFirstSpaceId = lazyListState.layoutInfo.visibleItemsInfo
+                .firstOrNull { it.index == 0 }?.key
+            if (previousFirstSpaceId != null && previousFirstSpaceId != firstSpaceId &&
+                !lazyListState.canScrollBackward &&
+                !lazyListState.isScrollInProgress &&
+                !reorderableLazyListState.isAnyItemDragging
+            ) {
+                lazyListState.requestScrollToItem(0)
+            }
+        }
+
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()


### PR DESCRIPTION
### Description

When the vault is at the top, inserting a space or moving one from position 5 to position 0 keeps the previous first card anchored. The new first space ends up above the viewport, requiring the user to scroll up.

Request index 0 for the next layout when the first space changes and the list is resting at the top. This preserves item placement animations. Scrolled lists retain their visible card and pixel offset; active scrolling and space dragging are left alone.

Also allow `CC0-1.0` for the Reactive Streams dependency brought in by ML Kit GenAI, so the release license check accepts that dependency.

### What type of PR is this?

- [x] 🐛 Bug Fix
- [x] ✅ Test
- [x] 🤖 Build

### Related Tickets & Documents

Fixes [DROID-4599](https://linear.app/anytype/issue/DROID-4599/vault-fix-keep-the-list-at-the-top-during-space-updates).

### Mobile & Desktop Screenshots/Recordings

Verified on the connected Android phone using the production vault list with synthetic subscription updates. Regression tests sample every rendered frame with item animations enabled and assert that the viewport does not shift during insertions, reordering, or pinned-space updates.

### Added tests?

- [x] 👍 yes

- All 42 vault unit tests pass (`:feature-vault:testDebugUnitTest`).
- All 7 device tests pass (`com.anytypeio.anytype.features.vault.VaultScrollTest`), covering top preservation, scrolled card/offset preservation, and active scrolling.
- The position-5-to-0 test reproduces the bug on the baseline app and passes with the fix.
- `:app:assembleDebug` and `:app:assembleDebugAndroidTest` succeed.
- `:app:licenseeRelease` passes with the updated allowlist.

### Added to documentation?

- [x] 🙅 no documentation needed

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/open/blob/main/templates/CLA.md)
